### PR TITLE
SYM-119 Use sender stats in thread actionability

### DIFF
--- a/message_index_store.py
+++ b/message_index_store.py
@@ -7,7 +7,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
-from thread_classifier import classify_thread
+from thread_classifier import classify_thread, sender_freq_score
 
 BASE_DIR = Path(__file__).parent
 DEFAULT_INDEX_DB = BASE_DIR / ".inbox_index.sqlite3"
@@ -27,6 +27,18 @@ def _json_loads(value: str | None) -> object:
 
 def _coalesce_str(value: object | None) -> str:
     return "" if value is None else str(value)
+
+
+def _sender_key(sender: object | None) -> str:
+    value = _coalesce_str(sender).strip()
+    return "" if value == "Me" else value.lower()
+
+
+@dataclass
+class SenderStat:
+    thread_count: int = 0
+    reply_count: int = 0
+    last_seen_at: str = ""
 
 
 @dataclass
@@ -330,7 +342,7 @@ class MessageIndexStore:
                 (source, account, error),
             )
 
-    def get_sync_state(self, source: str, account: str) -> dict[str, str] | None:
+    def get_sync_state(self, source: str, account: str) -> dict[str, Any] | None:
         with self._connect() as conn:
             row = conn.execute(
                 "SELECT * FROM sync_state WHERE source = ? AND account = ?",
@@ -354,6 +366,44 @@ class MessageIndexStore:
         data["metadata"] = _json_loads(str(data.get("metadata_json") or "{}"))
         return data
 
+    def _refresh_sender_stats(
+        self, conn: sqlite3.Connection, rows: list[sqlite3.Row]
+    ) -> dict[str, SenderStat]:
+        grouped: dict[tuple[str, str, str], list[sqlite3.Row]] = {}
+        for row in rows:
+            key = (str(row["source"]), str(row["account"]), str(row["thread_id"]))
+            grouped.setdefault(key, []).append(row)
+
+        stats: dict[str, SenderStat] = {}
+        for items in grouped.values():
+            has_reply = any(str(item["sender"]) == "Me" for item in items)
+            senders = {_sender_key(item["sender"]) for item in items}
+            for sender in sorted(sender for sender in senders if sender):
+                sender_items = [item for item in items if _sender_key(item["sender"]) == sender]
+                latest_seen = max(str(item["created_at"]) for item in sender_items)
+                row = stats.setdefault(sender, SenderStat())
+                row.thread_count += 1
+                row.reply_count += int(has_reply)
+                row.last_seen_at = max(row.last_seen_at, latest_seen)
+
+        conn.execute("DELETE FROM sender_stats")
+        conn.executemany(
+            """
+            INSERT INTO sender_stats (email, thread_count, reply_count, last_seen_at)
+            VALUES (:email, :thread_count, :reply_count, :last_seen_at)
+            """,
+            [
+                {
+                    "email": sender,
+                    "thread_count": row.thread_count,
+                    "reply_count": row.reply_count,
+                    "last_seen_at": row.last_seen_at,
+                }
+                for sender, row in sorted(stats.items())
+            ],
+        )
+        return stats
+
     def rebuild_threads(self, *, source: str | None = None, account: str | None = None) -> int:
         predicates: list[str] = []
         params: list[object] = []
@@ -366,6 +416,11 @@ class MessageIndexStore:
         where_clause = f"WHERE {' AND '.join(predicates)}" if predicates else ""
 
         with self._connect() as conn:
+            all_rows = conn.execute(
+                "SELECT * FROM items ORDER BY source, account, thread_id, created_at, id"
+            ).fetchall()
+            sender_stats = self._refresh_sender_stats(conn, all_rows)
+
             _q = f"SELECT * FROM items {where_clause} ORDER BY source, account, thread_id, created_at, id"  # nosec B608
             rows = conn.execute(_q, params).fetchall()
 
@@ -385,7 +440,12 @@ class MessageIndexStore:
                     }
                 )
                 unread_count = sum(int(item["is_read"] == 0) for item in items)
