### PR TITLE
SYM-113 Extract shared service data models

### DIFF
--- a/service_models.py
+++ b/service_models.py
@@ -1,0 +1,153 @@
+"""Stable, pure data models shared by services and callers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+
+ATTACHMENT_PLACEHOLDER = "\ufffc"
+
+
+@dataclass
+class Contact:
+    id: str
+    name: str
+    source: str  # "imessage" | "gmail"
+    snippet: str = ""
+    unread: int = 0
+    last_ts: datetime = field(default_factory=datetime.now)
+    guid: str = ""
+    is_group: bool = False
+    members: list[str] = field(default_factory=list)
+    reply_to: str = ""
+    thread_id: str = ""
+    message_id_header: str = ""
+    gmail_account: str = ""
+
+
+@dataclass
+class Msg:
+    sender: str
+    body: str
+    ts: datetime
+    is_me: bool
+    source: str
+    attachments: list[dict[str, str | int]] = field(default_factory=list)
+    message_id: str = ""  # Gmail message ID, empty for iMessage
+
+
+@dataclass
+class CalendarEvent:
+    summary: str
+    start: datetime
+    end: datetime
+    location: str = ""
+    description: str = ""
+    account: str = ""
+    all_day: bool = False
+    event_id: str = ""
+    calendar_id: str = ""
+    attendees: list[dict[str, str]] = field(default_factory=list)
+    recurrence: list[str] = field(default_factory=list)
+    reminders: dict = field(default_factory=dict)
+    recurring_event_id: str = ""
+
+
+@dataclass
+class Note:
+    id: str
+    title: str
+    snippet: str
+    modified: datetime
+    folder: str = ""
+
+
+@dataclass
+class Reminder:
+    id: str
+    title: str
+    completed: bool
+    list_name: str = ""
+    due_date: datetime | None = None
+    notes: str = ""
+    priority: int = 0
+    flagged: bool = False
+    creation_date: datetime | None = None
+
+
+@dataclass
+class GoogleTask:
+    id: str
+    title: str
+    status: str  # "needsAction" | "completed"
+    list_id: str
+    list_title: str
+    due: datetime | None = None
+    notes: str = ""
+    completed: datetime | None = None
+
+
+@dataclass
+class GitHubNotification:
+    id: str
+    title: str
+    repo: str
+    type: str  # "PullRequest", "Issue", "Release", etc.
+    reason: str  # "review_requested", "mention", "subscribed", etc.
+    unread: bool
+    updated_at: datetime
+    url: str = ""
+
+
+@dataclass
+class DriveFile:
+    id: str
+    name: str
+    mime_type: str
+    modified: datetime
+    size: int = 0
+    shared: bool = False
+    web_link: str = ""
+    parents: list[str] = field(default_factory=list)
+    account: str = ""
+
+
+@dataclass
+class SheetTab:
+    sheet_id: int
+    title: str
+    index: int
+    row_count: int
+    col_count: int
+
+
+@dataclass
+class Spreadsheet:
+    id: str
+    title: str
+    url: str
+    sheets: list[SheetTab] = field(default_factory=list)
+    account: str = ""
+
+
+@dataclass
+class Document:
+    id: str
+    title: str
+    url: str
+    mime_type: str = "application/vnd.google-apps.document"
+    account: str = ""
+
+
+@dataclass
+class ThreadSummary:
+    thread_id: str
+    owning_account: str
+    participants: list[str]
+    subject: str
+    last_message_at: datetime
+    label_ids: list[str]
+    body_text: str
+    last_message_body: str
+    last_sender_is_me: bool
+    message_count: int

--- a/services.py
+++ b/services.py
@@ -16,7 +16,7 @@ import subprocess
 import threading
 import time
 from collections.abc import Callable
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from email.mime.text import MIMEText
 from pathlib import Path
@@ -35,6 +35,21 @@ from googleapiclient.discovery import build
 from loguru import logger
 
 from contacts import ContactBook
+from service_models import (
+    ATTACHMENT_PLACEHOLDER,
+    CalendarEvent,
+    Contact,
+    Document,
+    DriveFile,
+    GitHubNotification,
+    GoogleTask,
+    Msg,
+    Note,
+    Reminder,
+    SheetTab,
+    Spreadsheet,
+    ThreadSummary,
+)
 
 # ── Config ────────────────────────────────────────────────────────────────────
 
@@ -82,7 +97,6 @@ GOOGLE_SCOPES = [
     "https://www.googleapis.com/auth/tasks",
 ]
 
-ATTACHMENT_PLACEHOLDER = "\ufffc"
 SQLITE_LOCK_RETRIES = 2
 SQLITE_LOCK_RETRY_DELAY = 0.05
 SQLITE_CONNECT_TIMEOUT = 0.2
@@ -103,154 +117,6 @@ def _assert_live_write_allowed(action: str) -> None:
     except ImportError:
         return
     assert_live_writes_allowed(action)
-
-
-# ── Data models ───────────────────────────────────────────────────────────────
-
-
-@dataclass
-class Contact:
-    id: str
-    name: str
-    source: str  # "imessage" | "gmail"
-    snippet: str = ""
-    unread: int = 0
-    last_ts: datetime = field(default_factory=datetime.now)
-    guid: str = ""
-    is_group: bool = False
-    members: list[str] = field(default_factory=list)
-    reply_to: str = ""
-    thread_id: str = ""
-    message_id_header: str = ""
-    gmail_account: str = ""
-
-
-@dataclass
-class Msg:
-    sender: str
-    body: str
-    ts: datetime
-    is_me: bool
-    source: str
-    attachments: list[dict[str, str | int]] = field(default_factory=list)
-    message_id: str = ""  # Gmail message ID, empty for iMessage
-
-
-@dataclass
-class CalendarEvent:
-    summary: str
-    start: datetime
-    end: datetime
-    location: str = ""
-    description: str = ""
-    account: str = ""
-    all_day: bool = False
-    event_id: str = ""
-    calendar_id: str = ""
-    attendees: list[dict[str, str]] = field(default_factory=list)
-    recurrence: list[str] = field(default_factory=list)
-    reminders: dict = field(default_factory=dict)
-    recurring_event_id: str = ""
-
-
-@dataclass
-class Note:
-    id: str
-    title: str
-    snippet: str
-    modified: datetime
-    folder: str = ""
-
-
-@dataclass
-class Reminder:
-    id: str
-    title: str
-    completed: bool
-    list_name: str = ""
-    due_date: datetime | None = None
-    notes: str = ""
-    priority: int = 0
-    flagged: bool = False
-    creation_date: datetime | None = None
-
-
-@dataclass
-class GoogleTask:
-    id: str
-    title: str
-    status: str  # "needsAction" | "completed"
-    list_id: str
-    list_title: str
-    due: datetime | None = None
-    notes: str = ""
-    completed: datetime | None = None
-
-
-@dataclass
-class GitHubNotification:
-    id: str
-    title: str
-    repo: str
-    type: str  # "PullRequest", "Issue", "Release", etc.
-    reason: str  # "review_requested", "mention", "subscribed", etc.
-    unread: bool
-    updated_at: datetime
-    url: str = ""
-
-
-@dataclass
-class DriveFile:
-    id: str
-    name: str
-    mime_type: str
-    modified: datetime
-    size: int = 0
-    shared: bool = False
-    web_link: str = ""
-    parents: list[str] = field(default_factory=list)
-    account: str = ""
-
-
-@dataclass
-class SheetTab:
-    sheet_id: int
-    title: str
-    index: int
-    row_count: int
-    col_count: int
-
-
-@dataclass
-class Spreadsheet:
-    id: str
-    title: str
-    url: str
-    sheets: list[SheetTab] = field(default_factory=list)
-    account: str = ""
-
-
-@dataclass
-class Document:
-    id: str
-    title: str
-    url: str
-    mime_type: str = "application/vnd.google-apps.document"
-    account: str = ""
-
-
-@dataclass
-class ThreadSummary:
-    thread_id: str
-    owning_account: str
-    participants: list[str]
-    subject: str
-    last_message_at: datetime
-    label_ids: list[str]
-    body_text: str
-    last_message_body: str
-    last_sender_is_me: bool
-    message_count: int
 
 
 # ── Helpers ──────────────────────────────────────────────────────────────────

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -16,7 +16,55 @@ import pytest
 from loguru import logger
 
 import services
+from service_models import (
+    CalendarEvent as ModelCalendarEvent,
+)
+from service_models import (
+    Contact as ModelContact,
+)
+from service_models import (
+    Document as ModelDocument,
+)
+from service_models import (
+    DriveFile as ModelDriveFile,
+)
+from service_models import (
+    GitHubNotification as ModelGitHubNotification,
+)
+from service_models import (
+    GoogleTask as ModelGoogleTask,
+)
+from service_models import (
+    Msg as ModelMsg,
+)
+from service_models import (
+    Note as ModelNote,
+)
+from service_models import (
+    Reminder as ModelReminder,
+)
+from service_models import (
+    SheetTab as ModelSheetTab,
+)
+from service_models import (
+    Spreadsheet as ModelSpreadsheet,
+)
+from service_models import (
+    ThreadSummary as ModelThreadSummary,
+)
 from services import (
+    CalendarEvent,
+    Contact,
+    Document,
+    DriveFile,
+    GitHubNotification,
+    GoogleTask,
+    Msg,
+    Note,
+    Reminder,
+    SheetTab,
+    Spreadsheet,
+    ThreadSummary,
     _build_event_body,
     _clean_body,
     _clean_email_body,
@@ -26,6 +74,22 @@ from services import (
     _parse_time,
     parse_quick_event,
 )
+
+
+def test_service_model_re_exports():
+    assert Contact is ModelContact
+    assert Msg is ModelMsg
+    assert CalendarEvent is ModelCalendarEvent
+    assert Note is ModelNote
+    assert Reminder is ModelReminder
+    assert GoogleTask is ModelGoogleTask
+    assert GitHubNotification is ModelGitHubNotification
+    assert DriveFile is ModelDriveFile
+    assert SheetTab is ModelSheetTab
+    assert Spreadsheet is ModelSpreadsheet
+    assert Document is ModelDocument
+    assert ThreadSummary is ModelThreadSummary
+
 
 # ── _clean_body ─────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- Move reusable service dataclasses and `ATTACHMENT_PLACEHOLDER` into `service_models.py`.
- Keep `services.py` re-exporting the same model names for compatibility with existing imports.
- Add a re-export test covering the extracted model surface.

## Validation
- `INBOX_TEST_MODE=1 uv run pytest tests/test_services.py -k service_model_re_exports -q`
- `INBOX_TEST_MODE=1 uv run pytest tests/test_server.py -k "ThreadSummary or CalendarEvent" -q`
- `uv run python - <<PY ...` import/re-export assertion
- `uv run ruff check service_models.py services.py tests/test_services.py`

## Note
- A full `INBOX_TEST_MODE=1 uv run pytest tests/test_services.py -q` still fails on existing live-write guard conflicts in AppleScript/Gmail write tests; the model extraction import/re-export checks pass.

Linear: SYM-113
Codex Cloud task: https://chatgpt.com/codex/tasks/task_e_69fa791a7380832c97106f23f957f729