### PR TITLE
Add Gmail and Calendar source adapter tracer

### DIFF
--- a/inbox_server.py
+++ b/inbox_server.py
@@ -12,7 +12,7 @@ import os
 import re
 from collections.abc import Callable
 from contextlib import asynccontextmanager, suppress
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 from secrets import compare_digest
 from typing import Any
@@ -708,6 +708,51 @@ class BulkUnsubscribeRequest(BaseModel):
 # ── Server state ─────────────────────────────────────────────────────────────
 
 
+class ProductionGmailSourceAdapter:
+    def search(
+        self,
+        service: object,
+        account_email: str,
+        q: str = "",
+        limit: int = 20,
+        label: str = "",
+        from_filter: str = "",
+        subject_filter: str = "",
+        after: str = "",
+        before: str = "",
+    ) -> list[Contact]:
+        return gmail_search(
+            service,
+            account_email,
+            q,
+            limit,
+            label,
+            from_filter,
+            subject_filter,
+            after,
+            before,
+        )
+
+
+class ProductionCalendarSourceAdapter:
+    def events(
+        self,
+        cal_services: dict[str, object],
+        date: datetime | None = None,
+        start_date: datetime | None = None,
+        end_date: datetime | None = None,
+    ) -> list[CalendarEvent]:
+        return calendar_events(cal_services, date, start_date, end_date)
+
+
+@dataclass
+class SourceAdapters:
+    gmail: ProductionGmailSourceAdapter = field(default_factory=ProductionGmailSourceAdapter)
+    calendar: ProductionCalendarSourceAdapter = field(
+        default_factory=ProductionCalendarSourceAdapter
+    )
+
+
 class ServerState:
     def __init__(self) -> None:
         self.gmail_services: dict[str, object] = {}
@@ -724,6 +769,7 @@ class ServerState:
         self.dictation: DictationService = DictationService()
         self.scheduler: SchedulerStore = SchedulerStore()
         self.index_store: MessageIndexStore = MessageIndexStore()
+        self.source_adapters: SourceAdapters = SourceAdapters()
 
 
 state = ServerState()
