### PR TITLE
Fix TUI refresh snapshots

### DIFF
--- a/inbox.py
+++ b/inbox.py
@@ -12,6 +12,7 @@ import subprocess
 import threading
 import time
 import webbrowser
+from dataclasses import dataclass
 from datetime import date, datetime, timedelta
 
 import httpx
@@ -59,6 +60,38 @@ def _format_request_error(action: str, exc: Exception) -> str:
     if isinstance(exc, httpx.RequestError):
         return "Server unreachable — press Ctrl+R to retry"
     return f"{action} failed: {exc}"
+
+
+@dataclass(frozen=True)
+class AuxiliaryDataSnapshot:
+    events: list[dict]
+    notes: list[dict]
+    reminders: list[dict]
+    reminder_lists: list[dict]
+    github_data: list[dict]
+    now_threads: list[dict]
+    actionable_threads: list[dict]
+    waiting_threads: list[dict]
+    errors: list[str]
+
+
+@dataclass(frozen=True)
+class RefreshDataSnapshot:
+    conversations: list[dict]
+    events: list[dict]
+    notes: list[dict]
+    reminders: list[dict]
+    reminder_lists: list[dict]
+    github_data: list[dict]
+    now_threads: list[dict]
+    actionable_threads: list[dict]
+    waiting_threads: list[dict]
+    status: str | None
+
+
+@dataclass(frozen=True)
+class PollDataSnapshot(RefreshDataSnapshot):
+    changed: bool
 
 
 # ── UI Widgets ───────────────────────────────────────────────────────────────
@@ -1216,6 +1249,7 @@ class InboxApp(App):
         self._client_closed = False
         self._poll_had_error = False
         self._consecutive_errors = 0
+        self._sidebar_status_override: str | None = None
         # Calendar state
         self._calendar_date: date = date.today()
         self._calendar_view_mode: str = "day"  # "day" | "week" | "agenda"
@@ -1537,6 +1571,9 @@ class InboxApp(App):
             else:
                 compose_input.placeholder = "Reply… (Enter to send)"
 
+    def _update_sidebar_status(self, status: str) -> None:
+        self.query_one("#status", Static).update(self._sidebar_status_override or status)
+
     def _render_sidebar(self) -> None:
         lv = self.query_one("#contact-list", ListView)
         lv.clear()
@@ -1604,14 +1641,14 @@ class InboxApp(App):
             if n_accts > 1:
                 status += f"  [dim]{n_accts} accounts[/]"
             status += "  [dim]v: view · ←→: nav · g: go to date · e: edit[/]"
-            self.query_one("#status", Static).update(status)
+            self._update_sidebar_status(status)
             return
 
         if self._active_filter == "notes":
             for n in self.notes_data:
                 lv.append(NoteItem(n))
             status = f"[magenta]{len(self.notes_data)} notes[/]"
-            self.query_one("#status", Static).update(status)
+            self._update_sidebar_status(status)
             return
 
         if self._active_filter == "reminders":
@@ -1630,7 +1667,7 @@ class InboxApp(App):
                     rl.get("name", "") for rl in self.reminder_lists if rl.get("name")
                 )
                 status += f"  [dim]f: filter ({list_names})[/]"
-            self.query_one("#status", Static).update(status)
+            self._update_sidebar_status(status)
             return
 
         if self._active_filter == "github":
@@ -1644,7 +1681,7 @@ class InboxApp(App):
             if unread:
                 status += f"  [yellow]{unread} unread[/]"
             status += "  [dim]r: mark read · R: read all · o: open[/]"
-            self.query_one("#status", Static).update(status)
+            self._update_sidebar_status(status)
             return
 
         if self._active_filter == "drive":
@@ -1659,7 +1696,7 @@ class InboxApp(App):
             status += "  [dim]d: download · u: upload · n: new folder · x: delete[/]"
             if self._drive_folder_id:
                 status += "  [dim]Bksp: back[/]"
-            self.query_one("#status", Static).update(status)
+            self._update_sidebar_status(status)
             return
 
         if self._active_filter == "all":
@@ -1667,7 +1704,7 @@ class InboxApp(App):
                 lv.append(IndexedThreadItem(thread))
             status = f"[green]{len(self.now_threads)} indexed threads[/]"
             status += "  [dim]Now view · summaries first[/]"
-            self.query_one("#status", Static).update(status)
+            self._update_sidebar_status(status)
             return
 
         if self._active_filter == "actionable":
@@ -1675,7 +1712,7 @@ class InboxApp(App):
                 lv.append(IndexedThreadItem(thread))
             status = f"[green]{len(self.actionable_threads)} actionable threads[/]"
             status += "  [dim]reply / review / track[/]"
-            self.query_one("#status", Static).update(status)
+            self._update_sidebar_status(status)
             return
 
         if self._active_filter == "waiting":