-                classification = classify_thread(latest=latest)
+                sender_stat = sender_stats.get(_sender_key(latest["sender"]), SenderStat())
+                sender_freq = sender_freq_score(
+                    reply_count=sender_stat.reply_count,
+                    thread_count=sender_stat.thread_count,
+                )
+                classification = classify_thread(latest=latest, sender_freq=sender_freq)
                 conn.execute(
                     """
                     INSERT INTO threads (

--- a/tests/test_message_index_store.py
+++ b/tests/test_message_index_store.py
@@ -119,6 +119,153 @@ def test_rebuild_threads_classifies_otp_as_ignore(tmp_path):
     assert rows[0]["actionability"] == "ignore"
 
 
+def test_rebuild_threads_uses_frequent_human_sender_stats(tmp_path):
+    store = MessageIndexStore(tmp_path / "index.sqlite3")
+    sender = "5551234567"
+    store.upsert_item(
+        _item(
+            source="imessage",
+            account="local",
+            external_id="h1-me",
+            thread_id="history-1",
+            sender="Me",
+            body="Following up from earlier.",
+            created_at="2026-04-17T00:00:00+00:00",
+            is_read=1,
+        )
+    )
+    store.upsert_item(
+        _item(
+            source="imessage",
+            account="local",
+            external_id="h1-them",
+            thread_id="history-1",
+            sender=sender,
+            body="Thanks.",
+            created_at="2026-04-17T01:00:00+00:00",
+            is_read=1,
+        )
+    )
+    store.upsert_item(
+        _item(
+            source="imessage",
+            account="local",
+            external_id="h2-me",
+            thread_id="history-2",
+            sender="Me",
+            body="Can you send that over?",
+            created_at="2026-04-17T02:00:00+00:00",
+            is_read=1,
+        )
+    )
+    store.upsert_item(
+        _item(
+            source="imessage",
+            account="local",
+            external_id="h2-them",
+            thread_id="history-2",
+            sender=sender,
+            body="Will do.",
+            created_at="2026-04-17T03:00:00+00:00",
+            is_read=1,
+        )
+    )
+    store.upsert_item(
+        _item(
+            source="imessage",
+            account="local",
+            external_id="current",
+            thread_id="current-thread",
+            sender=sender,
+            body="Quick FYI for later.",
+            created_at="2026-04-18T00:00:00+00:00",
+            is_read=0,
+        )
+    )
+
+    store.rebuild_threads()
+
+    rows = store.list_threads(limit=10)
+    current = next(row for row in rows if row["thread_id"] == "current-thread")
+    human_score = current["human_score"]
+    assert isinstance(human_score, float)
+    assert human_score < 1.0
+    assert current["actionability"] == "reply"
+    assert current["needs_reply"] == 1
+    with store._connect() as conn:
+        stats = conn.execute("SELECT * FROM sender_stats WHERE email = ?", (sender,)).fetchone()
+    assert stats["thread_count"] == 3
+    assert stats["reply_count"] == 2
+
+
+def test_rebuild_threads_does_not_promote_high_volume_automated_sender(tmp_path):
+    store = MessageIndexStore(tmp_path / "index.sqlite3")
+    sender = "no-reply@example.com"
+    for index in range(12):
+        store.upsert_item(
+            _item(
+                source="gmail",
+                account="a@example.com",
+                external_id=f"auto-{index}",
+                thread_id=f"auto-thread-{index}",
+                sender=sender,
+                subject="Account update",
+                body="This is an automated notification.",
+                created_at=f"2026-04-18T00:{index:02d}:00+00:00",
+                is_read=0,
+            )
+        )
+
+    store.rebuild_threads()
+
+    rows = store.list_threads(limit=20)
+    assert rows
+    assert {row["noise_class"] for row in rows} == {"automated"}
+    assert {row["actionability"] for row in rows} == {"archive"}
+    assert {row["needs_reply"] for row in rows} == {0}
+    with store._connect() as conn:
+        stats = conn.execute("SELECT * FROM sender_stats WHERE email = ?", (sender,)).fetchone()
+    assert stats["thread_count"] == 12
+    assert stats["reply_count"] == 0
+
+
+def test_rebuild_threads_sender_stats_are_deterministic(tmp_path):
+    store = MessageIndexStore(tmp_path / "index.sqlite3")
+    store.upsert_item(
+        _item(
+            source="gmail",
+            account="a@example.com",
+            external_id="m1",
+            thread_id="t1",
+            sender="Me",
+            subject="Hello",
+            created_at="2026-04-18T00:00:00+00:00",
+            is_read=1,
+        )
+    )
+    store.upsert_item(
+        _item(
+            source="gmail",
+            account="a@example.com",
+            external_id="m2",
+            thread_id="t1",
+            sender="Alex",
+            subject="Re: Hello",
+            created_at="2026-04-18T01:00:00+00:00",
+            is_read=0,
+        )
+    )
+
+    store.rebuild_threads()
+    with store._connect() as conn:
+        first = [dict(row) for row in conn.execute("SELECT * FROM sender_stats").fetchall()]
+    store.rebuild_threads()
+    with store._connect() as conn:
+        second = [dict(row) for row in conn.execute("SELECT * FROM sender_stats").fetchall()]
+
+    assert second == first
+
+
 def test_sync_state_tracks_status_and_metadata(tmp_path):
     store = MessageIndexStore(tmp_path / "index.sqlite3")
 
@@ -153,6 +300,7 @@ def test_sync_state_tracks_status_and_metadata(tmp_path):
 
 def test_list_threads_supports_waiting_on_and_recent_views(tmp_path):
     import datetime
+
     now = datetime.datetime.now(datetime.UTC)
     t1 = now.isoformat()
     t2 = (now + datetime.timedelta(hours=1)).isoformat()
@@ -197,6 +345,7 @@ def test_list_threads_supports_waiting_on_and_recent_views(tmp_path):
 
     recent = store.list_threads(limit=10, newest_only=True, sort_mode="recent")
     assert [row["thread_id"] for row in recent] == ["track-thread", "reply-thread"]
+
 
 def test_upsert_item_is_idempotent(tmp_path):
     store = MessageIndexStore(tmp_path / "index.sqlite3")

--- a/thread_classifier.py
+++ b/thread_classifier.py
@@ -119,12 +119,12 @@ def _actionability(
 ) -> str:
     if noise_class in {"otp", "receipt", "survey"}:
         return "ignore"
-    if topic in {"security", "health-admin"} and urgency in {"high", "medium"}:
-        return "track"
-    if human_score >= 0.7 or sender_freq >= 0.5:
-        return "reply"
     if noise_class in {"newsletter", "automated"}:
         return "archive"
+    if topic in {"security", "health-admin"} and urgency in {"high", "medium"}:
+        return "track"
+    if human_score >= 1.0 or sender_freq >= 0.5:
+        return "reply"
     if topic == "opportunity":
         return "review"
     return "track"


### PR DESCRIPTION
## Summary
- Populate `sender_stats` deterministically during index thread rebuilds
- Feed sender frequency into thread classification so repeated correspondents can raise reply actionability
- Keep newsletter/automated senders archived before any sender-frequency promotion
- Add tests for frequent human senders, high-volume automated senders, and deterministic stats rebuilds

## Validation
- `INBOX_TEST_MODE=1 uv run pytest tests/test_message_index_store.py tests/test_thread_classifier.py -q`
- `uv run ruff check message_index_store.py thread_classifier.py tests/test_message_index_store.py tests/test_thread_classifier.py`
- `uv run ruff format --check message_index_store.py thread_classifier.py tests/test_message_index_store.py tests/test_thread_classifier.py`
- `uv run pyright message_index_store.py thread_classifier.py tests/test_message_index_store.py tests/test_thread_classifier.py`