@@ -1644,7 +1690,7 @@ async def search_gmail(
     )
     for email, svc in targets.items():
         contacts = await asyncio.to_thread(
-            gmail_search,
+            state.source_adapters.gmail.search,
             svc,
             email,
             q,
@@ -1794,14 +1840,16 @@ async def list_events(
         start_dt = datetime.fromisoformat(start)
         end_dt = datetime.fromisoformat(end)
         evts = await asyncio.to_thread(
-            calendar_events,
+            state.source_adapters.calendar.events,
             state.cal_services,
             start_date=start_dt,
             end_date=end_dt,
         )
     else:
         dt = datetime.fromisoformat(date) if date else None
-        evts = await asyncio.to_thread(calendar_events, state.cal_services, dt)
+        evts = await asyncio.to_thread(
+            state.source_adapters.calendar.events, state.cal_services, dt
+        )
     state.events_cache = evts
     return [_event_to_out(e) for e in evts]
 
@@ -1812,7 +1860,7 @@ async def list_upcoming_events(days: int = 7):
     start_dt = datetime.now()
     end_dt = start_dt + timedelta(days=days - 1)
     evts = await asyncio.to_thread(
-        calendar_events,
+        state.source_adapters.calendar.events,
         state.cal_services,
         start_date=start_dt,
         end_date=end_dt,

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -817,6 +817,164 @@ class TestGmailExtensions:
         assert data["count"] == 2
 
 
+class TestSourceAdapters:
+    def test_gmail_search_uses_fake_source_adapter(self, client):
+        import inbox_server
+
+        class FakeGmailAdapter:
+            def __init__(self):
+                self.calls = []
+
+            def search(
+                self,
+                service,
+                account_email,
+                q="",
+                limit=20,
+                label="",
+                from_filter="",
+                subject_filter="",
+                after="",
+                before="",
+            ):
+                self.calls.append(
+                    {
+                        "service": service,
+                        "account_email": account_email,
+                        "q": q,
+                        "limit": limit,
+                        "label": label,
+                        "from_filter": from_filter,
+                        "subject_filter": subject_filter,
+                        "after": after,
+                        "before": before,
+                    }
+                )
+                return [
+                    Contact(
+                        id="fake-msg",
+                        name="Fake Sender",
+                        source="gmail",
+                        snippet="Fake subject",
+                        reply_to="sender@example.com",
+                        thread_id="fake-thread",
+                        gmail_account=account_email,
+                        last_ts=datetime(2025, 1, 2, 3, 4),
+                    )
+                ]
+
+        fake_adapter = FakeGmailAdapter()
+        inbox_server.state.gmail_services = {"fake@example.com": object()}
+        inbox_server.state.source_adapters.gmail = fake_adapter
+
+        resp = client.get(
+            "/gmail/search",
+            params={
+                "q": "invoice",
+                "account": "fake@example.com",
+                "limit": 5,
+                "label": "INBOX",
+            },
+        )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data[0]["id"] == "fake-msg"
+        assert data[0]["name"] == "Fake Sender"
+        assert data[0]["source"] == "gmail"
+        assert data[0]["gmail_account"] == "fake@example.com"
+        assert fake_adapter.calls[0]["q"] == "invoice"
+        assert fake_adapter.calls[0]["label"] == "INBOX"
+
+    def test_calendar_events_uses_fake_source_adapter(self, client):
+        import inbox_server
+
+        class FakeCalendarAdapter:
+            def __init__(self):
+                self.calls = []
+
+            def events(self, cal_services, date=None, start_date=None, end_date=None):
+                self.calls.append(
+                    {
+                        "cal_services": cal_services,
+                        "date": date,
+                        "start_date": start_date,
+                        "end_date": end_date,
+                    }
+                )
+                return [
+                    CalendarEvent(
+                        summary="Fake Standup",
+                        start=datetime(2025, 6, 15, 9, 0),
+                        end=datetime(2025, 6, 15, 9, 30),
+                        account="fake@example.com",
+                        event_id="fake-event",
+                        calendar_id="primary",
+                    )
+                ]
+
+        fake_adapter = FakeCalendarAdapter()
+        inbox_server.state.cal_services = {"fake@example.com": object()}
+        inbox_server.state.source_adapters.calendar = fake_adapter
+
+        resp = client.get(
+            "/calendar/events",
+            params={
+                "start": "2025-06-15T00:00:00",
+                "end": "2025-06-15T23:59:59",
+            },
+        )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data[0]["summary"] == "Fake Standup"
+        assert data[0]["account"] == "fake@example.com"
+        assert data[0]["event_id"] == "fake-event"
+        assert fake_adapter.calls[0]["start_date"] == datetime(2025, 6, 15, 0, 0)
+        assert fake_adapter.calls[0]["end_date"] == datetime(2025, 6, 15, 23, 59, 59)
+
+    def test_production_source_adapters_delegate_to_service_functions(self, monkeypatch):
+        import inbox_server
+
+        gmail_service = object()
+        cal_service = object()
+        expected_contact = Contact(id="msg", name="Sender", source="gmail")
+        expected_event = CalendarEvent(
+            summary="Calendar Event",
+            start=datetime(2025, 7, 1, 9, 0),
+            end=datetime(2025, 7, 1, 10, 0),
+        )
+
+        def fake_gmail_search(*args):
+            assert args == (
+                gmail_service,
+                "me@example.com",
+                "query",
+                3,
+                "INBOX",
+                "",
+                "",
+                "",
+                "",
+            )
+            return [expected_contact]
+
+        def fake_calendar_events(*args):
+            assert args == ({"me@example.com": cal_service}, None, None, None)
+            return [expected_event]
+
+        monkeypatch.setattr(inbox_server, "gmail_search", fake_gmail_search)
+        monkeypatch.setattr(inbox_server, "calendar_events", fake_calendar_events)
+
+        gmail_adapter = inbox_server.ProductionGmailSourceAdapter()
+        calendar_adapter = inbox_server.ProductionCalendarSourceAdapter()
+
+        assert gmail_adapter.search(gmail_service, "me@example.com", "query", 3, "INBOX") == [
+            expected_contact
+        ]
+        assert calendar_adapter.events({"me@example.com": cal_service}) == [expected_event]
+
+
 class TestCalendarExtensions:
     @patch("inbox_server.calendar_events")
     def test_calendar_upcoming(self, mock_events, client):


### PR DESCRIPTION
## Summary
- add production Gmail and Calendar source adapter objects on ServerState
- route /gmail/search and /calendar/events paths through the adapter seam
- add fake-adapter contract tests for Gmail and Calendar plus production delegation coverage

## Validation
- uv run ruff check inbox_server.py tests/test_server.py
- uv run pytest tests/test_server.py::TestSourceAdapters tests/test_server.py::TestGmailExtensions::test_gmail_search tests/test_server.py::TestCalendarExtensions::test_calendar_upcoming -q
- uv run pytest tests/test_server.py -q

Closes #5