### PR TITLE
[codex] Make indexed inbox endpoints the default read path

### DIFF
--- a/inbox_client.py
+++ b/inbox_client.py
@@ -108,10 +108,27 @@ class InboxClient:
         r.raise_for_status()
         return r.json()
 
+    def index_health(self) -> dict:
+        r = self._client.get("/index/health")
+        r.raise_for_status()
+        return r.json()
+
     def index_view(self, view_name: str, *, limit: int = 20) -> dict:
         r = self._client.get(f"/index/views/{view_name}", params={"limit": limit})
         r.raise_for_status()
         return r.json()
+
+    def indexed_recent_threads(self, *, limit: int = 20) -> dict:
+        return self.index_view("recent", limit=limit)
+
+    def indexed_actionable_threads(self, *, limit: int = 20) -> dict:
+        return self.index_view("actionable", limit=limit)
+
+    def indexed_waiting_on_me_threads(self, *, limit: int = 20) -> dict:
+        return self.index_view("waiting-on-me", limit=limit)
+
+    def indexed_waiting_on_others_threads(self, *, limit: int = 20) -> dict:
+        return self.index_view("waiting-on-others", limit=limit)
 
     # ── Messages ─────────────────────────────────────────────────────────
 

--- a/inbox_server.py
+++ b/inbox_server.py
@@ -563,6 +563,8 @@ class WorkflowEventRequest(BaseModel):
 
 
 class NeedsActionOut(BaseModel):
+    thread_read_model: str = "index"
+    raw_thread_provider_fetch: bool = False
     threads: list[GmailThreadSummaryOut]
     tasks: list[TaskOut]
     events: list[CalendarEventOut]
@@ -590,11 +592,15 @@ class IndexSyncStateOut(BaseModel):
 
 class IndexStatusOut(BaseModel):
     db_path: str
+    read_model: str = "index"
+    raw_provider_fetch: bool = False
     threads: list[GmailThreadSummaryOut]
 
 
 class IndexOverviewOut(BaseModel):
     db_path: str
+    read_model: str = "index"
+    raw_provider_fetch: bool = False
     counts: dict[str, int]
     sync_states: list[IndexSyncStateOut]
 
@@ -620,6 +626,9 @@ class IndexHealthOut(BaseModel):
 
 class IndexedThreadListOut(BaseModel):
     view: str
+    db_path: str
+    read_model: str = "index"
+    raw_provider_fetch: bool = False
     threads: list[GmailThreadSummaryOut]
 
 
@@ -2773,6 +2782,20 @@ def _index_view_rows(view: str, limit: int) -> list[dict[str, object]]:
             newest_only=True,
             sort_mode="recent",
         )
+    if view == "waiting-on-me":
+        return state.index_store.list_threads(
+            limit=limit,
+            needs_reply=True,
+            newest_only=True,
+            sort_mode="priority",
+        )
+    if view == "waiting-on-others":
+        return state.index_store.list_threads(
+            limit=limit,
+            latest_sender="Me",
+            newest_only=True,
+            sort_mode="recent",
+        )
     if view == "waiting-on":
         return state.index_store.list_threads(
             limit=limit,
@@ -3733,24 +3756,6 @@ async def get_needs_action(workflow: str = "", account: str = ""):
             threads.append(ts)
             if len(threads) >= 10:
                 break
-    elif state.gmail_services:
-        try:
-            acct, svc = _get_gmail_service_for_account(account)
-            contacts = await asyncio.to_thread(gmail_search, svc, acct, "is:inbox", 40)
-            seen_na: set[str] = set()
-            for c in contacts:
-                tid = c.thread_id or c.id
-                if c.unread == 0 or tid in seen_na:
-                    continue
-                seen_na.add(tid)
-                ts = _contact_to_thread_summary(c)
-                if workflow and ts.workflow != workflow:
-                    continue
-                threads.append(ts)
-                if len(threads) >= 10:
-                    break
-        except Exception:
-            pass
 
     tasks: list[TaskOut] = []
     if state.tasks_services:
@@ -3831,6 +3836,7 @@ async def get_index_view(view_name: str, limit: int = 20):
     rows = _index_view_rows(view_name, limit)
     return IndexedThreadListOut(
         view=view_name,
+        db_path=str(state.index_store.db_path),
         threads=[_indexed_thread_to_summary(row) for row in rows],
     )
 

--- a/message_index_store.py
+++ b/message_index_store.py
@@ -571,6 +571,7 @@ class MessageIndexStore:
         actions: tuple[str, ...] | None = None,
         needs_reply: bool | None = None,
         has_open_loop: bool | None = None,
+        latest_sender: str | None = None,
         sort_mode: str = "priority",
     ) -> list[dict[str, object]]:
         predicates: list[str] = []
