### PR TITLE
SYM-110 Require confirmation for sheet write tools

### DIFF
--- a/tests/test_tools_registry.py
+++ b/tests/test_tools_registry.py
@@ -1,0 +1,57 @@
+import inspect
+
+from tools_registry import TOOLS, register_all
+
+
+class DummyMCP:
+    def __init__(self):
+        self._handlers = []
+
+    def tool(self):
+        def decorator(fn):
+            self._handlers.append(fn)
+            return fn
+
+        return decorator
+
+
+class DummyBackend:
+    async def _request(self, method, path, params=None, json=None):
+        return {
+            "method": method,
+            "path": path,
+            "params": params,
+            "json": json,
+        }
+
+
+def test_create_sheet_and_append_rows_are_confirm_gated():
+    by_name = {tool.name: tool for tool in TOOLS}
+    assert by_name["create_sheet"].confirm is True
+    assert by_name["append_sheet_rows"].confirm is True
+
+
+def test_all_mutating_tools_require_confirm():
+    missing_confirm = [tool.name for tool in TOOLS if not tool.readonly and not tool.confirm]
+    assert missing_confirm == []
+
+
+def test_readonly_registration_preserved():
+    mcp = DummyMCP()
+    registered = register_all(mcp, DummyBackend(), readonly_only=True)
+
+    readonly_names = [tool.name for tool in TOOLS if tool.readonly]
+    assert registered == readonly_names
+    assert all(name not in registered for name in ("create_sheet", "append_sheet_rows"))
+
+
+def test_confirm_param_is_added_only_for_confirm_tools():
+    mcp = DummyMCP()
+    register_all(mcp, DummyBackend(), readonly_only=False)
+
+    handlers = {fn.__name__: fn for fn in mcp._handlers}
+    create_sheet_params = inspect.signature(handlers["create_sheet"]).parameters
+    list_sheets_params = inspect.signature(handlers["list_sheets"]).parameters
+
+    assert "confirm" in create_sheet_params
+    assert "confirm" not in list_sheets_params

--- a/tools_registry.py
+++ b/tools_registry.py
@@ -204,6 +204,7 @@ TOOLS: list[Tool] = [
             "list of tab names. Returns the new spreadsheet metadata including id."
         ),
         readonly=False,
+        confirm=True,
         params=[
             Param("title", str, _EMPTY, "body"),
             Param("sheets", list, None, "body"),
@@ -219,6 +220,7 @@ TOOLS: list[Tool] = [
             "(list[list[Any]]). `value_input` is USER_ENTERED or RAW."
         ),
         readonly=False,
+        confirm=True,
         params=[
             Param("spreadsheet_id", str, _EMPTY, "path"),
             Param("range_", str, _EMPTY, "path"),


### PR DESCRIPTION
## Summary
- Mark `create_sheet` and `append_sheet_rows` as confirmation-gated mutating MCP tools.
- Add registry tests to guard confirmation coverage for all mutating tools.
- Verify readonly registration still excludes write tools.

## Validation
- `INBOX_TEST_MODE=1 uv run pytest tests/test_tools_registry.py -q`
- `uv run ruff check tools_registry.py tests/test_tools_registry.py`

Linear: SYM-110
Codex Cloud task: https://chatgpt.com/codex/tasks/task_e_69fa7910a300832cbe4cd38fffb0ca6c