### PR TITLE
SYM-112 Extract shared TUI tab metadata

### DIFF
--- a/command_palette.py
+++ b/command_palette.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from collections.abc import Callable
 from typing import Any
 
+from tui_tabs import TUI_TABS
+
 # ── Command data model ───────────────────────────────────────────────────────
 
 CommandDict = dict[str, Any]
@@ -175,64 +177,16 @@ def build_commands(app: Any) -> list[CommandDict]:
         return lambda: getattr(app, method_name)()
 
     commands: list[CommandDict] = [
-        # Navigate
-        make_command(
-            "switch_all",
-            "Switch to All",
-            "Show all conversations",
-            "Navigate",
-            act("action_filter_all"),
-        ),
-        make_command(
-            "switch_imessage",
-            "Switch to iMessage",
-            "Show iMessage conversations",
-            "Navigate",
-            act("action_filter_imsg"),
-        ),
-        make_command(
-            "switch_gmail",
-            "Switch to Gmail",
-            "Show Gmail conversations",
-            "Navigate",
-            act("action_filter_gmail"),
-        ),
-        make_command(
-            "switch_calendar",
-            "Switch to Calendar",
-            "Show calendar events",
-            "Navigate",
-            act("action_filter_cal"),
-        ),
-        make_command(
-            "switch_notes",
-            "Switch to Notes",
-            "Show Apple Notes",
-            "Navigate",
-            act("action_filter_notes"),
-        ),
-        make_command(
-            "switch_reminders",
-            "Switch to Reminders",
-            "Show Apple Reminders",
-            "Navigate",
-            act("action_filter_rem"),
-        ),
-        make_command(
-            "switch_github",
-            "Switch to GitHub",
-            "Show GitHub notifications",
-            "Navigate",
-            act("action_filter_gh"),
-        ),
-        make_command(
-            "switch_drive",
-            "Switch to Drive",
-            "Show Google Drive files",
-            "Navigate",
-            act("action_filter_drv"),
-        ),
-        # Action
+        *[
+            make_command(
+                tab["command_id"],
+                tab["command_name"],
+                tab["command_description"],
+                "Navigate",
+                act(tab["action"]),
+            )
+            for tab in TUI_TABS
+        ],
         make_command(
             "refresh", "Refresh", "Reload all data from server", "Action", act("action_refresh")
         ),

--- a/inbox.py
+++ b/inbox.py
@@ -38,6 +38,7 @@ from textual.widgets import (
 
 from command_palette import CommandDict, build_commands, filter_commands, resolve_nlp
 from inbox_client import InboxClient
+from tui_tabs import TAB_BY_TEXTUAL_ID, TUI_TABS
 
 DEFAULT_POLL_INTERVAL = 10.0
 
@@ -1361,16 +1362,7 @@ class InboxApp(App):
         with Horizontal(id="main"):
             with Vertical(id="sidebar"):
                 yield Tabs(
-                    Tab("Now", id="tab-all"),
-                    Tab("Actionable", id="tab-act"),
-                    Tab("Waiting On", id="tab-wait"),
-                    Tab("iMessage", id="tab-imsg"),
-                    Tab("Gmail", id="tab-gmail"),
-                    Tab("Calendar", id="tab-cal"),
-                    Tab("Notes", id="tab-notes"),
-                    Tab("Reminders", id="tab-rem"),
-                    Tab("GitHub", id="tab-gh"),
-                    Tab("Drive", id="tab-drv"),
+                    *(Tab(tab["label"], id=tab["textual_tab_id"]) for tab in TUI_TABS),
                     id="tabs",
                 )
                 yield ListView(id="contact-list")
@@ -1503,19 +1495,8 @@ class InboxApp(App):
 
     @on(Tabs.TabActivated, "#tabs")
     def on_tab_activated(self, event: Tabs.TabActivated) -> None:
-        tab_map = {
-            "tab-all": "all",
-            "tab-act": "actionable",
-            "tab-wait": "waiting",
-            "tab-imsg": "imessage",
-            "tab-gmail": "gmail",
-            "tab-cal": "calendar",
-            "tab-notes": "notes",
-            "tab-rem": "reminders",
-            "tab-gh": "github",
-            "tab-drv": "drive",
-        }
-        new_filter = tab_map.get(event.tab.id or "", "all")
+        tab = TAB_BY_TEXTUAL_ID.get(event.tab.id or "")
+        new_filter = (tab or {"id": "all"})["id"]
         # Save state of the tab we're leaving
         if self._active_filter != new_filter:
             self._save_tab_state(self._active_filter)
@@ -1531,13 +1512,8 @@ class InboxApp(App):
             self._load_drive_files()
 
     def _toggle_views(self) -> None:
-        is_detail = self._active_filter in (
-            "calendar",
-            "notes",
-            "reminders",
-            "github",
-            "drive",
-        )
+        tab = next((t for t in TUI_TABS if t["id"] == self._active_filter), None)
+        is_detail = (tab or {"mode": "message"})["mode"] == "detail"
         msg_view = self.query_one("#messages", MessageView)
         det_view = self.query_one("#detail-view", DetailView)
         compose_input = self.query_one("#compose", Input)
@@ -1809,36 +1785,40 @@ class InboxApp(App):
             lv.index = target_index
 
     # ── Tab shortcuts ────────────────────────────────────────────────────
+    def _activate_tab(self, tab_id: str) -> None:
+        tab = next((t for t in TUI_TABS if t["id"] == tab_id), None)
+        if tab:
+            self.query_one("#tabs", Tabs).active = tab["textual_tab_id"]
 
     def action_filter_all(self) -> None:
-        self.query_one("#tabs", Tabs).active = "tab-all"
+        self._activate_tab("all")
 
     def action_filter_imsg(self) -> None:
-        self.query_one("#tabs", Tabs).active = "tab-imsg"
+        self._activate_tab("imessage")
 
     def action_filter_gmail(self) -> None:
-        self.query_one("#tabs", Tabs).active = "tab-gmail"
+        self._activate_tab("gmail")
 
     def action_filter_cal(self) -> None:
-        self.query_one("#tabs", Tabs).active = "tab-cal"
+        self._activate_tab("calendar")
 
     def action_filter_notes(self) -> None:
-        self.query_one("#tabs", Tabs).active = "tab-notes"
+        self._activate_tab("notes")
 
     def action_filter_rem(self) -> None:
-        self.query_one("#tabs", Tabs).active = "tab-rem"
+        self._activate_tab("reminders")
 
     def action_filter_gh(self) -> None:
-        self.query_one("#tabs", Tabs).active = "tab-gh"
+        self._activate_tab("github")
 
     def action_filter_drv(self) -> None:
-        self.query_one("#tabs", Tabs).active = "tab-drv"
+        self._activate_tab("drive")
 
     def action_filter_actionable(self) -> None:
-        self.query_one("#tabs", Tabs).active = "tab-act"
+        self._activate_tab("actionable")
 
     def action_filter_waiting(self) -> None:
-        self.query_one("#tabs", Tabs).active = "tab-wait"
+        self._activate_tab("waiting")
 
     # ── Vim mode actions ─────────────────────────────────────────────────
 

--- a/tests/test_command_palette.py
+++ b/tests/test_command_palette.py
@@ -150,7 +150,7 @@ def test_build_commands_all_have_required_fields():
 def test_build_commands_categories_are_valid():
     app = _mock_app()
     commands = build_commands(app)
-    valid_categories = {"Navigate", "Action", "Create", "Settings"}
+    valid_categories = {"Navigate", "Action", "Create", "Settings", "AI"}
     for cmd in commands:
         assert cmd["category"] in valid_categories, (
             f"Unexpected category '{cmd['category']}' for '{cmd['id']}'"

--- a/tests/test_tui_tabs.py
+++ b/tests/test_tui_tabs.py
@@ -1,0 +1,16 @@
+from tui_tabs import TAB_BY_ID, TAB_BY_TEXTUAL_ID, TUI_TABS
+
+
+def test_tui_tabs_have_unique_ids_and_textual_ids():
+    ids = [tab["id"] for tab in TUI_TABS]
+    textual_ids = [tab["textual_tab_id"] for tab in TUI_TABS]
+
+    assert len(ids) == len(set(ids))
+    assert len(textual_ids) == len(set(textual_ids))
+    assert set(TAB_BY_ID) == set(ids)
+    assert set(TAB_BY_TEXTUAL_ID) == set(textual_ids)
+
+
+def test_tui_tabs_include_expected_detail_modes():
+    detail_tabs = {tab["id"] for tab in TUI_TABS if tab["mode"] == "detail"}
+    assert detail_tabs == {"calendar", "notes", "reminders", "github", "drive"}

--- a/tui_tabs.py
+++ b/tui_tabs.py
@@ -1,0 +1,123 @@
+"""Shared TUI tab metadata for InboxApp and command palette navigation."""
+
+from __future__ import annotations
+
+from typing import TypedDict
+
+
+class TabMeta(TypedDict):
+    id: str
+    label: str
+    textual_tab_id: str
+    mode: str
+    action: str
+    command_id: str
+    command_name: str
+    command_description: str
+
+
+TUI_TABS: tuple[TabMeta, ...] = (
+    {
+        "id": "all",
+        "label": "Now",
+        "textual_tab_id": "tab-all",
+        "mode": "message",
+        "action": "action_filter_all",
+        "command_id": "switch_all",
+        "command_name": "Switch to All",
+        "command_description": "Show all conversations",
+    },
+    {
+        "id": "actionable",
+        "label": "Actionable",
+        "textual_tab_id": "tab-act",
+        "mode": "message",
+        "action": "action_filter_actionable",
+        "command_id": "switch_actionable",
+        "command_name": "Switch to Actionable",
+        "command_description": "Show actionable threads",
+    },
+    {
+        "id": "waiting",
+        "label": "Waiting On",
+        "textual_tab_id": "tab-wait",
+        "mode": "message",
+        "action": "action_filter_waiting",
+        "command_id": "switch_waiting",
+        "command_name": "Switch to Waiting On",
+        "command_description": "Show waiting-on threads",
+    },
+    {
+        "id": "imessage",
+        "label": "iMessage",
+        "textual_tab_id": "tab-imsg",
+        "mode": "message",
+        "action": "action_filter_imsg",
+        "command_id": "switch_imessage",
+        "command_name": "Switch to iMessage",
+        "command_description": "Show iMessage conversations",
+    },
+    {
+        "id": "gmail",
+        "label": "Gmail",
+        "textual_tab_id": "tab-gmail",
+        "mode": "message",
+        "action": "action_filter_gmail",
+        "command_id": "switch_gmail",
+        "command_name": "Switch to Gmail",
+        "command_description": "Show Gmail conversations",
+    },
+    {
+        "id": "calendar",
+        "label": "Calendar",
+        "textual_tab_id": "tab-cal",
+        "mode": "detail",
+        "action": "action_filter_cal",
+        "command_id": "switch_calendar",
+        "command_name": "Switch to Calendar",
+        "command_description": "Show calendar events",
+    },
+    {
+        "id": "notes",
+        "label": "Notes",
+        "textual_tab_id": "tab-notes",
+        "mode": "detail",
+        "action": "action_filter_notes",
+        "command_id": "switch_notes",
+        "command_name": "Switch to Notes",
+        "command_description": "Show Apple Notes",
+    },
+    {
+        "id": "reminders",
+        "label": "Reminders",
+        "textual_tab_id": "tab-rem",
+        "mode": "detail",
+        "action": "action_filter_rem",
+        "command_id": "switch_reminders",
+        "command_name": "Switch to Reminders",
+        "command_description": "Show Apple Reminders",
+    },
+    {
+        "id": "github",
+        "label": "GitHub",
+        "textual_tab_id": "tab-gh",
+        "mode": "detail",
+        "action": "action_filter_gh",
+        "command_id": "switch_github",
+        "command_name": "Switch to GitHub",
+        "command_description": "Show GitHub notifications",
+    },
+    {
+        "id": "drive",
+        "label": "Drive",
+        "textual_tab_id": "tab-drv",
+        "mode": "detail",
+        "action": "action_filter_drv",
+        "command_id": "switch_drive",
+        "command_name": "Switch to Drive",
+        "command_description": "Show Google Drive files",
+    },
+)
+
+TAB_BY_TEXTUAL_ID = {tab["textual_tab_id"]: tab for tab in TUI_TABS}
+TAB_BY_ID = {tab["id"]: tab for tab in TUI_TABS}


### PR DESCRIPTION
## Summary
- Add `tui_tabs.py` as the shared source of truth for TUI tab ids, labels, modes, actions, and command-palette metadata.
- Generate the Textual tabs and navigation commands from the shared registry.
- Add focused tab metadata tests and update the command category invariant to include the existing `AI` command category.

## Validation
- `INBOX_TEST_MODE=1 uv run pytest tests/test_tui_tabs.py tests/test_command_palette.py -q`
- `INBOX_TEST_MODE=1 uv run pytest tests/test_inbox_app.py -k "tab_state_saved_on_switch or tab_state_restored_on_switch_back or tab_state_preserves_reminder_filter or tab_state_preserves_calendar_event_selection or tab_state_messages_retained_across_switches" -q`
- `uv run ruff check command_palette.py inbox.py tui_tabs.py tests/test_command_palette.py tests/test_tui_tabs.py`

## Note
- A broader exploratory run including `test_sidebar_selection_restored_after_tab_switch` still fails with a pre-existing `main` behavior around the Now/indexed-thread view versus legacy conversation selection. That is outside this tab-metadata extraction.

Linear: SYM-112
Codex Cloud task: https://chatgpt.com/codex/tasks/task_e_69fa7916fea0832c87739ec71977c20e