### PR TITLE
Avoid large thread cleanup expressions

### DIFF
--- a/message_index_store.py
+++ b/message_index_store.py
@@ -516,14 +516,39 @@ class MessageIndexStore:
                 scope_clause = (
                     " AND ".join(deletion_scope_predicates) if deletion_scope_predicates else "1=1"
                 )
-                keep_clause = " OR ".join(
-                    "(source = ? AND account = ? AND thread_id = ?)" for _ in keys
-                )
-                keep_params: list[object] = [value for key in keys for value in key]
                 conn.execute(
-                    f"DELETE FROM threads WHERE ({scope_clause}) AND NOT ({keep_clause})",  # nosec: B608
-                    deletion_scope_params + keep_params,
+                    """
+                    CREATE TEMP TABLE IF NOT EXISTS rebuild_thread_keep (
+                        source TEXT NOT NULL,
+                        account TEXT NOT NULL,
+                        thread_id TEXT NOT NULL,
+                        PRIMARY KEY (source, account, thread_id)
+                    )
+                    """
                 )
+                conn.execute("DELETE FROM rebuild_thread_keep")
+                conn.executemany(
+                    """
+                    INSERT OR IGNORE INTO rebuild_thread_keep (source, account, thread_id)
+                    VALUES (?, ?, ?)
+                    """,
+                    keys,
+                )
+                conn.execute(
+                    f"""
+                    DELETE FROM threads
+                    WHERE ({scope_clause})
+                      AND NOT EXISTS (
+                          SELECT 1
+                          FROM rebuild_thread_keep keep
+                          WHERE keep.source = threads.source
+                            AND keep.account = threads.account
+                            AND keep.thread_id = threads.thread_id
+                      )
+                    """,  # nosec: B608
+                    deletion_scope_params,
+                )
+                conn.execute("DELETE FROM rebuild_thread_keep")
             elif source and account:
                 conn.execute(
                     "DELETE FROM threads WHERE source = ? AND account = ?", (source, account)

--- a/tests/test_message_index_store.py
+++ b/tests/test_message_index_store.py
@@ -390,6 +390,31 @@ def test_rebuild_threads_is_idempotent(tmp_path):
         assert row["thread_id"] == "t1"
 
 
+def test_rebuild_threads_handles_many_threads_without_expression_depth_failure(tmp_path):
+    store = MessageIndexStore(tmp_path / "index.sqlite3")
+    for index in range(1100):
+        store.upsert_item(
+            _item(
+                source="gmail",
+                account="a@example.com",
+                external_id=f"m{index}",
+                thread_id=f"t{index}",
+                sender="Sender",
+                subject=f"Thread {index}",
+            )
+        )
+
+    rebuilt = store.rebuild_threads(source="gmail", account="a@example.com")
+
+    assert rebuilt == 1100
+    with store._connect() as conn:
+        count = conn.execute(
+            "SELECT COUNT(*) FROM threads WHERE source = ? AND account = ?",
+            ("gmail", "a@example.com"),
+        ).fetchone()[0]
+        assert count == 1100
+
+
 def test_set_sync_state_is_idempotent(tmp_path):
     store = MessageIndexStore(tmp_path / "index.sqlite3")
 


### PR DESCRIPTION
## Summary

- Fixes `MessageIndexStore.rebuild_threads()` cleanup so it no longer builds a giant `OR` expression for changed thread keys.
- Uses a temporary keep table plus `NOT EXISTS` for cleanup, avoiding SQLite's expression tree depth limit.
- Adds a regression test that rebuilds 1100 threads for one source/account.

## Validation

- `uv run pytest tests/test_message_index_store.py -k "rebuild_threads" -q` - 7 passed
- `uv run pytest tests/test_message_sync.py -q` - 10 passed
- `uv run ruff check message_index_store.py tests/test_message_index_store.py`
- `uv run ruff format --check message_index_store.py tests/test_message_index_store.py`
- `uv run pytest -q` - 858 passed

Linear: SYM-229