### PR TITLE
Add agent-safe test mode

### DIFF
--- a/docs/TESTING_FOR_AGENTS.md
+++ b/docs/TESTING_FOR_AGENTS.md
@@ -1,0 +1,43 @@
+# Testing For Agents
+
+This repo contains personal-data integrations. Default agent runs must be deterministic, local, and safe.
+
+## Safe Commands
+
+Use this as the default verification loop:
+
+```bash
+INBOX_TEST_MODE=1 uv run pytest -m safe
+uv run ruff check .
+uv run pyright
+```
+
+For focused work, prefer the smallest relevant safe test:
+
+```bash
+INBOX_TEST_MODE=1 uv run pytest tests/test_inbox_test_mode.py -q
+```
+
+## Test Mode
+
+Set `INBOX_TEST_MODE=1` for agent-safe test runs.
+
+In test mode:
+- live writes are blocked through `assert_live_writes_allowed`
+- test data should use `INBOX_TEST_DATA_DIR` or another test-local temp path
+- date-sensitive tests can set `INBOX_TEST_NOW` to a fixed ISO timestamp
+- tests must avoid real Gmail, Calendar, Reminders, Notes, Messages, Drive, Docs, Sheets, Tasks, OAuth, microphone input, and notification mutation unless explicitly opted in
+
+## Markers
+
+- `safe` -- deterministic tests that do not touch live personal data or external write surfaces
+- `integration` -- tests that exercise integration behavior beyond a single module
+- `local_data` -- tests that require local user data stores and must be explicitly opted into
+- `slow` -- tests that are too slow for the default agent-safe loop
+- `live_write` -- tests that perform externally visible writes and require explicit human approval
+
+## Explicit Opt-In
+
+Do not run live-write tests unless explicitly instructed by the user.
+
+Do not run tests marked `local_data`, `live_write`, or live provider-specific integration tests unless the user asks for that class of verification by name.