@@ -588,6 +589,9 @@ class MessageIndexStore:
         if has_open_loop is not None:
             predicates.append("(open_loop != '') = ?")
             params.append(1 if has_open_loop else 0)
+        if latest_sender is not None:
+            predicates.append("latest_sender = ?")
+            params.append(latest_sender)
         where_clause = f"WHERE {' AND '.join(predicates)}" if predicates else ""
         if sort_mode == "recent":
             order_clause = "latest_item_at DESC"

--- a/tests/test_api_contract.py
+++ b/tests/test_api_contract.py
@@ -100,5 +100,23 @@ def test_inbox_client_index_status_matches_server_endpoint_shape(api_client: Tes
     result = client.index_status()
 
     assert result["db_path"].endswith(".inbox_index.sqlite3")
+    assert result["read_model"] == "index"
+    assert result["raw_provider_fetch"] is False
     assert result["counts"] == {"items": 3, "threads": 2}
     assert result["sync_states"] == []
+
+
+def test_inbox_client_index_health_matches_server_endpoint_shape(api_client: TestClient):
+    import inbox_server
+
+    inbox_server.state.index_store.list_sync_states = MagicMock(return_value=[])
+
+    client = InboxClient.__new__(InboxClient)
+    client._client = api_client
+
+    result = client.index_health()
+
+    assert result["db_path"].endswith(".inbox_index.sqlite3")
+    assert result["healthy"] is False
+    assert result["stale"] is True
+    assert result["reasons"] == ["no_sync_state"]

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, call
 
 import httpx
 import pytest
@@ -93,6 +93,34 @@ class TestClientConversations:
         client._client.get.assert_called_once_with(
             "/conversations", params={"source": "imessage", "limit": 10}
         )
+
+
+class TestClientIndexedInbox:
+    def test_index_health(self, client):
+        client._client.get.return_value = _mock_response({"healthy": True})
+        result = client.index_health()
+        assert result == {"healthy": True}
+        client._client.get.assert_called_once_with("/index/health")
+
+    def test_index_view(self, client):
+        client._client.get.return_value = _mock_response({"view": "recent", "threads": []})
+        result = client.index_view("recent", limit=7)
+        assert result == {"view": "recent", "threads": []}
+        client._client.get.assert_called_once_with("/index/views/recent", params={"limit": 7})
+
+    def test_indexed_view_helpers_use_compact_index_views(self, client):
+        client.index_view = MagicMock(return_value={"threads": []})
+
+        assert client.indexed_recent_threads(limit=1) == {"threads": []}
+        assert client.indexed_actionable_threads(limit=2) == {"threads": []}
+        assert client.indexed_waiting_on_me_threads(limit=3) == {"threads": []}
+        assert client.indexed_waiting_on_others_threads(limit=4) == {"threads": []}
+        assert client.index_view.call_args_list == [
+            call("recent", limit=1),
+            call("actionable", limit=2),
+            call("waiting-on-me", limit=3),
+            call("waiting-on-others", limit=4),
+        ]
 
 
 # ── Messages ────────────────────────────────────────────────────────────────

--- a/tests/test_message_index_store.py
+++ b/tests/test_message_index_store.py
@@ -415,6 +415,35 @@ def test_rebuild_threads_handles_many_threads_without_expression_depth_failure(t
         assert count == 1100
 
 
+def test_list_threads_can_filter_by_latest_sender(tmp_path):
+    store = MessageIndexStore(tmp_path / "index.sqlite3")
+    store.upsert_item(
+        _item(
+            source="gmail",
+            account="a@example.com",
+            external_id="m1",
+            thread_id="waiting-on-other",
+            sender="Me",
+            subject="Following up",
+        )
+    )
+    store.upsert_item(
+        _item(
+            source="gmail",
+            account="a@example.com",
+            external_id="m2",
+            thread_id="waiting-on-me",
+            sender="Recruiter",
+            subject="Can you reply?",
+        )
+    )
+    store.rebuild_threads()
+
+    rows = store.list_threads(limit=10, latest_sender="Me", sort_mode="recent")
+
+    assert [row["thread_id"] for row in rows] == ["waiting-on-other"]
+
+
 def test_set_sync_state_is_idempotent(tmp_path):
     store = MessageIndexStore(tmp_path / "index.sqlite3")
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -149,10 +149,13 @@ class TestIndexEndpoints:
         assert resp.status_code == 200
         data = resp.json()
         assert data["db_path"].endswith(".inbox_index.sqlite3")
+        assert data["read_model"] == "index"
+        assert data["raw_provider_fetch"] is False
         assert len(data["threads"]) == 1
         assert data["threads"][0]["thread_id"] == "t1"
         assert data["threads"][0]["needs_reply"] is True
         assert data["threads"][0]["workflow"] == ""
+        assert "body_text" not in data["threads"][0]
 
     def test_index_status_exposes_counts_and_sync_states(self, client):
         import inbox_server
@@ -296,7 +299,11 @@ class TestIndexEndpoints:
         assert resp.status_code == 200
         data = resp.json()
         assert data["view"] == "actionable"
+        assert data["db_path"].endswith(".inbox_index.sqlite3")
+        assert data["read_model"] == "index"
+        assert data["raw_provider_fetch"] is False
         assert len(data["threads"]) == 1
+        assert "body_text" not in data["threads"][0]
         inbox_server.state.index_store.list_threads.assert_called_once_with(
             limit=5,
             actions=("reply", "review", "track"),
@@ -318,6 +325,44 @@ class TestIndexEndpoints:
             limit=7,
             actions=("track",),
             has_open_loop=True,
+            newest_only=True,
+            sort_mode="recent",
+        )
+
+    def test_index_view_waiting_on_me_routes_to_needs_reply_threads(self, client):
+        import inbox_server
+
+        inbox_server.state.index_store.list_threads = MagicMock(return_value=[])
+
+        resp = client.get("/index/views/waiting-on-me", params={"limit": 9})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["view"] == "waiting-on-me"
+        assert data["read_model"] == "index"
+        assert data["raw_provider_fetch"] is False
+        assert data["threads"] == []
+        inbox_server.state.index_store.list_threads.assert_called_once_with(
+            limit=9,
+            needs_reply=True,
+            newest_only=True,
+            sort_mode="priority",
+        )
+
+    def test_index_view_waiting_on_others_routes_to_my_latest_threads(self, client):
+        import inbox_server
+
+        inbox_server.state.index_store.list_threads = MagicMock(return_value=[])
+
+        resp = client.get("/index/views/waiting-on-others", params={"limit": 11})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["view"] == "waiting-on-others"
+        assert data["read_model"] == "index"
+        assert data["raw_provider_fetch"] is False
+        assert data["threads"] == []
+        inbox_server.state.index_store.list_threads.assert_called_once_with(
+            limit=11,
+            latest_sender="Me",
             newest_only=True,
             sort_mode="recent",
         )
@@ -1784,10 +1829,13 @@ class TestPhase4:
         resp = client.get("/inbox/needs-action")
         assert resp.status_code == 200
         data = resp.json()
+        assert data["thread_read_model"] == "index"
+        assert data["raw_thread_provider_fetch"] is False
         assert "threads" in data
         assert "tasks" in data
         assert "events" in data
         assert "workflow_counts" in data
+        mock_gmail.assert_not_called()
 
     @patch("inbox_server.gmail_search")
     @patch("inbox_server.tasks_list")
@@ -1795,28 +1843,34 @@ class TestPhase4:
     def test_needs_action_workflow_counts(self, mock_events, mock_tasks, mock_gmail, client):
         import inbox_server
 
-        inbox_server.state.index_store.list_threads = MagicMock(return_value=[])
+        inbox_server.state.index_store.list_threads = MagicMock(
+            return_value=[
+                {
+                    "thread_id": "t1",
+                    "account": "me@gmail.com",
+                    "participants_json": ["HR"],
+                    "latest_subject": "Interview at Acme",
+                    "latest_snippet": "Interview at Acme",
+                    "latest_item_at": "2026-04-18T01:00:00+00:00",
+                    "summary": "HR: Interview at Acme [opportunity/review]",
+                    "open_loop": "Review opportunity details",
+                    "topic": "opportunity",
+                    "needs_reply": 1,
+                    "message_count": 1,
+                    "latest_sender": "HR",
+                }
+            ]
+        )
         inbox_server.state.gmail_services = {"me@gmail.com": MagicMock()}
         inbox_server.state.tasks_services = {"me@gmail.com": MagicMock()}
         inbox_server.state.cal_services = {}
-        mock_gmail.return_value = [
-            Contact(
-                id="m1",
-                name="HR",
-                source="gmail",
-                snippet="Interview at Acme",
-                unread=1,
-                last_ts=datetime(2020, 1, 1),
-                thread_id="t1",
-                gmail_account="me@gmail.com",
-            ),
-        ]
         mock_tasks.return_value = []
         mock_events.return_value = []
         resp = client.get("/inbox/needs-action")
         assert resp.status_code == 200
         data = resp.json()
         assert data["workflow_counts"].get("job_hunt", 0) >= 1
+        mock_gmail.assert_not_called()
 
     @patch("inbox_server.gmail_search")
     @patch("inbox_server.tasks_list")
@@ -1851,8 +1905,34 @@ class TestPhase4:
         resp = client.get("/inbox/needs-action")
         assert resp.status_code == 200
         data = resp.json()
+        assert data["thread_read_model"] == "index"
+        assert data["raw_thread_provider_fetch"] is False
         assert len(data["threads"]) == 1
         assert data["threads"][0]["thread_id"] == "t1"
+        mock_gmail.assert_not_called()
+
+    @patch("inbox_server.gmail_search")
+    @patch("inbox_server.tasks_list")
+    @patch("inbox_server.calendar_events")
+    def test_needs_action_does_not_fallback_to_live_gmail_when_index_empty(
+        self, mock_events, mock_tasks, mock_gmail, client
+    ):
+        import inbox_server
+
+        inbox_server.state.index_store.list_threads = MagicMock(return_value=[])
+        inbox_server.state.gmail_services = {"me@gmail.com": MagicMock()}
+        inbox_server.state.tasks_services = {"me@gmail.com": MagicMock()}
+        inbox_server.state.cal_services = {}
+        mock_tasks.return_value = []
+        mock_events.return_value = []
+
+        resp = client.get("/inbox/needs-action")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["threads"] == []
+        assert data["thread_read_model"] == "index"
+        assert data["raw_thread_provider_fetch"] is False
         mock_gmail.assert_not_called()
 
     @patch("inbox_server.drive_create_folder")


### PR DESCRIPTION
## Summary
- Add explicit indexed read-model metadata to index and needs-action thread responses.
- Add compact indexed views and client helpers for recent, actionable, waiting-on-me, and waiting-on-others threads.
- Remove live Gmail fallback from `/inbox/needs-action` thread rollup so default thread reads come from the index and avoid raw provider blobs.

## Validation
- `uv run pytest tests/test_server.py -k "index_view or index_threads or needs_action" -q` -> 9 passed
- `uv run pytest tests/test_client.py tests/test_api_contract.py -q` -> 72 passed
- `uv run pytest tests/test_message_index_store.py -k "latest_sender or rebuild_threads" -q` -> 8 passed
- `uv run ruff check inbox_server.py inbox_client.py message_index_store.py tests/test_server.py tests/test_client.py tests/test_api_contract.py tests/test_message_index_store.py` -> passed
- `uv run ruff format --check inbox_server.py inbox_client.py message_index_store.py tests/test_server.py tests/test_client.py tests/test_api_contract.py tests/test_message_index_store.py` -> passed
- `uv run pytest tests -k "endpoint or indexed or inbox_client or needs_action or waiting" -q` -> 102 passed, 764 deselected
- `uv run pytest -q` -> 866 passed

Linear: SYM-9