### PR TITLE
SYM-114 Extract shared MCP gateway setup

### DIFF
--- a/inbox_mcp_readonly.py
+++ b/inbox_mcp_readonly.py
@@ -8,19 +8,8 @@ and read data but not mutate inbox state.
 from __future__ import annotations
 
 import os
-from pathlib import Path
-from secrets import compare_digest
-
-from starlette.applications import Starlette
-from starlette.middleware import Middleware
-from starlette.middleware.base import BaseHTTPMiddleware
-from starlette.requests import Request
-from starlette.responses import JSONResponse
-from starlette.routing import Mount, Route
 
 import ambient_notes
-from mcp_backend import InboxBackend, InboxBackendError
-from memory_store import MemoryStore
 from tools_registry import register_all as _register_registry_tools
 
 try:
@@ -31,15 +20,13 @@ except ImportError as exc:  # pragma: no cover - runtime-only path
     ) from exc
 
 
-MCP_TOKEN_ENV = "INBOX_MCP_TOKEN"  # nosec: B105 - env var name, not a hardcoded credential
-MEMORY_DB_ENV = "INBOX_MEMORY_DB"
+from mcp_gateway import make_backend, make_health_handler, make_mcp_app, make_memory_store
+
 DEFAULT_HTTP_PORT = 8001
 
 
-backend = InboxBackend()
-memory_store = MemoryStore(
-    Path(os.getenv(MEMORY_DB_ENV, "")).expanduser() if os.getenv(MEMORY_DB_ENV) else None
-)
+backend = make_backend()
+memory_store = make_memory_store()
 mcp = FastMCP(
     "Inbox Personal Assistant (Read Only)",
     stateless_http=True,
@@ -47,51 +34,11 @@ mcp = FastMCP(
 )
 
 
-def _public_token() -> str:
-    return os.getenv(MCP_TOKEN_ENV, "").strip()
-
-
-def _is_publicly_authorized(request: Request) -> bool:
-    token = _public_token()
-    if not token:
-        return True
-
-    auth_header = request.headers.get("authorization", "")
-    if auth_header.lower().startswith("bearer "):
-        provided = auth_header[7:].strip()
-        return bool(provided) and compare_digest(provided, token)
-    return False
-
-
-class PublicAuthMiddleware(BaseHTTPMiddleware):
-    async def dispatch(self, request: Request, call_next):
-        if request.url.path == "/health":
-            return await call_next(request)
-        if not _is_publicly_authorized(request):
-            return JSONResponse(
-                {"detail": "Unauthorized"},
-                status_code=401,
-                headers={"WWW-Authenticate": "Bearer"},
-            )
-        return await call_next(request)
-
-
-async def health(_request: Request) -> JSONResponse:
-    try:
-        backend_health = await backend.health()
-    except InboxBackendError as exc:
-        backend_health = {"status": "error", "detail": str(exc)}
-
-    return JSONResponse(
-        {
-            "status": "ok",
-            "mode": "readonly",
-            "mcp_path": "/mcp",
-            "backend": backend_health,
-            "memory_db": str(memory_store.db_path),
-            "auth_enabled": bool(_public_token()),
-        }
-    )
+health = make_health_handler(
+    backend=backend,
+    memory_store=memory_store,
+    extra_payload={"mode": "readonly"},
+)
 
 
 @mcp.tool()
@@ -130,13 +77,7 @@ async def list_open_commitments(limit: int = 25) -> list[dict]:
 _register_registry_tools(mcp, backend, readonly_only=True)
 
 
-app = Starlette(
-    routes=[
-        Route("/health", endpoint=health),
-        Mount("/mcp", app=mcp.streamable_http_app()),
-    ],
-    middleware=[Middleware(PublicAuthMiddleware)],
-)
+app = make_mcp_app(mcp=mcp, health_endpoint=health)
 
 
 def main() -> None:

--- a/mcp_gateway.py
+++ b/mcp_gateway.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from secrets import compare_digest
+from typing import Any
+
+from starlette.applications import Starlette
+from starlette.middleware import Middleware
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+from starlette.routing import Mount, Route
+
+from mcp_backend import InboxBackend, InboxBackendError
+from memory_store import MemoryStore
+
+MCP_TOKEN_ENV = "INBOX_MCP_TOKEN"  # nosec: B105 - env var name, not a hardcoded credential
+MEMORY_DB_ENV = "INBOX_MEMORY_DB"
+
+
+def make_backend() -> InboxBackend:
+    return InboxBackend()
+
+
+def make_memory_store() -> MemoryStore:
+    db_env = os.getenv(MEMORY_DB_ENV)
+    db_path = Path(db_env).expanduser() if db_env else None
+    return MemoryStore(db_path)
+
+
+def _public_token() -> str:
+    return os.getenv(MCP_TOKEN_ENV, "").strip()
+
+
+def _is_publicly_authorized(request: Request) -> bool:
+    token = _public_token()
+    if not token:
+        return True
+
+    auth_header = request.headers.get("authorization", "")
+    if auth_header.lower().startswith("bearer "):
+        provided = auth_header[7:].strip()
+        return bool(provided) and compare_digest(provided, token)
+    return False
+
+
+class PublicAuthMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request: Request, call_next):
+        if request.url.path == "/health":
+            return await call_next(request)
+        if not _is_publicly_authorized(request):
+            return JSONResponse(
+                {"detail": "Unauthorized"},
+                status_code=401,
+                headers={"WWW-Authenticate": "Bearer"},
+            )
+        return await call_next(request)
+
+
+def make_health_handler(
+    *,
+    backend: InboxBackend,
+    memory_store: MemoryStore,
+    extra_payload: dict[str, Any] | None = None,
+):
+    async def health(_request: Request) -> JSONResponse:
+        try:
+            backend_health = await backend.health()
+        except InboxBackendError as exc:
+            backend_health = {"status": "error", "detail": str(exc)}
+
+        payload: dict[str, Any] = {
+            "status": "ok",
+            "mcp_path": "/mcp",
+            "backend": backend_health,
+            "memory_db": str(memory_store.db_path),
+            "auth_enabled": bool(_public_token()),
+        }
+        if extra_payload:
+            payload.update(extra_payload)
+        return JSONResponse(payload)
+
+    return health
+
+
+def make_mcp_app(*, mcp, health_endpoint) -> Starlette:
+    return Starlette(
+        routes=[
+            Route("/health", endpoint=health_endpoint),
+            Mount("/mcp", app=mcp.streamable_http_app()),
+        ],
+        middleware=[Middleware(PublicAuthMiddleware)],
+    )

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -16,20 +16,7 @@ Environment:
 
 from __future__ import annotations
 