--- a/inbox_test_mode.py
+++ b/inbox_test_mode.py
@@ -1,0 +1,36 @@
+"""Agent-safe test mode helpers."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+TEST_MODE_ENV = "INBOX_TEST_MODE"
+TEST_DATA_DIR_ENV = "INBOX_TEST_DATA_DIR"
+TEST_NOW_ENV = "INBOX_TEST_NOW"
+
+
+class LiveWriteBlocked(RuntimeError):
+    """Raised when a live write is attempted while safe test mode is enabled."""
+
+
+def is_test_mode() -> bool:
+    return os.environ.get(TEST_MODE_ENV, "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def assert_live_writes_allowed(action: str) -> None:
+    if is_test_mode():
+        raise LiveWriteBlocked(f"Live write blocked in INBOX_TEST_MODE: {action}")
+
+
+def test_data_dir() -> Path:
+    configured = os.environ.get(TEST_DATA_DIR_ENV, "").strip()
+    if configured:
+        return Path(configured).expanduser()
+    return Path(".inbox-test-data").resolve()
+
+
+def test_now() -> str | None:
+    if not is_test_mode():
+        return None
+    return os.environ.get(TEST_NOW_ENV, "").strip() or None

--- a/inbox_test_mode.py
+++ b/inbox_test_mode.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import tempfile
 from pathlib import Path
 
 TEST_MODE_ENV = "INBOX_TEST_MODE"
@@ -27,7 +28,7 @@ def test_data_dir() -> Path:
     configured = os.environ.get(TEST_DATA_DIR_ENV, "").strip()
     if configured:
         return Path(configured).expanduser()
-    return Path(".inbox-test-data").resolve()
+    return Path(tempfile.gettempdir()) / "inbox-test-data"
 
 
 def test_now() -> str | None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,13 @@ reportMissingImports = true
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 addopts = "--cov=. --cov-report=term-missing"
+markers = [
+    "safe: deterministic tests that do not touch live personal data or external write surfaces",
+    "integration: tests that exercise integration behavior beyond a single module",
+    "local_data: tests that require local user data stores and must be explicitly opted into",
+    "slow: tests that are too slow for the default agent-safe loop",
+    "live_write: tests that perform externally visible writes and require explicit human approval",
+]
 
 [tool.bandit]
 exclude_dirs = [".venv", "tests"]

--- a/services.py
+++ b/services.py
@@ -40,12 +40,29 @@ from contacts import ContactBook
 
 BASE_DIR = Path(__file__).parent
 CREDS_FILE = BASE_DIR / "credentials.json"
-TOKEN_FILE = BASE_DIR / "token.json"  # legacy single-account path
-TOKENS_DIR = BASE_DIR / "tokens"
-IMSG_DB = Path.home() / "Library/Messages/chat.db"
-NOTES_DB = Path.home() / "Library/Group Containers/group.com.apple.notes/NoteStore.sqlite"
+try:
+    from inbox_test_mode import is_test_mode, test_data_dir
+except ImportError:
+    _TEST_DATA_DIR = None
+else:
+    _TEST_DATA_DIR = test_data_dir() if is_test_mode() else None
+
+TOKEN_FILE = (_TEST_DATA_DIR / "token.json") if _TEST_DATA_DIR else BASE_DIR / "token.json"
+TOKENS_DIR = (_TEST_DATA_DIR / "tokens") if _TEST_DATA_DIR else BASE_DIR / "tokens"
+IMSG_DB = (
+    _TEST_DATA_DIR / "Library/Messages/chat.db"
+    if _TEST_DATA_DIR
+    else Path.home() / "Library/Messages/chat.db"
+)
+NOTES_DB = (
+    _TEST_DATA_DIR / "Library/Group Containers/group.com.apple.notes/NoteStore.sqlite"
+    if _TEST_DATA_DIR
+    else Path.home() / "Library/Group Containers/group.com.apple.notes/NoteStore.sqlite"
+)
 REMINDERS_DIR = (
-    Path.home() / "Library/Group Containers/group.com.apple.reminders/Container_v1/Stores"
+    _TEST_DATA_DIR / "Library/Group Containers/group.com.apple.reminders/Container_v1/Stores"
+    if _TEST_DATA_DIR
+    else Path.home() / "Library/Group Containers/group.com.apple.reminders/Container_v1/Stores"
 )
 APPLE_EPOCH = datetime(2001, 1, 1)
 
@@ -534,6 +551,7 @@ def google_auth_all() -> tuple[
 
 
 def add_google_account() -> str | None:
+    _assert_live_write_allowed("add Google account")
     TOKENS_DIR.mkdir(exist_ok=True)
     if not CREDS_FILE.exists():
         return None
@@ -547,6 +565,7 @@ def add_google_account() -> str | None:
 
 
 def reauth_google_account(email: str) -> str | None:
+    _assert_live_write_allowed("reauth Google account")
     token_path = TOKENS_DIR / f"{email}.json"
     if token_path.exists():
         token_path.unlink()
@@ -2452,6 +2471,7 @@ def whatsapp_send(chat_name: str, text: str) -> bool:
     Activates app, selects chat, focuses compose field, types text via
     synthesized keystrokes (AXValue set is ignored by Catalyst), presses Return.
     """
+    _assert_live_write_allowed("send WhatsApp message")
     try:
         if not whatsapp_check_accessibility(prompt=False):
             return False
@@ -3283,6 +3303,7 @@ def task_create(
     notes: str = "",
 ) -> bool:
     """Create a Google Task."""
+    _assert_live_write_allowed("create Google Task")
     try:
         body = {"title": title}
         if notes:
