### PR TITLE
SYM-118 Scope thread rebuilds after sync

### DIFF
--- a/message_sync.py
+++ b/message_sync.py
@@ -16,6 +16,7 @@ GMAIL_HISTORY_CURSOR = "gmailHistoryId"
 GMAIL_TIMESTAMP_CURSOR = "internalDateMs"
 IMESSAGE_PROGRESS_EVERY = 250
 _ATTACHMENT_TEXT = "(attachment)"
+SyncScope = tuple[str, str]
 
 
 def _iso_from_ms(value: int | str | None) -> str:
@@ -581,21 +582,48 @@ def sync_imessage_incremental(store: MessageIndexStore) -> dict[str, int]:
     return {"local": count}
 
 
+def _changed_scopes(source: str, stats: dict[str, int]) -> set[SyncScope]:
+    return {(source, account) for account, count in stats.items() if count > 0}
+
+
+def rebuild_changed_threads(
+    store: MessageIndexStore, scopes: set[SyncScope]
+) -> dict[SyncScope, int]:
+    rebuilt: dict[SyncScope, int] = {}
+    for source, account in sorted(scopes):
+        rebuilt[(source, account)] = store.rebuild_threads(source=source, account=account)
+    return rebuilt
+
+
+def rebuild_all_threads(store: MessageIndexStore) -> int:
+    return store.rebuild_threads()
+
+
 def bootstrap(store: MessageIndexStore) -> dict[str, dict[str, int]]:
+    gmail_stats = sync_gmail_bootstrap(store)
+    imessage_stats = sync_imessage_bootstrap(store)
     result = {
-        "gmail": sync_gmail_bootstrap(store),
-        "imessage": sync_imessage_bootstrap(store),
+        "gmail": gmail_stats,
+        "imessage": imessage_stats,
     }
-    store.rebuild_threads()
+    rebuild_changed_threads(
+        store,
+        _changed_scopes("gmail", gmail_stats) | _changed_scopes("imessage", imessage_stats),
+    )
     return result
 
 
 def incremental(store: MessageIndexStore) -> dict[str, dict[str, int]]:
+    gmail_stats = sync_gmail_incremental(store)
+    imessage_stats = sync_imessage_incremental(store)
     result = {
-        "gmail": sync_gmail_incremental(store),
-        "imessage": sync_imessage_incremental(store),
+        "gmail": gmail_stats,
+        "imessage": imessage_stats,
     }
-    store.rebuild_threads()
+    rebuild_changed_threads(
+        store,
+        _changed_scopes("gmail", gmail_stats) | _changed_scopes("imessage", imessage_stats),
+    )
     return result
 
 
@@ -611,7 +639,7 @@ def main() -> None:
     parser = argparse.ArgumentParser(
         description="Materialize raw inbox sources into a local index."
     )
-    parser.add_argument("mode", choices=["bootstrap", "incremental", "summary"])
+    parser.add_argument("mode", choices=["bootstrap", "incremental", "rebuild", "summary"])
     parser.add_argument("--db", default="", help="Override index database path.")
     parser.add_argument("--limit", type=int, default=20, help="Summary row limit.")
     args = parser.parse_args()
@@ -621,6 +649,8 @@ def main() -> None:
         print(bootstrap(store))
     elif args.mode == "incremental":
         print(incremental(store))
+    elif args.mode == "rebuild":
+        print({"threads": rebuild_all_threads(store)})
     else:
         print_summary(store, args.limit)
 

--- a/tests/test_message_sync.py
+++ b/tests/test_message_sync.py
@@ -3,7 +3,7 @@ import sqlite3
 import pytest
 
 import message_sync
-from message_index_store import MessageIndexStore
+from message_index_store import IndexedItem, MessageIndexStore
 
 
 class _FakeRequest:
@@ -101,6 +101,43 @@ def _gmail_message(
             "body": {"data": ""},
         },
     }
