### PR TITLE
SYM-108 Add InboxClient bearer token auth

### DIFF
--- a/inbox_client.py
+++ b/inbox_client.py
@@ -20,7 +20,9 @@ SERVER_SCRIPT = Path(__file__).parent / "inbox_server.py"
 
 class InboxClient:
     def __init__(self, base_url: str = SERVER_URL, timeout: float = 30):
-        self._client = httpx.Client(base_url=base_url, timeout=timeout)
+        token = os.environ.get("INBOX_SERVER_TOKEN", "").strip()
+        headers = {"Authorization": f"Bearer {token}"} if token else None
+        self._client = httpx.Client(base_url=base_url, timeout=timeout, headers=headers)
 
     def close(self) -> None:
         self._client.close()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -35,6 +35,30 @@ def _mock_response(data, status_code=200):
     return resp
 
 
+class TestClientInit:
+    def test_init_includes_bearer_header_when_token_set(self, monkeypatch):
+        mock_httpx_client = MagicMock()
+        monkeypatch.setenv("INBOX_SERVER_TOKEN", "secret-token")
+        monkeypatch.setattr(httpx, "Client", mock_httpx_client)
+        InboxClient(base_url="http://127.0.0.1:9999", timeout=7)
+        mock_httpx_client.assert_called_once_with(
+            base_url="http://127.0.0.1:9999",
+            timeout=7,
+            headers={"Authorization": "Bearer secret-token"},
+        )
+
+    def test_init_omits_bearer_header_when_token_unset(self, monkeypatch):
+        mock_httpx_client = MagicMock()
+        monkeypatch.delenv("INBOX_SERVER_TOKEN", raising=False)
+        monkeypatch.setattr(httpx, "Client", mock_httpx_client)
+        InboxClient(base_url="http://127.0.0.1:9999", timeout=7)
+        mock_httpx_client.assert_called_once_with(
+            base_url="http://127.0.0.1:9999",
+            timeout=7,
+            headers=None,
+        )
+
+
 # ── Health ──────────────────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary
- Read `INBOX_SERVER_TOKEN` in `InboxClient` and attach it as a bearer token when present.
- Keep unauthenticated local/dev behavior unchanged when the token is unset.
- Add client initialization tests for both token and no-token cases.

## Validation
- `INBOX_TEST_MODE=1 uv run pytest tests/test_client.py -q`
- `uv run ruff check inbox_client.py tests/test_client.py`

Linear: SYM-108
Codex Cloud task: https://chatgpt.com/codex/tasks/task_e_69fa7909b6e0832c8b6f605b0570b938