### PR TITLE
Make inbox server runtime testable

### DIFF
--- a/inbox_server.py
+++ b/inbox_server.py
@@ -10,7 +10,9 @@ import base64
 import math
 import os
 import re
+from collections.abc import Callable
 from contextlib import asynccontextmanager, suppress
+from dataclasses import dataclass
 from datetime import datetime, timedelta
 from secrets import compare_digest
 from typing import Any
@@ -173,6 +175,14 @@ from services import (
 
 PORT = 9849
 AUTH_TOKEN_ENV = "INBOX_SERVER_TOKEN"  # nosec: B105 - env var name, not a hardcoded credential
+GOOGLE_SERVICE_SET = tuple[
+    dict[str, object],
+    dict[str, object],
+    dict[str, object],
+    dict[str, object],
+    dict[str, object],
+    dict[str, object],
+]
 
 
 # ── Pydantic models ──────────────────────────────────────────────────────────
@@ -720,6 +730,21 @@ state = ServerState()
 memory_store = MemoryStore()
 
 
+@dataclass
+class InboxServerRuntime:
+    server_state: ServerState | None = None
+    init_contacts_func: Callable[[], int] | None = None
+    google_auth_func: Callable[[], GOOGLE_SERVICE_SET] | None = None
+    start_scheduler: bool = True
+    ambient_autostart: bool = True
+    prewarm_conversations: bool | None = None
+    close_sqlite_func: Callable[[], None] | None = None
+
+
+def _empty_google_services() -> GOOGLE_SERVICE_SET:
+    return {}, {}, {}, {}, {}, {}
+
+
 # ── Helpers ──────────────────────────────────────────────────────────────────
 
 
@@ -1110,78 +1135,119 @@ async def _scheduler_loop() -> None:
 # ── App lifecycle ────────────────────────────────────────────────────────────
 
 
-@asynccontextmanager
-async def lifespan(app: FastAPI):
-    n = await asyncio.to_thread(init_contacts)
-    print(f"Loaded {n} contacts")
+def make_lifespan(runtime: InboxServerRuntime | None = None):
+    runtime = runtime or InboxServerRuntime()
 
-    gmail, cal, drive, sheets, docs, tasks = await asyncio.to_thread(google_auth_all)
-    state.gmail_services = gmail
-    state.cal_services = cal
-    state.drive_services = drive
-    state.sheets_services = sheets
-    state.docs_services = docs
-    state.tasks_services = tasks
-    print(
-        f"Gmail accounts: {list(gmail.keys())}, "
-        f"Calendar accounts: {list(cal.keys())}, "
-        f"Drive accounts: {list(drive.keys())}, "
-        f"Sheets accounts: {list(sheets.keys())}, "
-        f"Docs accounts: {list(docs.keys())}, "
-        f"Tasks accounts: {list(tasks.keys())}"
+    @asynccontextmanager
+    async def lifespan(app: FastAPI):
+        global state
+
+        previous_state = state
+        if runtime.server_state is not None:
+            state = runtime.server_state
+
+        init_contacts_func = runtime.init_contacts_func or init_contacts
+        google_auth_func = runtime.google_auth_func or google_auth_all
+        close_sqlite_func = runtime.close_sqlite_func or close_sqlite_connections
+
+        n = await asyncio.to_thread(init_contacts_func)
+        print(f"Loaded {n} contacts")
+
+        gmail, cal, drive, sheets, docs, tasks = await asyncio.to_thread(google_auth_func)
+        state.gmail_services = gmail
+        state.cal_services = cal
+        state.drive_services = drive
+        state.sheets_services = sheets
+        state.docs_services = docs
+        state.tasks_services = tasks
+        print(
+            f"Gmail accounts: {list(gmail.keys())}, "
+            f"Calendar accounts: {list(cal.keys())}, "
+            f"Drive accounts: {list(drive.keys())}, "
+            f"Sheets accounts: {list(sheets.keys())}, "
+            f"Docs accounts: {list(docs.keys())}, "
+            f"Tasks accounts: {list(tasks.keys())}"
+        )
+
+        prewarm = runtime.prewarm_conversations
+        if prewarm is None:
+            prewarm = os.environ.get("INBOX_PRE_WARM_CONVERSATIONS", "").strip() in (
+                "1",
+                "true",
+                "yes",
+            )
+        if prewarm:
+            try:
+                results = await _fetch_conversations("all", limit=50)
+                state.conv_cache.clear()
+                for c in results:
+                    state.conv_cache[_cache_key(c.source, c.id)] = c
+                print(f"Pre-warmed {len(state.conv_cache)} conversations")
+            except Exception:
+                logger.warning("Pre-warm conversations failed (non-fatal)")
+
+        if runtime.ambient_autostart:
+            try:
+                disable_ambient = os.environ.get("INBOX_DISABLE_AMBIENT", "").strip().lower() in (
+                    "1",
+                    "true",
+                    "yes",
+                )
+                voice_cfg = load_voice_config()
+                if disable_ambient:
+                    print("[ambient] Autostart disabled by INBOX_DISABLE_AMBIENT")
+                elif voice_cfg.get("ambient_autostart", False):
+                    avail, reason = ambient_available()
+                    if avail:
+                        state.ambient.start()
+                        print("[ambient] Auto-started ambient listening")
+                    else:
+                        print(f"[ambient] Autostart skipped: {reason}")
+            except Exception:
+                logger.warning("Ambient autostart failed (non-fatal)")
+
+        scheduler_task = None
+        if runtime.start_scheduler:
+            scheduler_task = asyncio.create_task(_scheduler_loop())
+
+        try:
+            yield
+        finally:
+            if scheduler_task is not None:
+                scheduler_task.cancel()
+                with suppress(asyncio.CancelledError, Exception):
+                    await scheduler_task
+            state.ambient.stop()
+            await asyncio.to_thread(close_sqlite_func)
+            if runtime.server_state is not None:
+                state = previous_state
+
+    return lifespan
+
+
+def create_app(runtime: InboxServerRuntime | None = None) -> FastAPI:
+    new_app = FastAPI(
+        title="Inbox API",
+        lifespan=make_lifespan(runtime),
+        docs_url="/api-docs",
+        redoc_url="/api-redoc",
+        openapi_url="/api-openapi.json",
     )
 
-    # Pre-warm conversation cache if enabled (reduces cold-start latency)
-    if os.environ.get("INBOX_PRE_WARM_CONVERSATIONS", "").strip() in ("1", "true", "yes"):
-        try:
-            results = await _fetch_conversations("all", limit=50)
-            state.conv_cache.clear()
-            for c in results:
-                state.conv_cache[_cache_key(c.source, c.id)] = c
-            print(f"Pre-warmed {len(state.conv_cache)} conversations")
-        except Exception:
-            logger.warning("Pre-warm conversations failed (non-fatal)")
+    existing_app = globals().get("app")
+    if existing_app is not None:
+        generated_paths = {"/api-docs", "/api-redoc", "/api-openapi.json"}
+        for route in existing_app.router.routes:
+            if getattr(route, "path", "") not in generated_paths:
+                new_app.router.routes.append(route)
+        new_app.user_middleware.extend(existing_app.user_middleware)
+        new_app.exception_handlers.update(existing_app.exception_handlers)
+        new_app.middleware_stack = None
 
-    # Ambient autostart — can be disabled by env and otherwise respects voice config
-    try:
-        disable_ambient = os.environ.get("INBOX_DISABLE_AMBIENT", "").strip().lower() in (
-            "1",
-            "true",
-            "yes",
-        )
-        voice_cfg = load_voice_config()
-        if disable_ambient:
-            print("[ambient] Autostart disabled by INBOX_DISABLE_AMBIENT")
-        elif voice_cfg.get("ambient_autostart", False):
-            avail, reason = ambient_available()
-            if avail:
-                state.ambient.start()
-                print("[ambient] Auto-started ambient listening")
-            else:
-                print(f"[ambient] Autostart skipped: {reason}")
-    except Exception:
-        logger.warning("Ambient autostart failed (non-fatal)")
-
-    # Start background scheduler loop (message scheduling + followup reminders)
-    scheduler_task = asyncio.create_task(_scheduler_loop())
-
-    try:
-        yield
-    finally:
-        scheduler_task.cancel()
-        with suppress(asyncio.CancelledError, Exception):
-            await scheduler_task
-        state.ambient.stop()
-        await asyncio.to_thread(close_sqlite_connections)
+    return new_app
 
 
-app = FastAPI(
-    title="Inbox API",
-    lifespan=lifespan,
-    docs_url="/api-docs",
-    redoc_url="/api-redoc",
-    openapi_url="/api-openapi.json",
-)
+app = create_app()
 
 
 def _auth_token() -> str:

--- a/services.py
+++ b/services.py
@@ -470,7 +470,7 @@ def google_auth_all() -> tuple[
     dict[str, object],
 ]:
     """Auth all accounts from tokens/ dir. Returns (gmail_svcs, cal_svcs, drive_svcs, sheets_svcs, docs_svcs, tasks_svcs)."""
-    TOKENS_DIR.mkdir(exist_ok=True)
+    TOKENS_DIR.mkdir(parents=True, exist_ok=True)
 
     # Migrate legacy token.json — if it's missing scopes, re-auth
     if TOKEN_FILE.exists() and not any(TOKENS_DIR.glob("*.json")):
@@ -552,7 +552,7 @@ def google_auth_all() -> tuple[
 
 def add_google_account() -> str | None:
     _assert_live_write_allowed("add Google account")
-    TOKENS_DIR.mkdir(exist_ok=True)
+    TOKENS_DIR.mkdir(parents=True, exist_ok=True)
     if not CREDS_FILE.exists():
         return None
     flow = InstalledAppFlow.from_client_secrets_file(str(CREDS_FILE), GOOGLE_SCOPES)

--- a/tests/test_inbox_test_mode.py
+++ b/tests/test_inbox_test_mode.py
@@ -46,6 +46,24 @@ def test_services_resolve_local_data_paths_under_test_dir(tmp_path, monkeypatch)
         importlib.reload(services)
 
 
+def test_google_auth_all_creates_missing_test_data_parent(tmp_path, monkeypatch):
+    configured = tmp_path / "missing" / "nested"
+    monkeypatch.setenv("INBOX_TEST_MODE", "1")
+    monkeypatch.setenv("INBOX_TEST_DATA_DIR", str(configured))
+
+    import services
+
+    services = importlib.reload(services)
+    try:
+        assert services.google_auth_all() == ({}, {}, {}, {}, {}, {})
+        assert configured / "tokens" == services.TOKENS_DIR
+        assert services.TOKENS_DIR.is_dir()
+    finally:
+        monkeypatch.delenv("INBOX_TEST_MODE", raising=False)
+        monkeypatch.delenv("INBOX_TEST_DATA_DIR", raising=False)
+        importlib.reload(services)
+
+
 def test_agent_safe_pytest_markers_are_registered(pytestconfig):
     marker_lines = pytestconfig.getini("markers")
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -28,31 +28,31 @@ from services import (
 
 @pytest.fixture
 def client():
-    """TestClient with mocked lifespan (no real Google auth / contacts)."""
+    """TestClient with fake runtime state and disabled background loops."""
     import inbox_server
 
-    # Patch lifespan dependencies so real auth doesn't run
+    mock_ambient = MagicMock()
+    mock_ambient.is_running = False
+    mock_dictation = MagicMock()
+    mock_dictation.is_running = False
+    mock_dictation.available = True
+
+    fake_state = inbox_server.ServerState()
+    fake_state.ambient = mock_ambient
+    fake_state.dictation = mock_dictation
+
+    runtime = inbox_server.InboxServerRuntime(
+        server_state=fake_state,
+        init_contacts_func=lambda: 0,
+        google_auth_func=inbox_server._empty_google_services,
+        start_scheduler=False,
+        ambient_autostart=False,
+    )
+
     with (
         patch.dict(os.environ, {"INBOX_SERVER_TOKEN": ""}, clear=False),
-        patch("inbox_server.init_contacts", return_value=0),
-        patch("inbox_server.google_auth_all", return_value=({}, {}, {}, {}, {}, {})),
-        TestClient(inbox_server.app, raise_server_exceptions=False) as c,
+        TestClient(inbox_server.create_app(runtime), raise_server_exceptions=False) as c,
     ):
-        # Reset state after lifespan has run (lifespan sets from mocked return)
-        inbox_server.state.gmail_services = {}
-        inbox_server.state.cal_services = {}
-        inbox_server.state.drive_services = {}
-        inbox_server.state.sheets_services = {}
-        inbox_server.state.conv_cache = {}
-        inbox_server.state.events_cache = []
-        # Replace ambient/dictation with mocks for testing
-        mock_ambient = MagicMock()
-        mock_ambient.is_running = False
-        mock_dictation = MagicMock()
-        mock_dictation.is_running = False
-        mock_dictation.available = True
-        inbox_server.state.ambient = mock_ambient
-        inbox_server.state.dictation = mock_dictation
         yield c
 
 
@@ -261,15 +261,58 @@ class TestLifespanCleanup:
     def test_shutdown_closes_sqlite_connections(self):
         import inbox_server
 
-        with (
-            patch("inbox_server.init_contacts", return_value=0),
-            patch("inbox_server.google_auth_all", return_value=({}, {}, {}, {}, {}, {})),
-            patch("inbox_server.close_sqlite_connections") as mock_close,
-            TestClient(inbox_server.app, raise_server_exceptions=False),
-        ):
-            pass
+        with patch("inbox_server.close_sqlite_connections") as mock_close:
+            runtime = inbox_server.InboxServerRuntime(
+                init_contacts_func=lambda: 0,
+                google_auth_func=inbox_server._empty_google_services,
+                start_scheduler=False,
+                ambient_autostart=False,
+                close_sqlite_func=mock_close,
+            )
+            with TestClient(inbox_server.create_app(runtime), raise_server_exceptions=False):
+                pass
 
         mock_close.assert_called_once_with()
+
+    def test_create_app_runtime_uses_fake_state_and_skips_background_loop(self, monkeypatch):
+        import inbox_server
+
+        scheduler_started = False
+
+        async def fake_scheduler_loop():
+            nonlocal scheduler_started
+            scheduler_started = True
+
+        monkeypatch.setattr(inbox_server, "_scheduler_loop", fake_scheduler_loop)
+
+        fake_state = inbox_server.ServerState()
+        fake_state.ambient = MagicMock()
+        fake_state.ambient.is_running = False
+        runtime = inbox_server.InboxServerRuntime(
+            server_state=fake_state,
+            init_contacts_func=lambda: 0,
+            google_auth_func=lambda: (
+                {"fake@example.com": object()},
+                {},
+                {},
+                {},
+                {},
+                {},
+            ),
+            start_scheduler=False,
+            ambient_autostart=False,
+        )
+
+        with (
+            patch.dict(os.environ, {"INBOX_SERVER_TOKEN": ""}, clear=False),
+            patch("services._github_token", return_value=None),
+            TestClient(inbox_server.create_app(runtime), raise_server_exceptions=False) as client,
+        ):
+            resp = client.get("/health")
+            assert resp.status_code == 200
+            assert resp.json()["gmail_accounts"] == ["fake@example.com"]
+
+        assert scheduler_started is False
 
 
 # ── Conversations ───────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- add an injectable InboxServerRuntime/create_app path for tests to supply fake state and disable background startup work
- update server tests to use the runtime factory and assert scheduler/autostart can be skipped
- fix safe-mode Google token directory creation when INBOX_TEST_DATA_DIR parents do not exist

## Validation
- uv run ruff check services.py inbox_server.py tests/test_inbox_test_mode.py tests/test_server.py
- uv run pytest tests/test_inbox_test_mode.py tests/test_server.py -q
- INBOX_TEST_MODE=1 boot check against missing /tmp/inbox-repro-missing/nested data dir, /health returned 200