-import os
-from pathlib import Path
-from secrets import compare_digest
-
-from starlette.applications import Starlette
-from starlette.middleware import Middleware
-from starlette.middleware.base import BaseHTTPMiddleware
-from starlette.requests import Request
-from starlette.responses import JSONResponse
-from starlette.routing import Mount, Route
-
 import ambient_notes
-from mcp_backend import InboxBackend, InboxBackendError
-from memory_store import MemoryStore
 from tools_registry import register_all as _register_registry_tools
 
 try:
@@ -40,14 +27,10 @@ except ImportError as exc:  # pragma: no cover - runtime-only path
     ) from exc
 
 
-MCP_TOKEN_ENV = "INBOX_MCP_TOKEN"  # nosec: B105 - env var name, not a hardcoded credential
-MEMORY_DB_ENV = "INBOX_MEMORY_DB"
+from mcp_gateway import make_backend, make_health_handler, make_mcp_app, make_memory_store
 
-
-backend = InboxBackend()
-memory_store = MemoryStore(
-    Path(os.getenv(MEMORY_DB_ENV, "")).expanduser() if os.getenv(MEMORY_DB_ENV) else None
-)
+backend = make_backend()
+memory_store = make_memory_store()
 mcp = FastMCP(
     "Inbox Personal Assistant",
     stateless_http=True,
@@ -67,50 +50,7 @@ def _require_confirmation(confirm: bool, action: str) -> None:
 # integrations (ambient notes, memory_store).
 
 
-def _public_token() -> str:
-    return os.getenv(MCP_TOKEN_ENV, "").strip()
-
-
-def _is_publicly_authorized(request: Request) -> bool:
-    token = _public_token()
-    if not token:
-        return True
-
-    auth_header = request.headers.get("authorization", "")
-    if auth_header.lower().startswith("bearer "):
-        provided = auth_header[7:].strip()
-        return bool(provided) and compare_digest(provided, token)
-    return False
-
-
-class PublicAuthMiddleware(BaseHTTPMiddleware):
-    async def dispatch(self, request: Request, call_next):
-        if request.url.path == "/health":
-            return await call_next(request)
-        if not _is_publicly_authorized(request):
-            return JSONResponse(
-                {"detail": "Unauthorized"},
-                status_code=401,
-                headers={"WWW-Authenticate": "Bearer"},
-            )
-        return await call_next(request)
-
-
-async def health(_request: Request) -> JSONResponse:
-    try:
-        backend_health = await backend.health()
-    except InboxBackendError as exc:
-        backend_health = {"status": "error", "detail": str(exc)}
-
-    return JSONResponse(
-        {
-            "status": "ok",
-            "mcp_path": "/mcp",
-            "backend": backend_health,
-            "memory_db": str(memory_store.db_path),
-            "auth_enabled": bool(_public_token()),
-        }
-    )
+health = make_health_handler(backend=backend, memory_store=memory_store)
 
 
 @mcp.tool()
@@ -202,13 +142,7 @@ async def close_commitment(entry_id: int, confirm: bool = False) -> dict:
 _register_registry_tools(mcp, backend, readonly_only=False)
 
 
-app = Starlette(
-    routes=[
-        Route("/health", endpoint=health),
-        Mount("/mcp", app=mcp.streamable_http_app()),
-    ],
-    middleware=[Middleware(PublicAuthMiddleware)],
-)
+app = make_mcp_app(mcp=mcp, health_endpoint=health)
 
 
 def main() -> None:

--- a/tests/test_mcp_gateway.py
+++ b/tests/test_mcp_gateway.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import pytest
+from starlette.applications import Starlette
+from starlette.middleware import Middleware
+from starlette.responses import JSONResponse
+from starlette.routing import Route
+from starlette.testclient import TestClient
+
+from mcp_backend import InboxBackendError
+from mcp_gateway import (
+    MEMORY_DB_ENV,
+    PublicAuthMiddleware,
+    make_health_handler,
+    make_memory_store,
+)
+
+pytestmark = pytest.mark.safe
+
+
+async def _ok(_request):
+    return JSONResponse({"ok": True})
+
+
+async def _health(_request):
+    return JSONResponse({"ok": True})
+
+
+def _app():
+    return Starlette(
+        routes=[Route("/health", _health), Route("/secure", _ok)],
+        middleware=[Middleware(PublicAuthMiddleware)],
+    )
+
+
+def test_public_auth_middleware_allows_health_without_token(monkeypatch):
+    monkeypatch.setenv("INBOX_MCP_TOKEN", "secret")
+    app = _app()
+    with TestClient(app) as client:
+        resp = client.get("/health")
+    assert resp.status_code == 200
+
+
+def test_public_auth_middleware_rejects_missing_or_invalid_token(monkeypatch):
+    monkeypatch.setenv("INBOX_MCP_TOKEN", "secret")
+    app = _app()
+    with TestClient(app) as client:
+        missing = client.get("/secure")
+        invalid = client.get("/secure", headers={"Authorization": "Bearer nope"})
+        valid = client.get("/secure", headers={"Authorization": "Bearer secret"})
+    assert missing.status_code == 401
+    assert invalid.status_code == 401
+    assert valid.status_code == 200
+
+
+def test_make_memory_store_uses_configured_path(tmp_path, monkeypatch):
+    target = tmp_path / "mem.db"
+    monkeypatch.setenv(MEMORY_DB_ENV, str(target))
+
+    store = make_memory_store()
+
+    assert store.db_path == target
+
+
+@pytest.mark.anyio
+async def test_health_handler_includes_backend_and_extra_payload(monkeypatch):
+    monkeypatch.setenv("INBOX_MCP_TOKEN", "secret")
+
+    class HealthyBackend:
+        async def health(self):
+            return {"status": "ok"}
+
+    class FakeStore:
+        db_path = "/tmp/mem.db"
+
+    handler = make_health_handler(
+        backend=HealthyBackend(),
+        memory_store=FakeStore(),
+        extra_payload={"mode": "readonly"},
+    )
+    resp = await handler(None)
+    payload = resp.body.decode("utf-8")
+
+    assert '"status":"ok"' in payload
+    assert '"mode":"readonly"' in payload
+    assert '"auth_enabled":true' in payload
+
+
+@pytest.mark.anyio
+async def test_health_handler_handles_backend_error(monkeypatch):
+    monkeypatch.delenv("INBOX_MCP_TOKEN", raising=False)
+
+    class FailingBackend:
+        async def health(self):
+            raise InboxBackendError("down")
+
+    class FakeStore:
+        db_path = "/tmp/mem.db"
+
+    handler = make_health_handler(backend=FailingBackend(), memory_store=FakeStore())
+    resp = await handler(None)
+    payload = resp.body.decode("utf-8")
+
+    assert '"backend":{"status":"error","detail":"down"}' in payload
+    assert '"auth_enabled":false' in payload


### PR DESCRIPTION
## Summary
- Add `mcp_gateway.py` for shared MCP backend, memory store, public auth middleware, health handler, and Starlette app wiring.
- Refactor both full and readonly MCP servers to use the shared gateway setup.
- Add focused gateway tests for auth, health payloads, backend errors, and memory DB configuration.

## Validation
- `INBOX_TEST_MODE=1 uv run pytest tests/test_mcp_gateway.py -q`
- `uv run ruff check mcp_gateway.py mcp_server.py inbox_mcp_readonly.py tests/test_mcp_gateway.py`

Linear: SYM-114
Codex Cloud task: https://chatgpt.com/codex/tasks/task_e_69fa791e3528832cae99d8233e88f89d