### PR TITLE
Encode MCP registry path params

### DIFF
--- a/tests/test_tools_registry.py
+++ b/tests/test_tools_registry.py
@@ -1,3 +1,4 @@
+import asyncio
 import inspect
 
 from tools_registry import TOOLS, register_all
@@ -23,6 +24,12 @@ class DummyBackend:
             "params": params,
             "json": json,
         }
+
+
+def _handlers():
+    mcp = DummyMCP()
+    register_all(mcp, DummyBackend(), readonly_only=False)
+    return {fn.__name__: fn for fn in mcp._handlers}
 
 
 def test_create_sheet_and_append_rows_are_confirm_gated():
@@ -55,3 +62,54 @@ def test_confirm_param_is_added_only_for_confirm_tools():
 
     assert "confirm" in create_sheet_params
     assert "confirm" not in list_sheets_params
+
+
+def test_sheet_path_params_are_encoded_and_query_params_remain_query_values():
+    handlers = _handlers()
+
+    result = asyncio.run(
+        handlers["read_sheet_values"](
+            spreadsheet_id="sheet 1/abc",
+            range_="Tab One!A1:B/2",
+            account="acct/one two",
+        )
+    )
+
+    assert result["path"] == "/sheets/sheet%201%2Fabc/values/Tab%20One%21A1%3AB%2F2"
+    assert result["params"] == {"account": "acct/one two"}
+    assert result["json"] is None
+
+
+def test_chat_path_params_are_encoded_and_limit_remains_query_value():
+    handlers = _handlers()
+
+    result = asyncio.run(
+        handlers["get_message_thread"](
+            conv_id="chat/with spaces#frag?x=1",
+            limit=25,
+        )
+    )
+
+    assert result["path"] == "/messages/imessage/chat%2Fwith%20spaces%23frag%3Fx%3D1"
+    assert result["params"] == {"limit": 25}
+    assert result["json"] is None
+
+
+def test_body_params_are_not_url_encoded():
+    handlers = _handlers()
+
+    result = asyncio.run(
+        handlers["send_imessage"](
+            conv_id="chat/with spaces",
+            text="hello / raw",
+            confirm=True,
+        )
+    )
+
+    assert result["path"] == "/messages/send"
+    assert result["params"] is None
+    assert result["json"] == {
+        "source": "imessage",
+        "conv_id": "chat/with spaces",
+        "text": "hello / raw",
+    }

--- a/tools_registry.py
+++ b/tools_registry.py
@@ -17,6 +17,7 @@ import inspect
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import Any, Literal
+from urllib.parse import quote
 
 ParamLocation = Literal["query", "body", "path"]
 _EMPTY = inspect.Parameter.empty
@@ -42,6 +43,10 @@ class Tool:
     # Static extras baked into every call (e.g., `source="gmail"`).
     extra_query: dict[str, Any] = field(default_factory=dict)
     extra_body: dict[str, Any] = field(default_factory=dict)
+
+
+def _encode_path_value(value: Any) -> str:
+    return quote(str(value), safe="")
 
 
 def _build_handler(tool: Tool, backend: Any) -> Callable[..., Any]:
@@ -72,7 +77,7 @@ def _build_handler(tool: Tool, backend: Any) -> Callable[..., Any]:
                 "Retry with confirm=True after user approval."
             )
 
-        path_kwargs: dict[str, Any] = {}
+        path_kwargs: dict[str, str] = {}
         query: dict[str, Any] = dict(tool.extra_query)
         body: dict[str, Any] = dict(tool.extra_body)
 
@@ -81,7 +86,7 @@ def _build_handler(tool: Tool, backend: Any) -> Callable[..., Any]:
                 continue
             value = kwargs[p.name]
             if p.location == "path":
-                path_kwargs[p.name] = value
+                path_kwargs[p.name] = _encode_path_value(value)
             elif p.location == "query":
                 query[p.name] = value
             elif p.location == "body":


### PR DESCRIPTION
## Summary
- URL-encode only registry path parameter values before formatting backend paths
- Keep query and body parameters unencoded and routed through their existing request fields
- Add regression coverage for Sheets ranges, iMessage chat path params, and body params

## Validation
- INBOX_TEST_MODE=1 uv run pytest tests/test_tools_registry.py -q
- uv run ruff check tools_registry.py tests/test_tools_registry.py
- uv run ruff format --check tools_registry.py tests/test_tools_registry.py
- uv run pyright tools_registry.py tests/test_tools_registry.py