### PR TITLE
SYM-109 Fix iMessage skipped-row checkpoints

### DIFF
--- a/message_sync.py
+++ b/message_sync.py
@@ -13,6 +13,7 @@ from services import IMSG_DB, _clean_body, _decode_body, _parse_email_address, g
 GMAIL_BOOTSTRAP_BATCH_SIZE = 250
 GMAIL_INCREMENTAL_BATCH_SIZE = 100
 IMESSAGE_PROGRESS_EVERY = 250
+_ATTACHMENT_TEXT = "(attachment)"
 
 
 def _iso_from_ms(value: int | str | None) -> str:
@@ -30,6 +31,11 @@ def _iso_from_apple_seconds(value: float | int | None) -> str:
 
 def _hash_body(body: str) -> str:
     return hashlib.sha256(body.encode("utf-8")).hexdigest()
+
+
+def _clean_imessage_body(text: str | None) -> str:
+    body = _clean_body(text)
+    return "" if body.replace(_ATTACHMENT_TEXT, "").strip() == "" else body
 
 
 def _gmail_recipients(headers: dict[str, str]) -> list[str]:
@@ -238,7 +244,7 @@ def _imessage_messages_after(last_rowid: int | None = None) -> list[sqlite3.Row]
 
 
 def _imessage_item(row: sqlite3.Row) -> IndexedItem:
-    body = _clean_body(row["text"] or "")
+    body = _clean_imessage_body(row["text"] or "")
     created_at = _iso_from_apple_seconds(row["ts"])
     sender = "Me" if row["is_from_me"] else (row["sender_id"] or "?")
     return IndexedItem(
@@ -277,11 +283,11 @@ def sync_imessage_bootstrap(store: MessageIndexStore) -> dict[str, int]:
     try:
         rows = _imessage_messages_after(highest_rowid or None)
         for row in rows:
-            body = _clean_body(row["text"] or "")
+            highest_rowid = max(highest_rowid, int(row["message_rowid"]))
+            body = _clean_imessage_body(row["text"] or "")
             if not body:
                 continue
             store.upsert_item(_imessage_item(row))
-            highest_rowid = max(highest_rowid, int(row["message_rowid"]))
             count += 1
             if count % IMESSAGE_PROGRESS_EVERY == 0:
                 store.update_sync_progress(
@@ -321,11 +327,11 @@ def sync_imessage_incremental(store: MessageIndexStore) -> dict[str, int]:
     try:
         rows = _imessage_messages_after(last_rowid)
         for row in rows:
-            body = _clean_body(row["text"] or "")
+            highest_rowid = max(highest_rowid, int(row["message_rowid"]))
+            body = _clean_imessage_body(row["text"] or "")
             if not body:
                 continue
             store.upsert_item(_imessage_item(row))
-            highest_rowid = max(highest_rowid, int(row["message_rowid"]))
             count += 1
             if count % IMESSAGE_PROGRESS_EVERY == 0:
                 store.update_sync_progress(

--- a/tests/test_message_sync.py
+++ b/tests/test_message_sync.py
@@ -125,7 +125,9 @@ def test_sync_gmail_bootstrap_resumes_from_saved_page_token(tmp_path, monkeypatc
     assert row_count == 3
 
 
-def test_sync_gmail_bootstrap_does_not_double_count_or_rewrite_items_on_resume(tmp_path, monkeypatch):
+def test_sync_gmail_bootstrap_does_not_double_count_or_rewrite_items_on_resume(
+    tmp_path, monkeypatch
+):
     store = MessageIndexStore(tmp_path / "index.sqlite3")
 
     first_run_service = _FakeGmailService(
@@ -159,9 +161,7 @@ def test_sync_gmail_bootstrap_does_not_double_count_or_rewrite_items_on_resume(t
     assert interrupted["metadata"]["bootstrap_page_token"] == "page-2"
 
     with sqlite3.connect(store.db_path) as conn:
-        interrupted_count = conn.execute(
-            "SELECT COUNT(*) FROM items"
-        ).fetchone()[0]
+        interrupted_count = conn.execute("SELECT COUNT(*) FROM items").fetchone()[0]
         existing_m2_ingested_at = conn.execute(
             "SELECT ingested_at FROM items WHERE external_id = 'm2'"
         ).fetchone()[0]
@@ -200,3 +200,84 @@ def test_sync_gmail_bootstrap_does_not_double_count_or_rewrite_items_on_resume(t
         ).fetchone()[0]
     assert finished_count == 3
     assert resumed_m2_ingested_at == existing_m2_ingested_at
+
+
+def test_sync_imessage_incremental_advances_checkpoint_for_skipped_rows(tmp_path, monkeypatch):
+    store = MessageIndexStore(tmp_path / "index.sqlite3")
+    store.set_sync_state(
+        source="imessage",
+        account="local",
+        checkpoint_type="rowid",
+        checkpoint_value="10",
+        full_sync=False,
+        status="idle",
+        metadata={},
+    )
+
+    monkeypatch.setattr(
+        message_sync,
+        "_imessage_messages_after",
+        lambda _last_rowid: [
+            {
+                "message_rowid": 11,
+                "text": "",
+                "ts": 0,
+                "is_from_me": 0,
+                "sender_id": "a",
+                "chat_id": 1,
+            },
+            {
+                "message_rowid": 12,
+                "text": "\N{OBJECT REPLACEMENT CHARACTER}",
+                "ts": 0,
+                "is_from_me": 0,
+                "sender_id": "a",
+                "chat_id": 1,
+            },
+        ],
+    )
+
+    stats = message_sync.sync_imessage_incremental(store)
+    assert stats == {"local": 0}
+
+    state = store.get_sync_state("imessage", "local")
+    assert state is not None
+    assert state["checkpoint_value"] == "12"
+
+    with sqlite3.connect(store.db_path) as conn:
+        row_count = conn.execute("SELECT COUNT(*) FROM items").fetchone()[0]
+    assert row_count == 0
+
+
+def test_sync_imessage_bootstrap_advances_checkpoint_for_skipped_rows(tmp_path, monkeypatch):
+    store = MessageIndexStore(tmp_path / "index.sqlite3")
+
+    monkeypatch.setattr(
+        message_sync,
+        "_imessage_messages_after",
+        lambda _last_rowid: [
+            {
+                "message_rowid": 1,
+                "text": "",
+                "ts": 0,
+                "is_from_me": 1,
+                "sender_id": None,
+                "chat_id": 1,
+            },
+            {
+                "message_rowid": 2,
+                "text": "\N{OBJECT REPLACEMENT CHARACTER}",
+                "ts": 0,
+                "is_from_me": 1,
+                "sender_id": None,
+                "chat_id": 1,
+            },
+        ],
+    )
+
+    stats = message_sync.sync_imessage_bootstrap(store)
+    assert stats == {"local": 0}
+
+    state = store.get_sync_state("imessage", "local")
+    assert state is not None
+    assert state["checkpoint_value"] == "2"


### PR DESCRIPTION
## Summary
- Advance the iMessage rowid checkpoint before skipping empty rows.
- Treat attachment-placeholder-only iMessages as empty for indexing so they do not create useless indexed items.
- Add bootstrap and incremental tests covering skipped rows and checkpoint advancement.

## Validation
- `INBOX_TEST_MODE=1 uv run pytest tests/test_message_sync.py -q`
- `uv run ruff check message_sync.py tests/test_message_sync.py`

Linear: SYM-109
Codex Cloud task: https://chatgpt.com/codex/tasks/task_e_69fa790d2ae0832cab8514bf442b65d1