+
+
+def _indexed_item(
+    *,
+    source: str,
+    account: str,
+    external_id: str,
+    thread_id: str,
+    created_at: str,
+    subject: str,
+) -> IndexedItem:
+    return IndexedItem(
+        source=source,
+        account=account,
+        external_id=external_id,
+        thread_id=thread_id,
+        kind="email" if source == "gmail" else "imessage",
+        created_at=created_at,
+        updated_at=created_at,
+        ingested_at=created_at,
+        sender="Sender",
+        recipients_json="[]",
+        subject=subject,
+        snippet=subject,
+        body_text=subject,
+        body_hash=f"hash-{external_id}",
+        labels_json="[]",
+        raw_pointer=f"{source}:{account}:{external_id}",
+        is_deleted=0,
+        is_read=1,
+    )
+
+
+def _thread_rows(store: MessageIndexStore) -> dict[tuple[str, str, str], sqlite3.Row]:
+    with store._connect() as conn:
+        rows = conn.execute("SELECT * FROM threads").fetchall()
+    return {(str(row["source"]), str(row["account"]), str(row["thread_id"])): row for row in rows}
 
 
 def test_sync_gmail_bootstrap_resumes_from_saved_page_token(tmp_path, monkeypatch):
@@ -457,3 +494,156 @@ def test_sync_imessage_bootstrap_advances_checkpoint_for_skipped_rows(tmp_path, 
     state = store.get_sync_state("imessage", "local")
     assert state is not None
     assert state["checkpoint_value"] == "2"
+
+
+def test_incremental_rebuilds_only_changed_gmail_account(tmp_path, monkeypatch):
+    store = MessageIndexStore(tmp_path / "index.sqlite3")
+    store.upsert_item(
+        _indexed_item(
+            source="gmail",
+            account="acct@example.com",
+            external_id="gmail-a-1",
+            thread_id="gmail-a-thread",
+            created_at="2026-04-18T00:00:00+00:00",
+            subject="Old Gmail A",
+        )
+    )
+    store.upsert_item(
+        _indexed_item(
+            source="gmail",
+            account="other@example.com",
+            external_id="gmail-b-1",
+            thread_id="gmail-b-thread",
+            created_at="2026-04-18T00:00:00+00:00",
+            subject="Old Gmail B",
+        )
+    )
+    store.upsert_item(
+        _indexed_item(
+            source="imessage",
+            account="local",
+            external_id="imsg-1",
+            thread_id="imsg-thread",
+            created_at="2026-04-18T00:00:00+00:00",
+            subject="Old iMessage",
+        )
+    )
+    store.rebuild_threads()
+    with store._connect() as conn:
+        conn.execute("UPDATE threads SET updated_at = 'sentinel'")
+
+    def fake_gmail_incremental(sync_store: MessageIndexStore) -> dict[str, int]:
+        sync_store.upsert_item(
+            _indexed_item(
+                source="gmail",
+                account="acct@example.com",
+                external_id="gmail-a-2",
+                thread_id="gmail-a-thread",
+                created_at="2026-04-18T01:00:00+00:00",
+                subject="New Gmail A",
+            )
+        )
+        return {"acct@example.com": 1, "other@example.com": 0}
+
+    monkeypatch.setattr(message_sync, "sync_gmail_incremental", fake_gmail_incremental)
+    monkeypatch.setattr(message_sync, "sync_imessage_incremental", lambda _store: {"local": 0})
+
+    result = message_sync.incremental(store)
+
+    assert result == {
+        "gmail": {"acct@example.com": 1, "other@example.com": 0},
+        "imessage": {"local": 0},
+    }
+    rows = _thread_rows(store)
+    assert len(rows) == 3
+    changed = rows[("gmail", "acct@example.com", "gmail-a-thread")]
+    untouched_gmail = rows[("gmail", "other@example.com", "gmail-b-thread")]
+    untouched_imessage = rows[("imessage", "local", "imsg-thread")]
+    assert changed["latest_external_id"] == "gmail-a-2"
+    assert changed["latest_subject"] == "New Gmail A"
+    assert changed["updated_at"] != "sentinel"
+    assert untouched_gmail["latest_external_id"] == "gmail-b-1"
+    assert untouched_gmail["updated_at"] == "sentinel"
+    assert untouched_imessage["latest_external_id"] == "imsg-1"
+    assert untouched_imessage["updated_at"] == "sentinel"
+
+
+def test_incremental_rebuilds_only_changed_imessage_scope(tmp_path, monkeypatch):
+    store = MessageIndexStore(tmp_path / "index.sqlite3")
+    store.upsert_item(
+        _indexed_item(
+            source="gmail",
+            account="acct@example.com",
+            external_id="gmail-1",
+            thread_id="gmail-thread",
+            created_at="2026-04-18T00:00:00+00:00",
+            subject="Old Gmail",
+        )
+    )
+    store.upsert_item(
+        _indexed_item(
+            source="imessage",
+            account="local",
+            external_id="imsg-1",
+            thread_id="imsg-thread",
+            created_at="2026-04-18T00:00:00+00:00",
+            subject="Old iMessage",
+        )
+    )
+    store.rebuild_threads()
+    with store._connect() as conn:
+        conn.execute("UPDATE threads SET updated_at = 'sentinel'")
+
+    def fake_imessage_incremental(sync_store: MessageIndexStore) -> dict[str, int]:
+        sync_store.upsert_item(
+            _indexed_item(
+                source="imessage",
+                account="local",
+                external_id="imsg-2",
+                thread_id="imsg-thread",
+                created_at="2026-04-18T01:00:00+00:00",
+                subject="New iMessage",
+            )
+        )
+        return {"local": 1}
+
+    monkeypatch.setattr(
+        message_sync, "sync_gmail_incremental", lambda _store: {"acct@example.com": 0}
+    )
+    monkeypatch.setattr(message_sync, "sync_imessage_incremental", fake_imessage_incremental)
+
+    result = message_sync.incremental(store)
+
+    assert result == {
+        "gmail": {"acct@example.com": 0},
+        "imessage": {"local": 1},
+    }
+    rows = _thread_rows(store)
+    assert len(rows) == 2
+    untouched_gmail = rows[("gmail", "acct@example.com", "gmail-thread")]
+    changed_imessage = rows[("imessage", "local", "imsg-thread")]
+    assert untouched_gmail["latest_external_id"] == "gmail-1"
+    assert untouched_gmail["updated_at"] == "sentinel"
+    assert changed_imessage["latest_external_id"] == "imsg-2"
+    assert changed_imessage["latest_subject"] == "New iMessage"
+    assert changed_imessage["updated_at"] != "sentinel"
+
+
+def test_rebuild_all_threads_preserves_global_repair_path(tmp_path):
+    store = MessageIndexStore(tmp_path / "index.sqlite3")
+    store.upsert_item(
+        _indexed_item(
+            source="gmail",
+            account="acct@example.com",
+            external_id="gmail-1",
+            thread_id="gmail-thread",
+            created_at="2026-04-18T00:00:00+00:00",
+            subject="Gmail",
+        )
+    )
+
+    rebuilt = message_sync.rebuild_all_threads(store)
+
+    assert rebuilt == 1
+    rows = _thread_rows(store)
+    assert list(rows) == [("gmail", "acct@example.com", "gmail-thread")]


### PR DESCRIPTION
## Summary
- Track changed sync scopes from Gmail and iMessage sync stats
- Rebuild only changed `(source, account)` thread scopes after bootstrap/incremental sync
- Add an explicit `rebuild` CLI path for full manual thread repair
- Add regression tests proving unrelated source/account threads are not rewritten

## Validation
- `INBOX_TEST_MODE=1 uv run pytest tests/test_message_sync.py tests/test_message_index_store.py -q`
- `uv run ruff check message_sync.py message_index_store.py tests/test_message_sync.py`
- `uv run ruff format --check message_sync.py message_index_store.py tests/test_message_sync.py`
- `uv run pyright message_sync.py tests/test_message_sync.py`