@@ -1683,7 +1720,7 @@ class InboxApp(App):
                 lv.append(IndexedThreadItem(thread))
             status = f"[green]{len(self.waiting_threads)} waiting-on threads[/]"
             status += "  [dim]open loops being tracked[/]"
-            self.query_one("#status", Static).update(status)
+            self._update_sidebar_status(status)
             return
 
         shown = [c for c in self.conversations if c.get("source") == self._active_filter]
@@ -1725,7 +1762,7 @@ class InboxApp(App):
             )
         else:
             status += f"  [dim]{tab_label}[/]"
-        self.query_one("#status", Static).update(status)
+        self._update_sidebar_status(status)
 
     def _restore_sidebar_selection(self) -> None:
         """After _render_sidebar populates the ListView, restore the
@@ -2058,9 +2095,11 @@ class InboxApp(App):
         try:
             self.client.ensure_server()
         except RuntimeError as e:
+            status = f"[red]{e}[/]"
+            self._sidebar_status_override = status
             self.call_from_thread(
                 self.query_one("#status", Static).update,
-                f"[red]{e}[/]",
+                status,
             )
             # Start polling even if server boot fails — polling will keep
             # trying so the TUI recovers automatically when the server
@@ -2102,109 +2141,91 @@ class InboxApp(App):
     def _bg_poll(self) -> None:
         """Lightweight poll — updates data without disrupting UI if unchanged."""
         try:
-            (
-                convos,
-                events,
-                notes,
-                reminders,
-                reminder_lists,
-                github_data,
-                now_threads,
-                actionable_threads,
-                waiting_threads,
-                status_override,
-                changed,
-            ) = self._collect_poll_data()
+            snapshot = self._collect_poll_data()
         except Exception as exc:
             # Unhandled exception in poll data collection — keep the TUI alive
             self._consecutive_errors += 1
+            status_override = f"[red]{_format_request_error('Auto-refresh', exc)}[/]"
+            self._sidebar_status_override = status_override
             self.call_from_thread(
                 self.query_one("#status", Static).update,
-                f"[red]{_format_request_error('Auto-refresh', exc)}[/]",
+                status_override,
             )
             return
 
+        status_override = snapshot.status
         if status_override:
             self._consecutive_errors += 1
             self._poll_had_error = True
             if self._consecutive_errors >= self._SUSTAINED_OUTAGE_THRESHOLD:
                 # Show persistent outage message that reminds user about retry
                 status_override = "[red]Server unreachable — press Ctrl+R to retry[/]"
-            if changed:
+            self._sidebar_status_override = status_override
+            if snapshot.changed:
                 self.call_from_thread(
                     self._populate,
-                    convos,
-                    events,
-                    notes,
-                    reminders,
-                    reminder_lists,
-                    github_data,
-                    now_threads,
-                    actionable_threads,
-                    waiting_threads,
+                    snapshot.conversations,
+                    snapshot.events,
+                    snapshot.notes,
+                    snapshot.reminders,
+                    snapshot.reminder_lists,
+                    snapshot.github_data,
+                    snapshot.now_threads,
+                    snapshot.actionable_threads,
+                    snapshot.waiting_threads,
                     status_override,
                 )
                 return
-            self.conversations = convos
-            self.now_threads = now_threads
-            self.actionable_threads = actionable_threads
-            self.waiting_threads = waiting_threads
+            self.conversations = snapshot.conversations
+            self.now_threads = snapshot.now_threads
+            self.actionable_threads = snapshot.actionable_threads
+            self.waiting_threads = snapshot.waiting_threads
             self.call_from_thread(self.query_one("#status", Static).update, status_override)
             return
 
         # Success path — reset counters
         self._consecutive_errors = 0
-        if changed:
+        self._sidebar_status_override = None
+        if snapshot.changed:
             self._poll_had_error = False
             self.call_from_thread(
                 self._populate,
-                convos,
-                events,
-                notes,
-                reminders,
-                reminder_lists,
-                github_data,
-                now_threads,
-                actionable_threads,
-                waiting_threads,
+                snapshot.conversations,
+                snapshot.events,
+                snapshot.notes,
+                snapshot.reminders,
+                snapshot.reminder_lists,
+                snapshot.github_data,
+                snapshot.now_threads,
+                snapshot.actionable_threads,
+                snapshot.waiting_threads,
                 status_override,
             )
             return
 
-        self.conversations = convos
-        self.now_threads = now_threads
-        self.actionable_threads = actionable_threads
-        self.waiting_threads = waiting_threads
+        self.conversations = snapshot.conversations
+        self.now_threads = snapshot.now_threads
+        self.actionable_threads = snapshot.actionable_threads
+        self.waiting_threads = snapshot.waiting_threads
         if self._poll_had_error:
             self._poll_had_error = False
             self.call_from_thread(self._render_sidebar)
 
     def _do_refresh(self) -> None:
         """Fetch all data from the server (runs in worker thread)."""
-        (
-            convos,
-            events,
-            notes,
-            reminders,
-            reminder_lists,
-            github_data,
-            now_threads,
-            actionable_threads,
-            waiting_threads,
-            status_override,
-        ) = self._collect_refresh_data()
+        snapshot = self._collect_refresh_data()
         self.call_from_thread(
             self._populate,
-            convos,
-            events,
-            notes,
-            reminders,
-            reminder_lists,
-            github_data,
-            now_threads,
-            actionable_threads,
-            waiting_threads,
-            status_override,
+            snapshot.conversations,
+            snapshot.events,
+            snapshot.notes,
+            snapshot.reminders,
+            snapshot.reminder_lists,
+            snapshot.github_data,
+            snapshot.now_threads,
+            snapshot.actionable_threads,
+            snapshot.waiting_threads,
+            snapshot.status,
         )
 
     def _populate(
@@ -2220,6 +2241,7 @@ class InboxApp(App):
         waiting_threads: list[dict] | None = None,
         status_override: str | None = None,
     ) -> None:
+        self._sidebar_status_override = status_override
         # Check for notification-worthy changes before updating state
         gh = github_data if github_data is not None else self.github_data
         ev = events if events is not None else self.events
@@ -2272,17 +2294,7 @@ class InboxApp(App):
 
     def _collect_auxiliary_data(
         self,
-    ) -> tuple[
-        list[dict],
-        list[dict],
-        list[dict],
-        list[dict],
-        list[dict],
-        list[dict],
-        list[dict],
-        list[dict],
-        list[str],
-    ]:
+    ) -> AuxiliaryDataSnapshot:
         events = self.events
         notes = self.notes_data
         reminders = self.reminders_data
@@ -2336,32 +2348,21 @@ class InboxApp(App):
         except Exception as exc:
             errors.append(_format_request_error("Indexed waiting refresh", exc))
 
-        return (
-            events,
-            notes,
-            reminders,
-            reminder_lists,
-            github_data,
-            now_threads,
-            actionable_threads,
-            waiting_threads,
-            errors,
+        return AuxiliaryDataSnapshot(
+            events=events,
+            notes=notes,
+            reminders=reminders,
+            reminder_lists=reminder_lists,
+            github_data=github_data,
+            now_threads=now_threads,
+            actionable_threads=actionable_threads,
+            waiting_threads=waiting_threads,
+            errors=errors,
         )
 
     def _collect_refresh_data(
         self,
-    ) -> tuple[
-        list[dict],
-        list[dict],
-        list[dict],
-        list[dict],
-        list[dict],
-        list[dict],
-        list[dict],
-        list[dict],
-        list[dict],
-        str | None,
-    ]:
+    ) -> RefreshDataSnapshot:
         convos = self.conversations
         errors: list[str] = []
 
@@ -2370,61 +2371,39 @@ class InboxApp(App):
         except Exception as exc:
             errors.append(_format_request_error("Conversation refresh", exc))
 
-        (
-            events,
-            notes,
-            reminders,
-            reminder_lists,
-            github_data,
-            now_threads,
-            actionable_threads,
-            waiting_threads,
-            aux_errors,
-        ) = self._collect_auxiliary_data()
-        errors.extend(aux_errors)
-        return (
-            convos,
-            events,
-            notes,
-            reminders,
-            reminder_lists,
-            github_data,
-            now_threads,
-            actionable_threads,
-            waiting_threads,
-            self._merge_status_errors(errors),
+        auxiliary = self._collect_auxiliary_data()
+        errors.extend(auxiliary.errors)
+        return RefreshDataSnapshot(
+            conversations=convos,
+            events=auxiliary.events,
+            notes=auxiliary.notes,
+            reminders=auxiliary.reminders,
+            reminder_lists=auxiliary.reminder_lists,
+            github_data=auxiliary.github_data,
+            now_threads=auxiliary.now_threads,
+            actionable_threads=auxiliary.actionable_threads,
+            waiting_threads=auxiliary.waiting_threads,
+            status=self._merge_status_errors(errors),
         )
 
     def _collect_poll_data(
         self,
-    ) -> tuple[
-        list[dict],
-        list[dict],
-        list[dict],
-        list[dict],
-        list[dict],
-        list[dict],
-        list[dict],
-        list[dict],
-        list[dict],
-        str | None,
-        bool,
-    ]:
+    ) -> PollDataSnapshot:
         try:
             convos = self.client.conversations(limit=100)
         except Exception as exc:
-            return (
-                self.conversations,
-                self.events,
-                self.notes_data,
-                self.reminders_data,
-                self.reminder_lists,
-                self.github_data,
-                self.now_threads,
-                self.actionable_threads,
-                self.waiting_threads,
-                self._merge_status_errors([_format_request_error("Auto-refresh", exc)]),
-                False,
+            return PollDataSnapshot(
+                conversations=self.conversations,
+                events=self.events,
+                notes=self.notes_data,
+                reminders=self.reminders_data,
+                reminder_lists=self.reminder_lists,
+                github_data=self.github_data,
+                now_threads=self.now_threads,
+                actionable_threads=self.actionable_threads,
+                waiting_threads=self.waiting_threads,
+                status=self._merge_status_errors([_format_request_error("Auto-refresh", exc)]),
+                changed=False,
             )
 
         # Check if unread counts changed
@@ -2436,56 +2415,46 @@ class InboxApp(App):
         changed = (
             old_unread != new_unread or old_ids != new_ids or len(self.conversations) != len(convos)
         )
-        (
-            events,
-            notes,
-            reminders,
-            reminder_lists,
-            github_data,
-            now_threads,
-            actionable_threads,
-            waiting_threads,
-            errors,
-        ) = self._collect_auxiliary_data()
+        auxiliary = self._collect_auxiliary_data()
         if not changed:
             old_now_ids = [t.get("thread_id") for t in self.now_threads]
-            new_now_ids = [t.get("thread_id") for t in now_threads]
+            new_now_ids = [t.get("thread_id") for t in auxiliary.now_threads]
             old_action_ids = [t.get("thread_id") for t in self.actionable_threads]
-            new_action_ids = [t.get("thread_id") for t in actionable_threads]
+            new_action_ids = [t.get("thread_id") for t in auxiliary.actionable_threads]
             old_wait_ids = [t.get("thread_id") for t in self.waiting_threads]
-            new_wait_ids = [t.get("thread_id") for t in waiting_threads]
+            new_wait_ids = [t.get("thread_id") for t in auxiliary.waiting_threads]
             changed = (
                 old_now_ids != new_now_ids
                 or old_action_ids != new_action_ids
                 or old_wait_ids != new_wait_ids
             )
         if not changed:
-            return (
-                convos,
-                events,
-                notes,
-                reminders,
-                reminder_lists,
-                github_data,
-                now_threads,
-                actionable_threads,
-                waiting_threads,
-                self._merge_status_errors(errors),
-                False,
+            return PollDataSnapshot(
+                conversations=convos,
+                events=auxiliary.events,
+                notes=auxiliary.notes,
+                reminders=auxiliary.reminders,
+                reminder_lists=auxiliary.reminder_lists,
+                github_data=auxiliary.github_data,
+                now_threads=auxiliary.now_threads,
+                actionable_threads=auxiliary.actionable_threads,
+                waiting_threads=auxiliary.waiting_threads,
+                status=self._merge_status_errors(auxiliary.errors),
+                changed=False,
             )
 
-        return (
-            convos,
-            events,
-            notes,
-            reminders,
-            reminder_lists,
-            github_data,
-            now_threads,
-            actionable_threads,
-            waiting_threads,
-            self._merge_status_errors(errors),
-            True,
+        return PollDataSnapshot(
+            conversations=convos,
+            events=auxiliary.events,
+            notes=auxiliary.notes,
+            reminders=auxiliary.reminders,
+            reminder_lists=auxiliary.reminder_lists,
+            github_data=auxiliary.github_data,
+            now_threads=auxiliary.now_threads,
+            actionable_threads=auxiliary.actionable_threads,
+            waiting_threads=auxiliary.waiting_threads,
+            status=self._merge_status_errors(auxiliary.errors),
+            changed=True,
         )
 
     # ── Reminder key handling ─────────────────────────────────────────────

--- a/tests/test_inbox_app.py
+++ b/tests/test_inbox_app.py
@@ -74,14 +74,12 @@ def test_collect_refresh_data_preserves_other_data_on_partial_failure() -> None:
     app.events = [{"summary": "Existing event"}]
     app.notes_data = [{"id": "old-note", "title": "Old note"}]
 
-    convos, events, notes, reminders, reminder_lists, github_data, status = (
-        app._collect_refresh_data()
-    )
+    snapshot = app._collect_refresh_data()
 
-    assert convos == [{"id": "c1", "source": "imessage", "unread": 0}]
-    assert events == [{"summary": "Existing event"}]
-    assert notes == [{"id": "n1", "title": "Fresh note"}]
-    assert status == "[red]Calendar refresh failed (HTTP 500)[/]"
+    assert snapshot.conversations == [{"id": "c1", "source": "imessage", "unread": 0}]
+    assert snapshot.events == [{"summary": "Existing event"}]
+    assert snapshot.notes == [{"id": "n1", "title": "Fresh note"}]
+    assert snapshot.status == "[red]Calendar refresh failed (HTTP 500)[/]"
 
 
 def test_collect_poll_data_reports_server_unreachable() -> None:
@@ -95,15 +93,13 @@ def test_collect_poll_data_reports_server_unreachable() -> None:
     app.events = [{"summary": "Standup"}]
     app.notes_data = [{"id": "n1"}]
 
-    convos, events, notes, reminders, reminder_lists, github_data, status, changed = (
-        app._collect_poll_data()
-    )
+    snapshot = app._collect_poll_data()
 
-    assert changed is False
-    assert convos == app.conversations
-    assert events == app.events
-    assert notes == app.notes_data
-    assert status == "[red]Server unreachable — press Ctrl+R to retry[/]"
+    assert snapshot.changed is False
+    assert snapshot.conversations == app.conversations
+    assert snapshot.events == app.events
+    assert snapshot.notes == app.notes_data
+    assert snapshot.status == "[red]Server unreachable — press Ctrl+R to retry[/]"
 
 
 def test_start_polling_uses_configured_interval() -> None:
@@ -141,9 +137,14 @@ def test_boot_failure_shows_status_error() -> None:
         app.client.ensure_server.side_effect = RuntimeError(
             "Server unreachable — press Ctrl+R to retry"
         )
+        app.client.conversations.side_effect = httpx.ConnectError(
+            "refused", request=httpx.Request("GET", "http://test/conversations")
+        )
 
         async with app.run_test() as pilot:
-            await pilot.pause(0.2)
+            worker = app.boot()
+            await worker.wait()
+            await pilot.pause()
             assert "Server unreachable" in _status_text(app)
 
     asyncio.run(runner())
@@ -269,22 +270,18 @@ def test_poll_had_error_resets_after_successful_poll() -> None:
     app._poll_had_error = False
 
     # First poll fails
-    convos, events, notes, reminders, reminder_lists, github_data, status, changed = (
-        app._collect_poll_data()
-    )
-    assert status is not None
-    assert "unreachable" in status
-    assert changed is False
+    snapshot = app._collect_poll_data()
+    assert snapshot.status is not None
+    assert "unreachable" in snapshot.status
+    assert snapshot.changed is False
 
     # Simulate that the error was shown (flag set by _bg_poll)
     app._poll_had_error = True
 
     # Second poll succeeds — conversations changed so changed=True
-    convos2, events2, notes2, reminders2, reminder_lists2, github_data2, status2, changed2 = (
-        app._collect_poll_data()
-    )
-    assert changed2 is True
-    assert status2 is None
+    snapshot = app._collect_poll_data()
+    assert snapshot.changed is True
+    assert snapshot.status is None
 
 
 def test_collect_poll_data_succeeds_with_changed_data() -> None:
@@ -304,15 +301,13 @@ def test_collect_poll_data_succeeds_with_changed_data() -> None:
     app.events = []
     app.notes_data = []
 
-    convos, events, notes, reminders, reminder_lists, github_data, status, changed = (
-        app._collect_poll_data()
-    )
+    snapshot = app._collect_poll_data()
 
-    assert changed is True
-    assert len(convos) == 2
-    assert len(events) == 1
-    assert len(notes) == 1
-    assert status is None
+    assert snapshot.changed is True
+    assert len(snapshot.conversations) == 2
+    assert len(snapshot.events) == 1
+    assert len(snapshot.notes) == 1
+    assert snapshot.status is None
 
 
 def test_collect_refresh_data_all_succeed() -> None:
@@ -325,16 +320,14 @@ def test_collect_refresh_data_all_succeed() -> None:
     client.github_notifications.return_value = []
 
     app = _make_app(client)
-    convos, events, notes, reminders, reminder_lists, github_data, status = (
-        app._collect_refresh_data()
-    )
+    snapshot = app._collect_refresh_data()
 
-    assert convos == [{"id": "c1", "source": "imessage", "unread": 0}]
-    assert events == [{"summary": "Meeting"}]
-    assert notes == [{"id": "n1", "title": "My Note"}]
-    assert reminders == [{"id": "r1", "title": "Buy groceries"}]
-    assert reminder_lists == [{"name": "Reminders", "incomplete_count": 1}]
-    assert status is None
+    assert snapshot.conversations == [{"id": "c1", "source": "imessage", "unread": 0}]
+    assert snapshot.events == [{"summary": "Meeting"}]
+    assert snapshot.notes == [{"id": "n1", "title": "My Note"}]
+    assert snapshot.reminders == [{"id": "r1", "title": "Buy groceries"}]
+    assert snapshot.reminder_lists == [{"name": "Reminders", "incomplete_count": 1}]
+    assert snapshot.status is None
 
 
 def test_collect_refresh_data_conversations_fails_preserves_old() -> None:
@@ -351,16 +344,14 @@ def test_collect_refresh_data_conversations_fails_preserves_old() -> None:
     app = _make_app(client)
     app.conversations = [{"id": "old", "source": "imessage", "unread": 0}]
 
-    convos, events, notes, reminders, reminder_lists, github_data, status = (
-        app._collect_refresh_data()
-    )
+    snapshot = app._collect_refresh_data()
 
     # Conversations preserved from old data
-    assert convos == [{"id": "old", "source": "imessage", "unread": 0}]
-    assert events == [{"summary": "Meeting"}]
-    assert notes == [{"id": "n1"}]
-    assert status is not None
-    assert "unreachable" in status
+    assert snapshot.conversations == [{"id": "old", "source": "imessage", "unread": 0}]
+    assert snapshot.events == [{"summary": "Meeting"}]
+    assert snapshot.notes == [{"id": "n1"}]
+    assert snapshot.status is not None
+    assert "unreachable" in snapshot.status
 
 
 def test_poll_interval_env_not_set_uses_default(monkeypatch) -> None:
@@ -384,13 +375,11 @@ def test_consecutive_errors_increment_on_poll_failure() -> None:
     assert app._consecutive_errors == 0
 
     # First poll failure
-    convos, events, notes, reminders, reminder_lists, github_data, status, changed = (
-        app._collect_poll_data()
-    )
-    assert status is not None
+    snapshot = app._collect_poll_data()
+    assert snapshot.status is not None
     # The counter is incremented by _bg_poll, not by _collect_poll_data,
     # but we can verify the method returns the error status
-    assert "unreachable" in status
+    assert "unreachable" in snapshot.status
 
 
 def test_consecutive_errors_reset_on_successful_poll() -> None:
@@ -413,11 +402,9 @@ def test_consecutive_errors_reset_on_successful_poll() -> None:
     app._consecutive_errors = 3  # Simulate sustained outage state
 
     # Successful poll returns fresh data
-    convos, events, notes, reminders, reminder_lists, github_data, status, changed = (
-        app._collect_poll_data()
-    )
-    assert changed is True
-    assert status is None
+    snapshot = app._collect_poll_data()
+    assert snapshot.changed is True
+    assert snapshot.status is None
 
     # The _consecutive_errors is reset by _bg_poll on the success path
     # Verify the reset happens (simulating _bg_poll logic)
@@ -439,11 +426,9 @@ def test_sustained_outage_threshold_message() -> None:
     app._consecutive_errors = InboxApp._SUSTAINED_OUTAGE_THRESHOLD - 1
 
     # This poll failure pushes us over the threshold
-    convos, events, notes, reminders, reminder_lists, github_data, status, changed = (
-        app._collect_poll_data()
-    )
-    assert status is not None
-    assert "unreachable" in status
+    snapshot = app._collect_poll_data()
+    assert snapshot.status is not None
+    assert "unreachable" in snapshot.status
 
     # The _bg_poll method checks threshold and overrides the status message.
     # We can verify the threshold constant is used correctly.
@@ -484,7 +469,7 @@ def test_status_bar_clears_unreachable_message_after_recovery() -> None:
             assert "unreachable" not in status, (
                 f"Status bar still shows outage after recovery: {status!r}"
             )
-            assert "conversations" in status or "conversation" in status
+            assert "indexed threads" in status
 
     asyncio.run(runner())
 
@@ -560,12 +545,10 @@ def test_bg_poll_catches_unexpected_exceptions() -> None:
 
     # _collect_poll_data catches Exception on conversations, so RuntimeError
     # will be caught there and an error status returned. Verify this:
-    convos, events, notes, reminders, reminder_lists, github_data, status, changed = (
-        app._collect_poll_data()
-    )
-    assert status is not None
-    assert "unexpected" in status or "failed" in status
-    assert changed is False
+    snapshot = app._collect_poll_data()
+    assert snapshot.status is not None
+    assert "unexpected" in snapshot.status or "failed" in snapshot.status
+    assert snapshot.changed is False
 
 
 def test_bg_refresh_catches_unexpected_exceptions() -> None:
@@ -578,11 +561,9 @@ def test_bg_refresh_catches_unexpected_exceptions() -> None:
 
     # _collect_refresh_data catches Exception on conversations, so the
     # RuntimeError will be caught and an error status returned.
-    convos, events, notes, reminders, reminder_lists, github_data, status = (
-        app._collect_refresh_data()
-    )
-    assert status is not None
-    assert "unexpected" in status or "failed" in status
+    snapshot = app._collect_refresh_data()
+    assert snapshot.status is not None
+    assert "unexpected" in snapshot.status or "failed" in snapshot.status
 
 
 def test_worker_exit_on_error_is_false() -> None:
@@ -650,13 +631,11 @@ def test_tui_survives_repeated_poll_failures() -> None:
         client.conversations.side_effect = httpx.ConnectError(
             "refused", request=httpx.Request("GET", "http://test/")
         )
-        convos, events, notes, reminders, reminder_lists, github_data, status, changed = (
-            app._collect_poll_data()
-        )
-        assert changed is False
-        assert convos == app.conversations  # Old data preserved
-        assert status is not None
-        assert "unreachable" in status
+        snapshot = app._collect_poll_data()
+        assert snapshot.changed is False
+        assert snapshot.conversations == app.conversations  # Old data preserved
+        assert snapshot.status is not None
+        assert "unreachable" in snapshot.status
 
 
 def test_tui_recovers_after_sustained_outage() -> None:
@@ -685,22 +664,18 @@ def test_tui_recovers_after_sustained_outage() -> None:
 
     # Failures during outage
     for _ in range(3):
-        convos, events, notes, reminders, reminder_lists, github_data, status, changed = (
-            app._collect_poll_data()
-        )
-        assert status is not None
-        assert "unreachable" in status
+        snapshot = app._collect_poll_data()
+        assert snapshot.status is not None
+        assert "unreachable" in snapshot.status
 
     # Server comes back — poll succeeds with changed data
-    convos, events, notes, reminders, reminder_lists, github_data, status, changed = (
-        app._collect_poll_data()
-    )
-    assert changed is True
-    assert len(convos) == 1
-    assert convos[0]["id"] == "c2"
-    assert len(events) == 1
-    assert events[0]["summary"] == "New event"
-    assert status is None
+    snapshot = app._collect_poll_data()
+    assert snapshot.changed is True
+    assert len(snapshot.conversations) == 1
+    assert snapshot.conversations[0]["id"] == "c2"
+    assert len(snapshot.events) == 1
+    assert snapshot.events[0]["summary"] == "New event"
+    assert snapshot.status is None
 
 
 def test_sustained_outage_threshold_is_reasonable() -> None:
@@ -1120,15 +1095,13 @@ def test_collect_refresh_data_includes_reminders() -> None:
     client.github_notifications.return_value = []
 
     app = _make_app(client)
-    convos, events, notes, reminders, reminder_lists, github_data, status = (
-        app._collect_refresh_data()
-    )
+    snapshot = app._collect_refresh_data()
 
-    assert len(reminders) == 1
-    assert reminders[0]["title"] == "Buy groceries"
-    assert len(reminder_lists) == 1
-    assert reminder_lists[0]["name"] == "Shopping"
-    assert status is None
+    assert len(snapshot.reminders) == 1
+    assert snapshot.reminders[0]["title"] == "Buy groceries"
+    assert len(snapshot.reminder_lists) == 1
+    assert snapshot.reminder_lists[0]["name"] == "Shopping"
+    assert snapshot.status is None
 
 
 def test_collect_auxiliary_data_fetches_reminders() -> None:
@@ -1141,11 +1114,11 @@ def test_collect_auxiliary_data_fetches_reminders() -> None:
     client.github_notifications.return_value = []
 
     app = _make_app(client)
-    events, notes, reminders, reminder_lists, github_data, errors = app._collect_auxiliary_data()
+    snapshot = app._collect_auxiliary_data()
 
-    assert len(reminders) == 1
-    assert len(reminder_lists) == 1
-    assert errors == []
+    assert len(snapshot.reminders) == 1
+    assert len(snapshot.reminder_lists) == 1
+    assert snapshot.errors == []
 
 
 def test_collect_auxiliary_data_reminders_failure_preserves_old() -> None:
@@ -1162,13 +1135,13 @@ def test_collect_auxiliary_data_reminders_failure_preserves_old() -> None:
     app = _make_app(client)
     app.reminders_data = [_make_reminder_data(title="Old reminder")]
 
-    events, notes, reminders, reminder_lists, github_data, errors = app._collect_auxiliary_data()
+    snapshot = app._collect_auxiliary_data()
 
     # Old reminders preserved
-    assert len(reminders) == 1
-    assert reminders[0]["title"] == "Old reminder"
-    assert len(errors) == 1
-    assert "unreachable" in errors[0]
+    assert len(snapshot.reminders) == 1
+    assert snapshot.reminders[0]["title"] == "Old reminder"
+    assert len(snapshot.errors) == 1
+    assert "unreachable" in snapshot.errors[0]
 
 
 def test_populate_stores_reminders_data() -> None:
@@ -1547,13 +1520,16 @@ def test_sidebar_selection_restored_after_tab_switch() -> None:
         app.conversations = client.conversations.return_value
 
         async with app.run_test() as pilot:
+            await pilot.press("ctrl+2")
+            await pilot.pause(0.5)
             # Select Alice in the sidebar
-            app.active_conv = {"id": "c1", "source": "imessage", "name": "Alice"}
+            app.active_conv = app.conversations[0]
+            app._restore_sidebar_selection()
 
             # Switch to calendar and back
             await pilot.press("ctrl+4")
             await pilot.pause(0.5)
-            await pilot.press("ctrl+1")
+            await pilot.press("ctrl+2")
             await pilot.pause(0.5)
 
             # Check that the sidebar selection is restored (index matches Alice)
@@ -2022,13 +1998,11 @@ def test_collect_refresh_data_includes_github() -> None:
     client.github_notifications.return_value = [_make_notification_data()]
 
     app = _make_app(client)
-    convos, events, notes, reminders, reminder_lists, github_data, status = (
-        app._collect_refresh_data()
-    )
+    snapshot = app._collect_refresh_data()
 
-    assert len(github_data) == 1
-    assert github_data[0]["title"] == "Fix auth bug"
-    assert status is None
+    assert len(snapshot.github_data) == 1
+    assert snapshot.github_data[0]["title"] == "Fix auth bug"
+    assert snapshot.status is None
 
 
 def test_collect_auxiliary_data_fetches_github() -> None:
@@ -2041,10 +2015,10 @@ def test_collect_auxiliary_data_fetches_github() -> None:
     client.github_notifications.return_value = [_make_notification_data()]
 
     app = _make_app(client)
-    events, notes, reminders, reminder_lists, github_data, errors = app._collect_auxiliary_data()
+    snapshot = app._collect_auxiliary_data()
 
-    assert len(github_data) == 1
-    assert errors == []
+    assert len(snapshot.github_data) == 1
+    assert snapshot.errors == []
 
 
 def test_collect_auxiliary_data_github_failure_preserves_old() -> None:
@@ -2061,12 +2035,12 @@ def test_collect_auxiliary_data_github_failure_preserves_old() -> None:
     app = _make_app(client)
     app.github_data = [_make_notification_data(title="Old notif")]
 
-    events, notes, reminders, reminder_lists, github_data, errors = app._collect_auxiliary_data()
+    snapshot = app._collect_auxiliary_data()
 
-    assert len(github_data) == 1
-    assert github_data[0]["title"] == "Old notif"
-    assert len(errors) == 1
-    assert "unreachable" in errors[0]
+    assert len(snapshot.github_data) == 1
+    assert snapshot.github_data[0]["title"] == "Old notif"
+    assert len(snapshot.errors) == 1
+    assert "unreachable" in snapshot.errors[0]
 
 
 def test_github_key_handlers_mark_read() -> None:
@@ -2156,12 +2130,10 @@ def test_github_notifications_not_fetched_on_non_github_tabs() -> None:
     client.github_notifications.return_value = [_make_notification_data()]
 
     app = _make_app(client)
-    convos, events, notes, reminders, reminder_lists, github_data, status = (
-        app._collect_refresh_data()
-    )
+    snapshot = app._collect_refresh_data()
 
     # GitHub notifications should be included in refresh
-    assert len(github_data) == 1
+    assert len(snapshot.github_data) == 1
     client.github_notifications.assert_called()
 
 
@@ -3112,6 +3084,11 @@ def test_p_key_calls_show_contact_profile() -> None:
         app.action_show_contact_profile = MagicMock()
 
         async with app.run_test() as pilot:
+            await pilot.press("ctrl+2")
+            await pilot.pause(0.5)
+            app.active_conv = app.conversations[0]
+            app.query_one("#compose", Input).blur()
+            await pilot.pause()
             await pilot.press("p")
             await pilot.pause(0.2)
 
@@ -3376,6 +3353,7 @@ def test_search_on_result_selected_navigates_to_notes() -> None:
         assert navigated[0]["source"] == "notes"
 
     asyncio.run(runner())
+
 
 # ── AI layer TUI tests ───────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- Replace TUI refresh/poll tuple returns with named snapshot dataclasses.
- Update refresh/poll tests to assert named fields instead of positional tuple slots.
- Preserve sidebar outage status across re-renders until a successful refresh or poll clears it.

## Validation
- `uv run pytest tests/test_inbox_app.py -k 'collect_refresh_data or collect_poll_data or collect_auxiliary_data' -q`\n- `uv run pytest tests/test_inbox_app.py -q`\n- `INBOX_TEST_MODE=1 uv run pytest tests/test_inbox_app.py -q`\n- `uv run ruff check inbox.py tests/test_inbox_app.py`\n- `uv run ruff format --check inbox.py tests/test_inbox_app.py`\n\n## Notes\n- `uv run pyright inbox.py tests/test_inbox_app.py` still reports 8 existing Textual/import issues outside this change.\n- `uv run pytest -q` still has one existing failure in `tests/test_calendar.py::TestCalendarDateRangeEndpoint::test_date_range_params`; 851 tests pass.