### PR TITLE
SYM-117 Make Gmail incremental sync history-based

### DIFF
--- a/message_index_store.py
+++ b/message_index_store.py
@@ -330,7 +330,7 @@ class MessageIndexStore:
                 (source, account, error),
             )
 
-    def get_sync_state(self, source: str, account: str) -> dict[str, str] | None:
+    def get_sync_state(self, source: str, account: str) -> dict[str, Any] | None:
         with self._connect() as conn:
             row = conn.execute(
                 "SELECT * FROM sync_state WHERE source = ? AND account = ?",

--- a/message_sync.py
+++ b/message_sync.py
@@ -12,6 +12,8 @@ from services import IMSG_DB, _clean_body, _decode_body, _parse_email_address, g
 
 GMAIL_BOOTSTRAP_BATCH_SIZE = 250
 GMAIL_INCREMENTAL_BATCH_SIZE = 100
+GMAIL_HISTORY_CURSOR = "gmailHistoryId"
+GMAIL_TIMESTAMP_CURSOR = "internalDateMs"
 IMESSAGE_PROGRESS_EVERY = 250
 _ATTACHMENT_TEXT = "(attachment)"
 
@@ -89,21 +91,112 @@ def _fetch_gmail_full_message(service: Any, message_id: str) -> dict[str, Any]:
     return service.users().messages().get(userId="me", id=message_id, format="full").execute()
 
 
+def _fetch_gmail_profile_history_id(service: Any) -> str:
+    try:
+        request = service.users().getProfile(userId="me")
+    except AttributeError:
+        return ""
+    profile = request.execute()
+    return str(profile.get("historyId") or "")
+
+
+def _gmail_history_api(service: Any) -> Any | None:
+    try:
+        return service.users().history()
+    except AttributeError:
+        return None
+
+
+def _gmail_timestamp_checkpoint(state: dict[str, Any]) -> int:
+    metadata = state.get("metadata") or {}
+    if state.get("checkpoint_type") == GMAIL_TIMESTAMP_CURSOR:
+        return int(state.get("checkpoint_value", "0") or 0)
+    return int(metadata.get("timestamp_checkpoint_ms") or 0)
+
+
+def _gmail_history_cursor(state: dict[str, Any]) -> str:
+    metadata = state.get("metadata") or {}
+    if state.get("checkpoint_type") == GMAIL_HISTORY_CURSOR:
+        return str(state.get("checkpoint_value") or "")
+    return str(metadata.get("history_id") or "")
+
+
+def _gmail_bootstrap_metadata(
+    *,
+    page_token: str | None,
+    count: int,
+    newest_seen: int,
+) -> dict[str, object]:
+    return {
+        "bootstrap_page_token": page_token or "",
+        "messages_processed": count,
+        "cursor_mode": "bootstrap",
+        "timestamp_checkpoint_ms": str(newest_seen),
+    }
+
+
+def _gmail_timestamp_metadata(
+    *,
+    count: int,
+    checkpoint: int,
+    fallback_reason: str,
+) -> dict[str, object]:
+    return {
+        "messages_processed": count,
+        "cursor_mode": "timestamp_fallback",
+        "fallback_reason": fallback_reason,
+        "timestamp_checkpoint_ms": str(checkpoint),
+    }
+
+
+def _gmail_history_metadata(
+    *,
+    count: int,
+    history_id: str,
+    timestamp_checkpoint: int,
+) -> dict[str, object]:
+    return {
+        "messages_processed": count,
+        "cursor_mode": "history",
+        "history_id": history_id,
+        "timestamp_checkpoint_ms": str(timestamp_checkpoint),
+    }
+
+
+def _history_message_ids(history_entries: list[dict[str, Any]]) -> list[str]:
+    seen: set[str] = set()
+    message_ids: list[str] = []
+    for entry in history_entries:
+        for key in ("messagesAdded", "labelsAdded", "labelsRemoved"):
+            for change in entry.get(key, []):
+                message = change.get("message") or {}
+                message_id = str(message.get("id") or "")
+                if message_id and message_id not in seen:
+                    seen.add(message_id)
+                    message_ids.append(message_id)
+    return message_ids
+
+
 def sync_gmail_bootstrap(store: MessageIndexStore) -> dict[str, int]:
     gmail_services, _, _, _, _, _ = google_auth_all()
     stats: dict[str, int] = {}
-    for account, service in gmail_services.items():
+    for account, service_obj in gmail_services.items():
+        service: Any = service_obj
         state = store.get_sync_state("gmail", account) or {}
         metadata = state.get("metadata") or {}
-        newest_seen = int(state.get("checkpoint_value", "0") or 0)
+        newest_seen = _gmail_timestamp_checkpoint(state)
         page_token = str(metadata.get("bootstrap_page_token") or "") or None
         count = 0
         store.mark_sync_started(
             source="gmail",
             account=account,
-            checkpoint_type="internalDateMs",
+            checkpoint_type=GMAIL_TIMESTAMP_CURSOR,
             checkpoint_value=str(newest_seen),
-            metadata={"bootstrap_page_token": page_token or "", "messages_processed": count},
+            metadata=_gmail_bootstrap_metadata(
+                page_token=page_token,
+                count=count,
+                newest_seen=newest_seen,
+            ),
         )
         try:
             while True:
@@ -130,96 +223,228 @@ def sync_gmail_bootstrap(store: MessageIndexStore) -> dict[str, int]:
                 store.update_sync_progress(
                     source="gmail",
                     account=account,
-                    checkpoint_type="internalDateMs",
+                    checkpoint_type=GMAIL_TIMESTAMP_CURSOR,
                     checkpoint_value=str(newest_seen),
-                    metadata={
-                        "bootstrap_page_token": page_token or "",
-                        "messages_processed": count,
-                    },
+                    metadata=_gmail_bootstrap_metadata(
+                        page_token=page_token,
+                        count=count,
+                        newest_seen=newest_seen,
+                    ),
                 )
                 if not page_token:
                     break
         except Exception as exc:
             store.record_sync_error(source="gmail", account=account, error=str(exc))
             raise
+        history_id = _fetch_gmail_profile_history_id(service)
+        checkpoint_type = GMAIL_HISTORY_CURSOR if history_id else GMAIL_TIMESTAMP_CURSOR
+        checkpoint_value = history_id or str(newest_seen)
+        final_metadata = (
+            _gmail_history_metadata(
+                count=count,
+                history_id=history_id,
+                timestamp_checkpoint=newest_seen,
+            )
+            if history_id
+            else {
+                **_gmail_timestamp_metadata(
+                    count=count,
+                    checkpoint=newest_seen,
+                    fallback_reason="missing_history_cursor",
+                ),
+                "bootstrap_page_token": "",  # nosec B105
+            }
+        )
         store.set_sync_state(
             source="gmail",
             account=account,
-            checkpoint_type="internalDateMs",
-            checkpoint_value=str(newest_seen),
+            checkpoint_type=checkpoint_type,
+            checkpoint_value=checkpoint_value,
             full_sync=True,
             status="idle",
-            metadata={"bootstrap_page_token": "", "messages_processed": count},  # nosec B105
+            metadata=final_metadata,
         )
         stats[account] = count
     return stats
 
 
-def sync_gmail_incremental(store: MessageIndexStore) -> dict[str, int]:
-    gmail_services, _, _, _, _, _ = google_auth_all()
-    stats: dict[str, int] = {}
-    for account, service in gmail_services.items():
-        state = store.get_sync_state("gmail", account) or {}
-        checkpoint = int(state.get("checkpoint_value", "0") or 0)
-        page_token: str | None = None
-        newest_seen = checkpoint
+def _sync_gmail_incremental_history(
+    store: MessageIndexStore,
+    *,
+    account: str,
+    service: Any,
+    history_api: Any,
+    history_id: str,
+    timestamp_checkpoint: int,
+) -> int:
+    page_token: str | None = None
+    latest_history_id = history_id
+    changed_message_ids: list[str] = []
+    store.mark_sync_started(
+        source="gmail",
+        account=account,
+        checkpoint_type=GMAIL_HISTORY_CURSOR,
+        checkpoint_value=history_id,
+        metadata=_gmail_history_metadata(
+            count=0,
+            history_id=history_id,
+            timestamp_checkpoint=timestamp_checkpoint,
+        ),
+    )
+    try:
+        while True:
+            response = history_api.list(
+                userId="me",
+                startHistoryId=history_id,
+                pageToken=page_token,
+                historyTypes=["messageAdded", "labelAdded", "labelRemoved"],
+            ).execute()
+            latest_history_id = str(response.get("historyId") or latest_history_id)
+            changed_message_ids.extend(_history_message_ids(response.get("history", [])))
+            page_token = response.get("nextPageToken")
+            if not page_token:
+                break
+
         count = 0
-        stop = False
-        store.mark_sync_started(
-            source="gmail",
-            account=account,
-            checkpoint_type="internalDateMs",
-            checkpoint_value=str(checkpoint),
-            metadata={"messages_processed": 0},
-        )
-        try:
-            while not stop:
-                response = (
-                    service.users()
-                    .messages()
-                    .list(
-                        userId="me",
-                        maxResults=GMAIL_INCREMENTAL_BATCH_SIZE,
-                        includeSpamTrash=False,
-                        pageToken=page_token,
-                    )
-                    .execute()
-                )
-                messages = response.get("messages", [])
-                if not messages:
-                    break
-                for stub in messages:
-                    full_message = _fetch_gmail_full_message(service, stub["id"])
-                    internal_date = int(full_message.get("internalDate", 0) or 0)
-                    if internal_date <= checkpoint:
-                        stop = True
-                        break
-                    store.upsert_item(_gmail_item(account, full_message))
-                    newest_seen = max(newest_seen, internal_date)
-                    count += 1
-                store.update_sync_progress(
-                    source="gmail",
-                    account=account,
-                    checkpoint_type="internalDateMs",
-                    checkpoint_value=str(newest_seen),
-                    metadata={"messages_processed": count},
-                )
-                page_token = response.get("nextPageToken")
-                if not page_token:
-                    break
-        except Exception as exc:
-            store.record_sync_error(source="gmail", account=account, error=str(exc))
-            raise
+        seen: set[str] = set()
+        for message_id in changed_message_ids:
+            if message_id in seen:
+                continue
+            seen.add(message_id)
+            full_message = _fetch_gmail_full_message(service, message_id)
+            timestamp_checkpoint = max(
+                timestamp_checkpoint, int(full_message.get("internalDate", 0) or 0)
+            )
+            store.upsert_item(_gmail_item(account, full_message))
+            count += 1
+
         store.set_sync_state(
             source="gmail",
             account=account,
-            checkpoint_type="internalDateMs",
-            checkpoint_value=str(newest_seen),
+            checkpoint_type=GMAIL_HISTORY_CURSOR,
+            checkpoint_value=latest_history_id,
             full_sync=False,
             status="idle",
-            metadata={"messages_processed": count},
+            metadata=_gmail_history_metadata(
+                count=count,
+                history_id=latest_history_id,
+                timestamp_checkpoint=timestamp_checkpoint,
+            ),
         )
-        stats[account] = count
+        return count
+    except Exception as exc:
+        store.record_sync_error(source="gmail", account=account, error=str(exc))
+        raise
+
+
+def _sync_gmail_incremental_timestamp(
+    store: MessageIndexStore,
+    *,
+    account: str,
+    service: Any,
+    checkpoint: int,
+    fallback_reason: str,
+) -> int:
+    page_token: str | None = None
+    newest_seen = checkpoint
+    count = 0
+    stop = False
+    store.mark_sync_started(
+        source="gmail",
+        account=account,
+        checkpoint_type=GMAIL_TIMESTAMP_CURSOR,
+        checkpoint_value=str(checkpoint),
+        metadata=_gmail_timestamp_metadata(
+            count=0,
+            checkpoint=checkpoint,
+            fallback_reason=fallback_reason,
+        ),
+    )
+    try:
+        while not stop:
+            response = (
+                service.users()
+                .messages()
+                .list(
+                    userId="me",
+                    maxResults=GMAIL_INCREMENTAL_BATCH_SIZE,
+                    includeSpamTrash=False,
+                    pageToken=page_token,
+                )
+                .execute()
+            )
+            messages = response.get("messages", [])
+            if not messages:
+                break
+            for stub in messages:
+                full_message = _fetch_gmail_full_message(service, stub["id"])
+                internal_date = int(full_message.get("internalDate", 0) or 0)
+                if internal_date <= checkpoint:
+                    stop = True
+                    break
+                store.upsert_item(_gmail_item(account, full_message))
+                newest_seen = max(newest_seen, internal_date)
+                count += 1
+            store.update_sync_progress(
+                source="gmail",
+                account=account,
+                checkpoint_type=GMAIL_TIMESTAMP_CURSOR,
+                checkpoint_value=str(newest_seen),
+                metadata=_gmail_timestamp_metadata(
+                    count=count,
+                    checkpoint=newest_seen,
+                    fallback_reason=fallback_reason,
+                ),
+            )
+            page_token = response.get("nextPageToken")
+            if not page_token:
+                break
+    except Exception as exc:
+        store.record_sync_error(source="gmail", account=account, error=str(exc))
+        raise
+    store.set_sync_state(
+        source="gmail",
+        account=account,
+        checkpoint_type=GMAIL_TIMESTAMP_CURSOR,
+        checkpoint_value=str(newest_seen),
+        full_sync=False,
+        status="idle",
+        metadata=_gmail_timestamp_metadata(
+            count=count,
+            checkpoint=newest_seen,
+            fallback_reason=fallback_reason,
+        ),
+    )
+    return count
+
+
+def sync_gmail_incremental(store: MessageIndexStore) -> dict[str, int]:
+    gmail_services, _, _, _, _, _ = google_auth_all()
+    stats: dict[str, int] = {}
+    for account, service_obj in gmail_services.items():
+        service: Any = service_obj
+        state = store.get_sync_state("gmail", account) or {}
+        timestamp_checkpoint = _gmail_timestamp_checkpoint(state)
+        history_id = _gmail_history_cursor(state)
+        history_api = _gmail_history_api(service) if history_id else None
+        if history_id and history_api is not None:
+            stats[account] = _sync_gmail_incremental_history(
+                store,
+                account=account,
+                service=service,
+                history_api=history_api,
+                history_id=history_id,
+                timestamp_checkpoint=timestamp_checkpoint,
+            )
+        else:
+            fallback_reason = "history_api_unavailable" if history_id else "missing_history_cursor"
+            stats[account] = _sync_gmail_incremental_timestamp(
+                store,
+                account=account,
+                service=service,
+                checkpoint=timestamp_checkpoint,
+                fallback_reason=fallback_reason,
+            )
     return stats
 
 

--- a/tests/test_message_sync.py
+++ b/tests/test_message_sync.py
@@ -29,29 +29,68 @@ class _FakeMessagesApi:
         return _FakeRequest(self._full_messages[id])
 
 
+class _FakeHistoryApi:
+    def __init__(self, history_payloads):
+        self._history_payloads = history_payloads
+
+    def list(self, *, pageToken=None, **_kwargs):
+        key = pageToken or "__first__"
+        return _FakeRequest(self._history_payloads[key])
+
+
 class _FakeUsersApi:
-    def __init__(self, list_payloads, full_messages):
+    def __init__(
+        self, list_payloads, full_messages, *, profile_payload=None, history_payloads=None
+    ):
         self._messages_api = _FakeMessagesApi(list_payloads, full_messages)
+        self._profile_payload = profile_payload
+        self._history_payloads = history_payloads
 
     def messages(self):
         return self._messages_api
 
+    def getProfile(self, **_kwargs):
+        return _FakeRequest(self._profile_payload or {})
+
+    def history(self):
+        if self._history_payloads is None:
+            raise AttributeError("history unavailable")
+        return _FakeHistoryApi(self._history_payloads)
+
 
 class _FakeGmailService:
-    def __init__(self, list_payloads, full_messages):
-        self._users_api = _FakeUsersApi(list_payloads, full_messages)
+    def __init__(
+        self,
+        list_payloads,
+        full_messages,
+        *,
+        profile_payload=None,
+        history_payloads=None,
+    ):
+        self._users_api = _FakeUsersApi(
+            list_payloads,
+            full_messages,
+            profile_payload=profile_payload,
+            history_payloads=history_payloads,
+        )
 
     def users(self):
         return self._users_api
 
 
-def _gmail_message(message_id: str, internal_date: int, *, thread_id: str | None = None):
+def _gmail_message(
+    message_id: str,
+    internal_date: int,
+    *,
+    thread_id: str | None = None,
+    labels: list[str] | None = None,
+):
     return {
         "id": message_id,
         "threadId": thread_id or message_id,
         "internalDate": str(internal_date),
         "snippet": f"snippet-{message_id}",
-        "labelIds": ["INBOX"],
+        "labelIds": labels or ["INBOX"],
         "payload": {
             "headers": [
                 {"name": "From", "value": "Sender <sender@example.com>"},
@@ -123,6 +162,37 @@ def test_sync_gmail_bootstrap_resumes_from_saved_page_token(tmp_path, monkeypatc
     with sqlite3.connect(store.db_path) as conn:
         row_count = conn.execute("SELECT COUNT(*) FROM items").fetchone()[0]
     assert row_count == 3
+
+
+def test_sync_gmail_bootstrap_records_history_cursor(tmp_path, monkeypatch):
+    store = MessageIndexStore(tmp_path / "index.sqlite3")
+    service = _FakeGmailService(
+        list_payloads={
+            "__first__": {
+                "messages": [{"id": "m1"}],
+            },
+        },
+        full_messages={
+            "m1": _gmail_message("m1", 300),
+        },
+        profile_payload={"historyId": "9000"},
+    )
+    monkeypatch.setattr(
+        message_sync,
+        "google_auth_all",
+        lambda: ({"acct@example.com": service}, {}, {}, {}, {}, {}),
+    )
+
+    stats = message_sync.sync_gmail_bootstrap(store)
+    assert stats == {"acct@example.com": 1}
+
+    state = store.get_sync_state("gmail", "acct@example.com")
+    assert state is not None
+    assert state["checkpoint_type"] == message_sync.GMAIL_HISTORY_CURSOR
+    assert state["checkpoint_value"] == "9000"
+    assert state["metadata"]["cursor_mode"] == "history"
+    assert state["metadata"]["history_id"] == "9000"
+    assert state["metadata"]["timestamp_checkpoint_ms"] == "300"
 
 
 def test_sync_gmail_bootstrap_does_not_double_count_or_rewrite_items_on_resume(
@@ -200,6 +270,112 @@ def test_sync_gmail_bootstrap_does_not_double_count_or_rewrite_items_on_resume(
         ).fetchone()[0]
     assert finished_count == 3
     assert resumed_m2_ingested_at == existing_m2_ingested_at
+
+
+def test_sync_gmail_incremental_uses_history_for_new_and_changed_messages(tmp_path, monkeypatch):
+    store = MessageIndexStore(tmp_path / "index.sqlite3")
+    store.upsert_item(
+        message_sync._gmail_item(
+            "acct@example.com",
+            _gmail_message("m1", 100, labels=["INBOX", "UNREAD"]),
+        )
+    )
+    store.set_sync_state(
+        source="gmail",
+        account="acct@example.com",
+        checkpoint_type=message_sync.GMAIL_HISTORY_CURSOR,
+        checkpoint_value="9000",
+        status="idle",
+        metadata={
+            "cursor_mode": "history",
+            "history_id": "9000",
+            "timestamp_checkpoint_ms": "100",
+        },
+    )
+    service = _FakeGmailService(
+        list_payloads={},
+        full_messages={
+            "m1": _gmail_message("m1", 100, labels=["INBOX"]),
+            "m2": _gmail_message("m2", 200, labels=["INBOX", "UNREAD"]),
+        },
+        history_payloads={
+            "__first__": {
+                "historyId": "9001",
+                "history": [
+                    {
+                        "labelsRemoved": [{"message": {"id": "m1"}, "labelIds": ["UNREAD"]}],
+                        "messagesAdded": [{"message": {"id": "m2"}}],
+                    }
+                ],
+            }
+        },
+    )
+    monkeypatch.setattr(
+        message_sync,
+        "google_auth_all",
+        lambda: ({"acct@example.com": service}, {}, {}, {}, {}, {}),
+    )
+
+    stats = message_sync.sync_gmail_incremental(store)
+    assert stats == {"acct@example.com": 2}
+
+    state = store.get_sync_state("gmail", "acct@example.com")
+    assert state is not None
+    assert state["checkpoint_type"] == message_sync.GMAIL_HISTORY_CURSOR
+    assert state["checkpoint_value"] == "9001"
+    assert state["metadata"]["cursor_mode"] == "history"
+    assert state["metadata"]["timestamp_checkpoint_ms"] == "200"
+
+    with sqlite3.connect(store.db_path) as conn:
+        conn.row_factory = sqlite3.Row
+        existing = conn.execute(
+            "SELECT is_read, labels_json FROM items WHERE external_id = 'm1'"
+        ).fetchone()
+        inserted = conn.execute(
+            "SELECT is_read, labels_json FROM items WHERE external_id = 'm2'"
+        ).fetchone()
+    assert existing["is_read"] == 1
+    assert '"UNREAD"' not in existing["labels_json"]
+    assert inserted["is_read"] == 0
+
+
+def test_sync_gmail_incremental_falls_back_without_history_cursor(tmp_path, monkeypatch):
+    store = MessageIndexStore(tmp_path / "index.sqlite3")
+    store.set_sync_state(
+        source="gmail",
+        account="acct@example.com",
+        checkpoint_type=message_sync.GMAIL_TIMESTAMP_CURSOR,
+        checkpoint_value="100",
+        status="idle",
+        metadata={},
+    )
+    service = _FakeGmailService(
+        list_payloads={
+            "__first__": {
+                "messages": [{"id": "m2"}, {"id": "m1"}],
+            },
+        },
+        full_messages={
+            "m2": _gmail_message("m2", 200),
+            "m1": _gmail_message("m1", 100),
+        },
+    )
+    monkeypatch.setattr(
+        message_sync,
+        "google_auth_all",
+        lambda: ({"acct@example.com": service}, {}, {}, {}, {}, {}),
+    )
+
+    stats = message_sync.sync_gmail_incremental(store)
+    assert stats == {"acct@example.com": 1}
+
+    state = store.get_sync_state("gmail", "acct@example.com")
+    assert state is not None
+    assert state["checkpoint_type"] == message_sync.GMAIL_TIMESTAMP_CURSOR
+    assert state["checkpoint_value"] == "200"
+    assert state["metadata"]["cursor_mode"] == "timestamp_fallback"
+    assert state["metadata"]["fallback_reason"] == "missing_history_cursor"
+    assert state["metadata"]["timestamp_checkpoint_ms"] == "200"
 
 
 def test_sync_imessage_incremental_advances_checkpoint_for_skipped_rows(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- Store Gmail profile historyId after successful bootstrap when available
- Use Gmail history deltas for incremental new-message and label/read-state changes
- Keep timestamp incremental fallback with explicit sync metadata when no history cursor/API is available

## Validation
- INBOX_TEST_MODE=1 uv run pytest tests/test_message_sync.py tests/test_message_index_store.py -q
- uv run ruff check message_sync.py message_index_store.py tests/test_message_sync.py
- uv run ruff format --check message_sync.py message_index_store.py tests/test_message_sync.py
- uv run pyright message_sync.py tests/test_message_sync.py