@@ -3298,6 +3319,7 @@ def task_create(
 
 def task_complete(service, task_id: str, list_id: str = "@default") -> bool:
     """Mark a Google Task as complete."""
+    _assert_live_write_allowed("complete Google Task")
     try:
         service.tasks().patch(
             tasklist=list_id,
@@ -3312,6 +3334,7 @@ def task_complete(service, task_id: str, list_id: str = "@default") -> bool:
 
 def task_delete(service, task_id: str, list_id: str = "@default") -> bool:
     """Delete a Google Task."""
+    _assert_live_write_allowed("delete Google Task")
     try:
         service.tasks().delete(tasklist=list_id, task=task_id).execute()
         return True
@@ -3329,6 +3352,7 @@ def task_update(
     notes: str | None = None,
 ) -> bool:
     """Update a Google Task."""
+    _assert_live_write_allowed("update Google Task")
     try:
         body = {}
         if title is not None:
@@ -3841,6 +3865,7 @@ def github_notifications(all_notifs: bool = False) -> list[GitHubNotification]:
 
 def github_mark_read(notification_id: str) -> bool:
     """Mark a single GitHub notification as read."""
+    _assert_live_write_allowed("mark GitHub notification read")
     headers = _github_headers()
     if not headers:
         return False
@@ -3858,6 +3883,7 @@ def github_mark_read(notification_id: str) -> bool:
 
 def github_mark_all_read() -> bool:
     """Mark all GitHub notifications as read."""
+    _assert_live_write_allowed("mark all GitHub notifications read")
     headers = _github_headers()
     if not headers:
         return False
@@ -4019,6 +4045,7 @@ def drive_upload(
 
 def drive_create_folder(drive_service, name: str, parent_id: str = "") -> DriveFile | None:
     """Create a folder in Google Drive."""
+    _assert_live_write_allowed("create Google Drive folder")
     try:
         metadata: dict = {
             "name": name,
@@ -4047,6 +4074,7 @@ def drive_create_folder(drive_service, name: str, parent_id: str = "") -> DriveF
 
 def drive_delete(drive_service, file_id: str) -> bool:
     """Delete (trash) a file from Google Drive."""
+    _assert_live_write_allowed("delete Google Drive file")
     try:
         drive_service.files().update(fileId=file_id, body={"trashed": True}).execute()
         return True
@@ -4190,6 +4218,7 @@ def sheets_create(
     sheets_service: object, title: str, sheets: list[str] | None = None
 ) -> Spreadsheet | None:
     """Create a new spreadsheet with optional sheet tabs."""
+    _assert_live_write_allowed("create Google Sheet")
     try:
         requests = []
         body = {
@@ -4216,6 +4245,7 @@ def sheets_create(
 
 def sheets_delete(drive_service: object, spreadsheet_id: str) -> bool:
     """Soft-delete (trash) a spreadsheet."""
+    _assert_live_write_allowed("delete Google Sheet")
     try:
         drive_service.files().update(fileId=spreadsheet_id, body={"trashed": True}).execute()
         return True
@@ -4270,6 +4300,7 @@ def sheets_values_update(
     value_input: str = "USER_ENTERED",
 ) -> dict | None:
     """Update a range with values. Returns update stats or None on error."""
+    _assert_live_write_allowed("update Google Sheet values")
     try:
         result = (
             sheets_service.spreadsheets()
@@ -4295,6 +4326,7 @@ def sheets_values_batch_update(
     value_input: str = "USER_ENTERED",
 ) -> dict | None:
     """Update multiple ranges. data = [{"range": "...", "values": [...]}, ...]."""
+    _assert_live_write_allowed("batch update Google Sheet values")
     try:
         result = (
             sheets_service.spreadsheets()
@@ -4322,6 +4354,7 @@ def sheets_values_append(
     value_input: str = "USER_ENTERED",
 ) -> dict | None:
     """Append rows to a range. Returns append stats or None on error."""
+    _assert_live_write_allowed("append Google Sheet values")
     try:
         result = (
             sheets_service.spreadsheets()
@@ -4342,6 +4375,7 @@ def sheets_values_append(
 
 def sheets_values_clear(sheets_service: object, spreadsheet_id: str, range_: str) -> bool:
     """Clear a range."""
+    _assert_live_write_allowed("clear Google Sheet values")
     try:
         sheets_service.spreadsheets().values().clear(
             spreadsheetId=spreadsheet_id, range=range_
@@ -4360,6 +4394,7 @@ def sheets_add_sheet(
     cols: int = 26,
 ) -> SheetTab | None:
     """Add a new sheet tab to a spreadsheet."""
+    _assert_live_write_allowed("add Google Sheet tab")
     try:
         result = (
             sheets_service.spreadsheets()
@@ -4397,6 +4432,7 @@ def sheets_add_sheet(
 
 def sheets_delete_sheet(sheets_service: object, spreadsheet_id: str, sheet_id: int) -> bool:
     """Delete a sheet tab by sheet_id."""
+    _assert_live_write_allowed("delete Google Sheet tab")
     try:
         sheets_service.spreadsheets().batchUpdate(
             spreadsheetId=spreadsheet_id,
@@ -4534,6 +4570,7 @@ def docs_get(docs_service: object, document_id: str) -> Document | None:
 
 def docs_create(docs_service: object, title: str) -> Document | None:
     """Create a new Google Doc."""
+    _assert_live_write_allowed("create Google Doc")
     try:
         result = docs_service.documents().create(body={"title": title}).execute()
         document_id = result.get("documentId", "")
@@ -4549,6 +4586,7 @@ def docs_create(docs_service: object, title: str) -> Document | None:
 
 def docs_delete(drive_service: object, document_id: str) -> bool:
     """Soft-delete (trash) a document."""
+    _assert_live_write_allowed("delete Google Doc")
     try:
         drive_service.files().update(fileId=document_id, body={"trashed": True}).execute()
         return True
@@ -5522,7 +5560,11 @@ def autocomplete(
 
 # ── Desktop Notifications ─────────────────────────────────────────────────────
 
-NOTIFICATION_CONFIG_PATH = Path.home() / ".config" / "inbox" / "notifications.json"
+NOTIFICATION_CONFIG_PATH = (
+    _TEST_DATA_DIR / "config/inbox/notifications.json"
+    if _TEST_DATA_DIR
+    else Path.home() / ".config" / "inbox" / "notifications.json"
+)
 
 _DEFAULT_NOTIFICATION_CONFIG: dict = {
     "enabled": True,
@@ -5600,6 +5642,7 @@ def send_notification(title: str, body: str, source: str = "") -> bool:
     falls back to osascript so tests/CI without pyobjc still work.
     Respects the notification config (enabled flag, per-source toggle, quiet hours).
     """
+    _assert_live_write_allowed("send desktop notification")
     cfg = load_notification_config()
     if not cfg.get("enabled", True):
         return False
@@ -5648,7 +5691,11 @@ def send_notification(title: str, body: str, source: str = "") -> bool:
 
 # ── Contacts search / profile ────────────────────────────────────────────────
 
-FAVORITES_FILE = Path.home() / ".config" / "inbox" / "favorites.json"
+FAVORITES_FILE = (
+    _TEST_DATA_DIR / "config/inbox/favorites.json"
+    if _TEST_DATA_DIR
+    else Path.home() / ".config" / "inbox" / "favorites.json"
+)
 
 
 def load_favorites() -> set[str]:
@@ -6174,7 +6221,11 @@ def ai_extract_actions(text: str) -> dict:  # type: ignore[type-arg]
 
 # ── Voice Config ────────────────────────────────────────────────────────────
 
-VOICE_CONFIG_PATH = Path.home() / ".config" / "inbox" / "voice.json"
+VOICE_CONFIG_PATH = (
+    _TEST_DATA_DIR / "config/inbox/voice.json"
+    if _TEST_DATA_DIR
+    else Path.home() / ".config" / "inbox" / "voice.json"
+)
 
 _VOICE_CONFIG_DEFAULTS: dict[str, object] = {
     "ambient_autostart": False,
@@ -6350,6 +6401,7 @@ def calendar_modify_attendees(
     calendar_id: str = "primary",
 ) -> bool:
     """Add/remove attendees from an event."""
+    _assert_live_write_allowed("modify calendar attendees")
     try:
         existing = cal_service.events().get(calendarId=calendar_id, eventId=event_id).execute()
         attendees = existing.get("attendees", [])

--- a/services.py
+++ b/services.py
@@ -80,6 +80,14 @@ def init_contacts() -> int:
     return _contacts.load()
 
 
+def _assert_live_write_allowed(action: str) -> None:
+    try:
+        from inbox_test_mode import assert_live_writes_allowed
+    except ImportError:
+        return
+    assert_live_writes_allowed(action)
+
+
 # ── Data models ───────────────────────────────────────────────────────────────
 
 
@@ -681,6 +689,7 @@ def imsg_thread(chat_id: str, limit: int = 50) -> list[Msg]:
 
 
 def imsg_send(contact: Contact, text: str) -> bool:
+    _assert_live_write_allowed("send iMessage")
     safe_text = _escape_applescript(text)
 
     if contact.is_group:
@@ -1074,6 +1083,7 @@ def gmail_thread_summary(service, thread_id: str, account_email: str) -> ThreadS
 
 
 def gmail_send(service, contact: Contact, body: str) -> bool:
+    _assert_live_write_allowed("send Gmail reply")
     msg = MIMEText(body)
     msg["to"] = contact.reply_to
     msg["subject"] = f"Re: {contact.snippet}"
@@ -1102,6 +1112,7 @@ def gmail_send(service, contact: Contact, body: str) -> bool:
 
 def gmail_archive(service, msg_id: str) -> bool:
     """Archive a Gmail message by removing the INBOX label."""
+    _assert_live_write_allowed("archive Gmail message")
     try:
         service.users().messages().modify(
             userId="me", id=msg_id, body={"removeLabelIds": ["INBOX"]}
@@ -1150,6 +1161,7 @@ def gmail_unsubscribe(service, msg_id: str) -> dict[str, str]:
     Execute unsubscribe via List-Unsubscribe header, then archive the message.
     Returns {"method": "url|mailto|none", "ok": bool}.
     """
+    _assert_live_write_allowed("unsubscribe Gmail message")
     import urllib.parse
 
     import requests
@@ -1189,6 +1201,7 @@ def gmail_unsubscribe(service, msg_id: str) -> dict[str, str]:
 
 def gmail_delete(service, msg_id: str) -> bool:
     """Move a Gmail message to trash."""
+    _assert_live_write_allowed("delete Gmail message")
     try:
         service.users().messages().trash(userId="me", id=msg_id).execute()
         return True
@@ -1199,6 +1212,7 @@ def gmail_delete(service, msg_id: str) -> bool:
 
 def gmail_star(service, msg_id: str) -> bool:
     """Add STARRED label to a Gmail message."""
+    _assert_live_write_allowed("star Gmail message")
     try:
         service.users().messages().modify(
             userId="me", id=msg_id, body={"addLabelIds": ["STARRED"]}
@@ -1211,6 +1225,7 @@ def gmail_star(service, msg_id: str) -> bool:
 
 def gmail_unstar(service, msg_id: str) -> bool:
     """Remove STARRED label from a Gmail message."""
+    _assert_live_write_allowed("unstar Gmail message")
     try:
         service.users().messages().modify(
             userId="me", id=msg_id, body={"removeLabelIds": ["STARRED"]}
@@ -1223,6 +1238,7 @@ def gmail_unstar(service, msg_id: str) -> bool:
 
 def gmail_mark_read(service, msg_id: str) -> bool:
     """Mark a Gmail message as read by removing UNREAD label."""
+    _assert_live_write_allowed("mark Gmail message read")
     try:
         service.users().messages().modify(
             userId="me", id=msg_id, body={"removeLabelIds": ["UNREAD"]}
@@ -1235,6 +1251,7 @@ def gmail_mark_read(service, msg_id: str) -> bool:
 
 def gmail_mark_unread(service, msg_id: str) -> bool:
     """Mark a Gmail message as unread by adding UNREAD label."""
+    _assert_live_write_allowed("mark Gmail message unread")
     try:
         service.users().messages().modify(
             userId="me", id=msg_id, body={"addLabelIds": ["UNREAD"]}
@@ -1285,6 +1302,7 @@ def gmail_attachment_download(service, msg_id: str, att_id: str) -> bytes | None
 
 def gmail_compose_send(service, to: str, subject: str, body: str) -> bool:
     """Send a new email (not a reply)."""
+    _assert_live_write_allowed("send Gmail message")
     msg = MIMEText(body)
     msg["to"] = to
     msg["subject"] = subject
@@ -1437,6 +1455,7 @@ def gmail_batch_modify(
     remove_label_ids: list[str] | None = None,
 ) -> bool:
     """Apply Gmail labels to multiple messages at once."""
+    _assert_live_write_allowed("modify Gmail labels")
     try:
         service.users().messages().batchModify(
             userId="me",
@@ -1465,6 +1484,7 @@ def gmail_create_filter(
     forward: str = "",
 ) -> dict | None:
     """Create a Gmail filter. Requires gmail.settings.basic scope."""
+    _assert_live_write_allowed("create Gmail filter")
     try:
         action: dict[str, object] = {
             "addLabelIds": add_label_ids or [],
@@ -1712,6 +1732,7 @@ def calendar_create_event(
     recurrence: list[str] | None = None,
     reminders: dict | None = None,
 ) -> str | None:
+    _assert_live_write_allowed("create calendar event")
     try:
         body = _build_event_body(
             summary,
@@ -1755,6 +1776,7 @@ def calendar_update_event(
     calendar_id: str = "primary",
     reminders: dict | None = None,
 ) -> bool:
+    _assert_live_write_allowed("update calendar event")
     try:
         existing = cal_service.events().get(calendarId=calendar_id, eventId=event_id).execute()
         if summary is not None:
@@ -1798,6 +1820,7 @@ def calendar_update_event(
 
 
 def calendar_delete_event(cal_service, event_id: str, calendar_id: str = "primary") -> bool:
+    _assert_live_write_allowed("delete calendar event")
     try:
         cal_service.events().delete(calendarId=calendar_id, eventId=event_id).execute()
         return True
@@ -2965,6 +2988,7 @@ def reminder_complete(title: str, list_name: str = "") -> bool:
     Returns:
         True if the completion succeeded, False otherwise.
     """
+    _assert_live_write_allowed("complete Apple Reminder")
     find_clause = _applescript_find_reminder(title, list_name)
     script = f"""
     tell application "Reminders"
@@ -2992,6 +3016,7 @@ def reminder_uncomplete(title: str, list_name: str = "") -> bool:
     Returns:
         True if the operation succeeded, False otherwise.
     """
+    _assert_live_write_allowed("uncomplete Apple Reminder")
     find_clause = _applescript_find_reminder(title, list_name)
     script = f"""
     tell application "Reminders"
@@ -3030,6 +3055,7 @@ def reminder_create(
     Returns:
         True if creation succeeded, False otherwise.
     """
+    _assert_live_write_allowed("create Apple Reminder")
     safe_title = _escape_applescript(title)
     safe_notes = _escape_applescript(notes)
     safe_list = _escape_applescript(list_name)
@@ -3106,6 +3132,7 @@ def reminder_edit(
     Returns:
         True if the edit succeeded, False otherwise.
     """
+    _assert_live_write_allowed("edit Apple Reminder")
     find_clause = _applescript_find_reminder(current_title, list_name)
     set_clauses: list[str] = []
 
@@ -3166,6 +3193,7 @@ def reminder_delete(title: str, list_name: str = "") -> bool:
     Returns:
         True if the deletion succeeded, False otherwise.
     """
+    _assert_live_write_allowed("delete Apple Reminder")
     find_clause = _applescript_find_reminder(title, list_name)
     script = f"""
     tell application "Reminders"

--- a/tests/test_inbox_test_mode.py
+++ b/tests/test_inbox_test_mode.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.safe
+
+
+def test_test_mode_blocks_live_writes(monkeypatch):
+    monkeypatch.setenv("INBOX_TEST_MODE", "1")
+
+    from inbox_test_mode import LiveWriteBlocked, assert_live_writes_allowed
+
+    with pytest.raises(LiveWriteBlocked, match="send email"):
+        assert_live_writes_allowed("send email")
+
+
+def test_test_mode_uses_configured_test_data_dir(tmp_path, monkeypatch):
+    monkeypatch.setenv("INBOX_TEST_MODE", "1")
+    monkeypatch.setenv("INBOX_TEST_DATA_DIR", str(tmp_path))
+
+    from inbox_test_mode import test_data_dir
+
+    assert test_data_dir() == tmp_path
+
+
+def test_agent_safe_pytest_markers_are_registered(pytestconfig):
+    marker_lines = pytestconfig.getini("markers")
+
+    for marker in ["safe", "integration", "local_data", "slow", "live_write"]:
+        assert any(line.startswith(f"{marker}:") for line in marker_lines)
+
+
+def test_agent_testing_docs_define_safe_commands_and_opt_in_warnings():
+    docs = Path("docs/TESTING_FOR_AGENTS.md").read_text()
+
+    assert "INBOX_TEST_MODE=1 uv run pytest -m safe" in docs
+    assert "uv run ruff check ." in docs
+    assert "uv run pyright" in docs
+    assert "Do not run live-write tests unless explicitly instructed" in docs

--- a/tests/test_inbox_test_mode.py
+++ b/tests/test_inbox_test_mode.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import importlib
 from pathlib import Path
 
 import pytest
@@ -23,6 +24,26 @@ def test_test_mode_uses_configured_test_data_dir(tmp_path, monkeypatch):
     from inbox_test_mode import test_data_dir
 
     assert test_data_dir() == tmp_path
+
+
+def test_services_resolve_local_data_paths_under_test_dir(tmp_path, monkeypatch):
+    monkeypatch.setenv("INBOX_TEST_MODE", "1")
+    monkeypatch.setenv("INBOX_TEST_DATA_DIR", str(tmp_path))
+
+    import services
+
+    services = importlib.reload(services)
+    try:
+        assert tmp_path / "token.json" == services.TOKEN_FILE
+        assert tmp_path / "tokens" == services.TOKENS_DIR
+        assert tmp_path / "Library/Messages/chat.db" == services.IMSG_DB
+        assert tmp_path / "config/inbox/notifications.json" == services.NOTIFICATION_CONFIG_PATH
+        assert tmp_path / "config/inbox/favorites.json" == services.FAVORITES_FILE
+        assert tmp_path / "config/inbox/voice.json" == services.VOICE_CONFIG_PATH
+    finally:
+        monkeypatch.delenv("INBOX_TEST_MODE", raising=False)
+        monkeypatch.delenv("INBOX_TEST_DATA_DIR", raising=False)
+        importlib.reload(services)
 
 
 def test_agent_safe_pytest_markers_are_registered(pytestconfig):

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -865,3 +865,23 @@ def test_test_mode_blocks_representative_live_writes(monkeypatch):
         )
     with pytest.raises(LiveWriteBlocked, match="Apple Reminder"):
         services.reminder_complete("Test reminder")
+
+
+def test_test_mode_blocks_extended_live_writes(monkeypatch):
+    monkeypatch.setenv("INBOX_TEST_MODE", "1")
+    from inbox_test_mode import LiveWriteBlocked
+
+    with pytest.raises(LiveWriteBlocked, match="Google Task"):
+        services.task_create(_WriteShouldNotRun(), "Test task")
+    with pytest.raises(LiveWriteBlocked, match="Google Drive"):
+        services.drive_create_folder(_WriteShouldNotRun(), "Test folder")
+    with pytest.raises(LiveWriteBlocked, match="Google Sheet"):
+        services.sheets_values_update(_WriteShouldNotRun(), "sheet-id", "A1", [["x"]])
+    with pytest.raises(LiveWriteBlocked, match="Google Doc"):
+        services.docs_create(_WriteShouldNotRun(), "Test doc")
+    with pytest.raises(LiveWriteBlocked, match="GitHub notification"):
+        services.github_mark_read("notification-id")
+    with pytest.raises(LiveWriteBlocked, match="desktop notification"):
+        services.send_notification("Title", "Body")
+    with pytest.raises(LiveWriteBlocked, match="WhatsApp"):
+        services.whatsapp_send("Alice", "hello")

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -7,11 +7,12 @@ import re
 import sqlite3
 import threading
 from collections.abc import Callable
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from io import StringIO
 from pathlib import Path
 from typing import Any
 
+import pytest
 from loguru import logger
 
 import services
@@ -834,3 +835,33 @@ def test_load_favorites_handles_corrupt_file(tmp_path, monkeypatch):
 
     result = load_favorites()
     assert result == set()
+
+
+class _WriteShouldNotRun:
+    def __getattr__(self, name: str) -> Any:
+        raise AssertionError(f"live write service was touched: {name}")
+
+
+def test_test_mode_blocks_representative_live_writes(monkeypatch):
+    monkeypatch.setenv("INBOX_TEST_MODE", "1")
+    from inbox_test_mode import LiveWriteBlocked
+
+    contact = services.Contact(
+        id="msg-1",
+        name="Alice",
+        source="gmail",
+        reply_to="alice@example.com",
+        snippet="Hello",
+    )
+
+    with pytest.raises(LiveWriteBlocked, match="Gmail reply"):
+        services.gmail_send(_WriteShouldNotRun(), contact, "hello")
+    with pytest.raises(LiveWriteBlocked, match="calendar event"):
+        services.calendar_create_event(
+            _WriteShouldNotRun(),
+            "Test",
+            datetime(2026, 5, 3, tzinfo=UTC),
+            datetime(2026, 5, 3, 1, tzinfo=UTC),
+        )
+    with pytest.raises(LiveWriteBlocked, match="Apple Reminder"):
+        services.reminder_complete("Test reminder")


### PR DESCRIPTION
## Summary
- add INBOX_TEST_MODE helpers and documented agent-safe test commands
- register safe/integration/local_data/slow/live_write pytest markers
- block representative live Gmail, Calendar, iMessage, Apple Reminder, Google Tasks/Drive/Docs/Sheets, GitHub notification, WhatsApp, and desktop notification write surfaces in test mode
- redirect local token, message/note/reminder, notification, favorites, and voice config paths under INBOX_TEST_DATA_DIR while test mode is enabled

## Tests
- INBOX_TEST_MODE=1 uv run pytest tests/test_inbox_test_mode.py tests/test_services.py::test_test_mode_blocks_representative_live_writes tests/test_services.py::test_test_mode_blocks_extended_live_writes -q
- uv run ruff check services.py tests/test_services.py inbox_test_mode.py tests/test_inbox_test_mode.py
- uv run pyright services.py inbox_test_mode.py tests/test_inbox_test_mode.py tests/test_services.py (fails: existing broad services.py dynamic API typing issues)

Closes #2