### PR TITLE
[codex] Add overnight review reports

### DIFF
--- a/docs/overnight/2026-05-07-30min-extension/inbox-action-plan.md
+++ b/docs/overnight/2026-05-07-30min-extension/inbox-action-plan.md
@@ -1,0 +1,234 @@
+# Inbox 30 Minute Extension Action Plan
+
+Date: 2026-05-07
+Repo: inbox
+Branch: codex/goal-inbox-30min-action-plan
+Base HEAD: 2805b8400519da188ca7d3f6e39b19a8ca42b05a
+
+## Scope
+
+This was a read-only planning audit of the inbox repo. I did not edit product code. The only intended repo change from this worker is this report.
+
+The audit focused on:
+
+- repo docs and stated product direction
+- current validation surface
+- recent merged work that already covered overnight-style concerns
+- index, sync, TUI, MCP, account routing, and task-link handoff gaps
+
+## Previous Report Reconciliation
+
+No prior overnight report was present in this worktree. `docs/` only contained `docs/TESTING_FOR_AGENTS.md` before this report, and searches for `docs/overnight`, `runs/**/result.json`, `runs/**/handoff.md`, and `handoff.md` found no repo-local artifacts to reconcile.
+
+What recent repo work already covered:
+
+- `a821b5a Make indexed inbox views the default` added indexed client/server behavior and tests across `inbox_client.py`, `inbox_server.py`, `message_index_store.py`, and API tests.
+- `05fc249 Add index sync health endpoint` added `/index/health` and server tests.
+- `44be0c8 Avoid large thread cleanup expressions` hardened `message_index_store.py` rebuild cleanup for large thread sets.
+- `9825e50 Fix TUI refresh snapshots` repaired TUI refresh state around indexed views.
+
+What is still missing:
+
+- There is no recorded implementation queue item tying these index improvements to MCP tools, TUI stale-state behavior, or automatic freshness recovery.
+- There is no repo-local overnight report preserving the validation state and blockers found below.
+- Some docs still describe old health claims, especially total tests and "all tests pass" claims.
+
+## Current Repo Health
+
+Commands run:
+
+- `git status --short`: passed before edits with no output.
+- `UV_CACHE_DIR=/private/tmp/uv-cache-inbox uv run ruff check .`: passed with `All checks passed!`.
+- `UV_CACHE_DIR=/private/tmp/uv-cache-inbox INBOX_TEST_MODE=1 uv run pytest -m safe -q`: passed, `11 passed, 855 deselected in 10.25s`.
+- `UV_CACHE_DIR=/private/tmp/uv-cache-inbox INBOX_TEST_MODE=1 uv run pytest tests/test_message_sync.py tests/test_message_index_store.py tests/test_server.py::TestIndexEndpoints tests/test_api_contract.py -q`: passed, `37 passed in 7.89s`.
+- `UV_CACHE_DIR=/private/tmp/uv-cache-inbox uv run pyright`: failed with 108 errors.
+
+Validation caveat:
+
+- Running `INBOX_TEST_MODE=1 uv run pytest -m safe -q` without `UV_CACHE_DIR` initially failed because the sandbox could not open `/Users/jwalinshah/.cache/uv/sdists-v9/.git`. Use `UV_CACHE_DIR=/private/tmp/uv-cache-inbox` in this worktree.
+
+Known type blockers from `pyright`:
+
+- `inbox.py:1888`, `inbox.py:1896`, `inbox.py:1907`, `inbox.py:1909`, `inbox.py:1923`, `inbox.py:1927`, `inbox.py:1931`: Textual `Widget` narrowing issues around list/table cursor actions.
+- `inbox.py:4131`: unresolved `agents.runner` import.
+- `inbox_mcp_readonly.py:47`: `ambient_notes.VAULT_DIR` is referenced, but the module exposes `VAULT_PATH`, `DAILY_DIR`, and `AMBIENT_DIR` in tests.
+- `inbox_server.py:3905` through `inbox_server.py:3909`: unresolved `gemma4_hackathon.silos.*` imports.
+- `services.py` has many dynamic Google API and macOS framework attribute errors, especially around `Quartz`, Accessibility APIs, Sheets, Docs, Drive, and Calendar service objects.
+
+## Concrete File Observations
+
+1. `PLAN.md` defines the active product direction as an indexed local-first inbox OS, not raw provider tabs. Phase 1 explicitly prioritizes reliable bootstrap/incremental sync, indexed endpoints, and a TUI home surface.
+
+2. `message_index_store.py:86` to `message_index_store.py:160` defines the local operational index tables: `sync_state`, `items`, `threads`, and `sender_stats`. The schema already has status, run-start, metadata, and last-error fields needed for health reporting.
+
+3. `message_index_store.py:239` to `message_index_store.py:356` implements `set_sync_state`, `mark_sync_started`, `update_sync_progress`, `record_sync_error`, and sync-state reads. This gives implementation agents a durable checkpoint/status surface instead of relying on logs.
+
+4. `message_index_store.py:407` to `message_index_store.py:563` rebuilds thread rows from indexed items, refreshes sender stats, classifies each thread, and deletes stale thread rows within the rebuild scope. The recent temp-table cleanup avoids expression depth failures.
+
+5. `message_index_store.py:565` to `message_index_store.py:612` supports the indexed views with filters for `actionable_only`, `newest_only`, explicit actions, `needs_reply`, `has_open_loop`, `latest_sender`, and priority/recent sorting.
+
+6. `message_sync.py:181` to `message_sync.py:269` implements resumable Gmail bootstrap using saved `bootstrap_page_token`, timestamp checkpoint metadata, and an optional Gmail history cursor after full sync.
+
+7. `message_sync.py:272` to `message_sync.py:420` implements Gmail incremental sync through history API when a cursor is present, with timestamp fallback when the cursor or history API is missing.
+
+8. `message_sync.py:498` to `message_sync.py:580` advances iMessage rowid checkpoints even when rows are skipped because message bodies are empty or cleaned away. Tests cover this behavior.
+
+9. `message_sync.py:602` to `message_sync.py:627` rebuilds only changed Gmail/iMessage scopes after bootstrap or incremental sync. This is the right shape for cheap recurring sync work.
+
+10. `inbox_server.py:2771` to `inbox_server.py:2807` maps named index views to store queries. The server supports `actionable`, `recent`, `waiting-on-me`, `waiting-on-others`, and `waiting-on`.
+
+11. `inbox_server.py:2810` to `inbox_server.py:2898` marks index health stale after 30 minutes and reports `no_sync_state`, `missing_checkpoint`, `stale_checkpoint`, and `sync_error`.
+
+12. `inbox_server.py:3739` to `inbox_server.py:3802` makes `/inbox/needs-action` use index threads only and explicitly avoids live Gmail thread fallback when the index is empty.
+
+13. `inbox_server.py:3820` to `inbox_server.py:3853` exposes `/index/status`, `/index/health`, `/index/views/{view_name}`, `/index/sync/bootstrap`, and `/index/sync/incremental`.
+
+14. `inbox_client.py:90` to `inbox_client.py:131` already has client helpers for index status, health, generic index view, recent, actionable, waiting-on-me, and waiting-on-others.
+
+15. `inbox.py:1702` to `inbox.py:1723` renders the TUI `Now`, `Actionable`, and `Waiting On` indexed lists. `inbox.py:2328` to `inbox.py:2349` refreshes `recent`, `actionable`, and `waiting-on`, but does not consume `waiting-on-me`, `waiting-on-others`, or `/index/health`.
+
+16. `inbox.py:2720` to `inbox.py:2749` shows indexed thread summaries as a synthetic message from "Inbox Index", which keeps the first view compact but leaves raw-thread drilldown as a future UX problem.
+
+17. `tui_tabs.py:16` to `tui_tabs.py:48` makes `Now`, `Actionable`, and `Waiting On` first-class tabs before raw source tabs. This matches the phase-1 information architecture.
+
+18. `google_account_resolution.py:24` to `google_account_resolution.py:33` honors `INBOX_DEFAULT_GOOGLE_ACCOUNT` only if the account exists in the service map. `config/inbox.env.example` does not document this variable yet.
+
+19. `google_account_resolution.py:85` to `google_account_resolution.py:106` resolves Gmail reply ownership from explicit account, conversation cache, or live message/thread existence before falling back to default.
+
+20. `google_account_resolution.py:160` to `google_account_resolution.py:304` already has a preflight payload builder for Drive/Docs/Sheets, Tasks, and Calendar write destinations.
+
+21. `tools_registry.py` centralizes MCP tool definitions and confirm gates. A search for `/index`, `index_health`, `index_status`, `index_view`, and `indexed_` across `tools_registry.py`, `mcp_backend.py`, `mcp_server.py`, and `inbox_mcp_readonly.py` found no index MCP tools yet.
+
+22. `mcp_gateway.py` authenticates public MCP requests with `INBOX_MCP_TOKEN` while `mcp_backend.py` forwards `INBOX_SERVER_TOKEN` to the private REST server. `tests/test_mcp_gateway.py:18` marks these tests safe and `tests/test_mcp_gateway.py:44` to `tests/test_mcp_gateway.py:51` covers public token rejection/acceptance.
+
+23. `tools_registry.py:630` to `tools_registry.py:666` exposes task-message linking tools over MCP, including `create_task_from_message`.
+
+24. `inbox_server.py:441` to `inbox_server.py:450` defines `TaskFromMessageRequest` without a due-date field. `inbox_server.py:2152` to `inbox_server.py:2191` creates a task, then finds the newly-created task by matching title from `tasks_list`, which is brittle when duplicate task titles exist.
+
+25. `services.py:3164` to `services.py:3183` returns only `bool` from `task_create`, discarding the Google Tasks API response that could provide a durable task id.
+
+26. `docs/TESTING_FOR_AGENTS.md` correctly tells agents to use `INBOX_TEST_MODE=1`, safe pytest markers, ruff, and pyright. `pyproject.toml` registers `safe`, `integration`, `local_data`, `slow`, and `live_write` markers.
+
+27. `DOCS_INDEX.md:44` and `DOCS_INDEX.md:140` still claim `uv run pytest` has 736 passing tests and that all 736 tests pass. The safe-marker run collected 866 tests total (`11 passed, 855 deselected`), and full pyright currently fails.
+
+## Risks And Blockers
+
+- `pyright` is not a passing validation gate today. It reports 108 errors across product code, tests, dynamic Google clients, macOS APIs, and missing optional modules.
+- Index freshness exists as an endpoint but is not surfaced in the TUI. A stale or never-built index can make `Now` look empty without clearly telling the user why.
+- The TUI consumes the broad `waiting-on` view but leaves server/client support for `waiting-on-me` and `waiting-on-others` unused.
+- MCP clients cannot currently ask for compact indexed views or index health even though the REST and TUI layers can.
+- `create_task_from_message` can link the wrong Google Task when task titles collide, because `task_create` drops the inserted task response and the server re-queries by title.
+- Live provider health was not validated. This audit avoided local personal data, live Google writes, AppleScript writes, microphone access, and external services.
+- No previous overnight report was available, so there was no prior report content to explicitly close out.
+
+## Implementation Queue
+
+### 1. Surface Index Freshness In The TUI
+
+Owned files:
+
+- `inbox_client.py`
+- `inbox.py`
+- `tests/test_client.py`
+- `tests/test_inbox_app.py`
+- `tests/test_server.py`
+
+Acceptance criteria:
+
+- `InboxClient.index_health()` is used by the TUI refresh path.
+- The `Now` and indexed tab status bars show stale/no-sync/error reasons when `/index/health` is unhealthy.
+- A stale index does not silently render as just an empty useful inbox.
+- Tests cover healthy index, `no_sync_state`, `stale_checkpoint`, and `sync_error` status text.
+- Validation: `UV_CACHE_DIR=/private/tmp/uv-cache-inbox INBOX_TEST_MODE=1 uv run pytest tests/test_client.py tests/test_inbox_app.py tests/test_server.py::TestIndexEndpoints -q`.
+
+### 2. Split Waiting-On TUI Into Me vs Others
+
+Owned files:
+
+- `tui_tabs.py`
+- `inbox.py`
+- `inbox_client.py`
+- `tests/test_tui_tabs.py`
+- `tests/test_client.py`
+- `tests/test_inbox_app.py`
+
+Acceptance criteria:
+
+- The TUI exposes separate views for `waiting-on-me` and `waiting-on-others`, or a clear toggle within Waiting On.
+- `waiting-on-me` calls the existing `/index/views/waiting-on-me` path.
+- `waiting-on-others` calls the existing `/index/views/waiting-on-others` path.
+- The older `waiting-on` track/open-loop view remains available or is intentionally renamed.
+- Tests assert the correct endpoint names and status text for each view.
+- Validation: `UV_CACHE_DIR=/private/tmp/uv-cache-inbox INBOX_TEST_MODE=1 uv run pytest tests/test_tui_tabs.py tests/test_client.py tests/test_inbox_app.py -q`.
+
+### 3. Expand Thread Classification Fixtures Before Changing Heuristics
+
+Owned files:
+
+- `thread_classifier.py`
+- `tests/test_thread_classifier.py`
+- `tests/test_message_index_store.py`
+- optional helper file if fixtures become repetitive
+
+Acceptance criteria:
+
+- Add representative tests for recruiter outreach, direct human follow-up, newsletter/job alert, receipt/order, OTP, security alert, medical appointment, and billing/admin follow-up.
+- Tests pin `noise_class`, `topic`, `urgency`, `actionability`, `needs_reply`, and `open_loop`.
+- Existing OTP ignore behavior remains unchanged.
+- Classifier changes, if any, are limited to improving failures in those fixtures.
+- Validation: `UV_CACHE_DIR=/private/tmp/uv-cache-inbox INBOX_TEST_MODE=1 uv run pytest tests/test_thread_classifier.py tests/test_message_index_store.py -q`.
+
+### 4. Expose Compact Index Tools Through MCP
+
+Owned files:
+
+- `tools_registry.py`
+- `mcp_backend.py`
+- `tests/test_tools_registry.py`
+- `tests/test_api_contract.py`
+- `tests/test_mcp_gateway.py`
+- `MCP_SETUP.md`
+
+Acceptance criteria:
+
+- Add read-only MCP tools for index health/status and named indexed views.
+- Add confirm-gated MCP tools for `/index/sync/incremental` and, if included, `/index/sync/bootstrap`.
+- Read-only MCP registration includes only safe index read tools.
+- Full MCP registration includes sync tools with `confirm=True`.
+- API-contract tests prove every new MCP tool routes to a FastAPI endpoint.
+- Docs explain that local assistants should prefer compact index tools before raw Gmail/iMessage reads.
+- Validation: `UV_CACHE_DIR=/private/tmp/uv-cache-inbox INBOX_TEST_MODE=1 uv run pytest tests/test_tools_registry.py tests/test_api_contract.py tests/test_mcp_gateway.py -q`.
+
+### 5. Make Task-From-Message Linking Use Durable Task IDs
+
+Owned files:
+
+- `services.py`
+- `inbox_server.py`
+- `inbox_client.py`
+- `mcp_backend.py`
+- `tools_registry.py`
+- `scheduler.py`
+- `tests/test_server.py`
+- `tests/test_client.py`
+- `tests/test_tools_registry.py`
+
+Acceptance criteria:
+
+- `task_create` returns the created Google Task id or task payload instead of only `bool`.
+- `/tasks/from-message` links the created task by returned id, not by re-querying recent tasks by title.
+- Duplicate task titles cannot cause a link to point at the wrong task.
+- The endpoint response includes resolved account, list id, task source, task id, and link id.
+- MCP and client helpers preserve the same response shape.
+- Tests cover duplicate-title safety and existing Reminder fallback behavior.
+- Validation: `UV_CACHE_DIR=/private/tmp/uv-cache-inbox INBOX_TEST_MODE=1 uv run pytest tests/test_server.py tests/test_client.py tests/test_tools_registry.py -q`.
+
+## Suggested Order
+
+1. Surface index freshness in TUI.
+2. Expose compact index tools through MCP.
+3. Split waiting-on views.
+4. Expand classifier fixtures.
+5. Fix task-from-message durable IDs.
+
+This order keeps the default indexed inbox path observable first, lets agents consume the same compact state, then improves classification and task handoff safety.

--- a/docs/overnight/inbox-docs-claims.md
+++ b/docs/overnight/inbox-docs-claims.md
@@ -1,0 +1,384 @@
+# inbox-docs-claims
+
+Queue item: `inbox-docs-claims`
+Repo: `inbox`
+Focus area: docs claims
+Branch observed: `codex/goal-inbox-docs-claims`
+HEAD observed: `2805b8400519da188ca7d3f6e39b19a8ca42b05a`
+Report date: 2026-05-07
+
+## Scope And Method
+
+This is a read-only documentation-claims audit. Product code, generated data,
+secrets, external services, deploys, pushes, PR creation, and tracker updates
+were out of scope. The only intended filesystem change is this report:
+`docs/overnight/inbox-docs-claims.md`.
+
+Initial dirty state was clean:
+
+```text
+$ git status --short --branch
+## codex/goal-inbox-docs-claims
+```
+
+The repo purpose, as supported by `README.md` and `CLAUDE.md`, is a local
+Python/Textual/FastAPI personal inbox that unifies iMessage, Gmail, Google
+Calendar, Google Sheets, Apple Notes, Apple Reminders, GitHub notifications,
+Google Drive, Google Docs, Google Tasks, voice/ambient capture, and MCP access.
+The code is a flat Python application rather than a package tree.
+
+## Commands Run
+
+- `llm-tldr tree .` - mapped repo structure, including top-level app files,
+  docs, config examples, deploy examples, scripts, modes, batch helpers, and
+  31 test files.
+- `git status --short --branch` - confirmed starting branch and clean dirty
+  state.
+- `git rev-parse HEAD` - recorded
+  `2805b8400519da188ca7d3f6e39b19a8ca42b05a`.
+- `rg --files -g '*.md'` - found 18 Markdown files, not the six docs claimed
+  by `DOCS_INDEX.md`.
+- `rg -n "@app\.(get|post|put|delete|patch)" inbox_server.py | wc -l` -
+  found 159 FastAPI endpoint decorators.
+- `rg -n "^\s*Tool\(" tools_registry.py | wc -l` - found 60 MCP registry
+  tools.
+- `rg --files tests | wc -l` - found 31 test files.
+- `rg -n "^def test_|^    def test_" tests | wc -l` - found 864 static
+  `test_` definitions.
+- `rg -n "pytestmark = pytest\.mark\.safe|@pytest\.mark\.safe" tests` -
+  found only `tests/test_inbox_test_mode.py` and `tests/test_mcp_gateway.py`
+  marked safe at module/decorator level.
+- `test -e .claude/skills/inbox/SKILL.md && echo present || echo missing` -
+  confirmed the documented slash-command skill router is absent in this
+  checkout.
+
+## Evidence Inventory
+
+1. `README.md:1-27` claims a unified communication/productivity TUI with
+   iMessage, Gmail, Calendar, Sheets, Notes, Reminders, GitHub, Drive, ambient
+   listening, dictation, autocomplete, optimistic UI, client-server split, local
+   ML, and multi-account Gmail routing.
+2. `README.md:31-45` says requirements are Python 3.10+, macOS, and `uv`, and
+   gives `uv run python inbox.py` / `uv run python inbox_server.py`.
+3. `pyproject.toml:1-25` is stronger evidence for runtime support than the
+   README: it requires Python `>=3.12,<3.15` and declares FastAPI, Textual,
+   MLX, Outlines, MCP, Google API clients, PyObjC, sounddevice, Rich, and
+   Uvicorn dependencies.
+4. `pyproject.toml:53-62` configures pytest to use `tests` and coverage, and
+   registers safe/integration/local_data/slow/live_write markers.
+5. `CLAUDE.md:118-190` lists a broad endpoint catalog, but
+   `inbox_server.py:1346-3896` currently exposes 159 FastAPI endpoint
+   decorators, including many endpoints absent from the short README.
+6. `inbox_server.py:2596-2761` supports the Sheets endpoint family listed in
+   the Sheets docs: list, create, get, delete, range read/write/append/clear,
+   batch get/update, tab add/delete/rename/copy, and formatting.
+7. `services.py:4083-4388` implements the Sheets service operations. Most
+   mutating operations call `_assert_live_write_allowed`, but
+   `sheets_rename_sheet`, `sheets_format`, and `sheets_copy_to` do not.
+8. `inbox_server.py:2932-2998` supports Google Docs list/create/get/delete/text
+   insert/export endpoints.
+9. `services.py:4437-4474` blocks live writes for Docs create/delete, but
+   `services.py:4476-4495` inserts text without `_assert_live_write_allowed`.
+10. `google_account_resolution.py:24-33` implements
+    `INBOX_DEFAULT_GOOGLE_ACCOUNT` fallback for service selection; this supports
+    the connector-roadmap direction that default account routing should be in
+    code.
+11. `google_account_resolution.py:85-106` resolves Gmail replies by explicit
+    account, cached message/thread owner, message/thread existence probes, then
+    default fallback. `inbox_server.py:1581-1594` returns the resolved account
+    for Gmail replies.
+12. `tools_registry.py:1-11` says one central table drives full and read-only
+    MCP servers. `tools_registry.py:110-119` filters by `readonly_only`, and
+    `tests/test_tools_registry.py:41-53` asserts all mutating tools are
+    confirmation-gated and read-only registration excludes write tools.
+13. `mcp_server.py:34-38` creates a stateless HTTP `FastMCP`; `mcp_server.py:148-151`
+    runs Uvicorn on `127.0.0.1:8000`. This contradicts older `CLAUDE.md`
+    language calling `mcp_server.py` stdio-based.
+14. `inbox_mcp_stdio.py:13-17` is the actual local stdio entrypoint for the full
+    tool surface; `inbox_mcp_readonly_stdio.py:7-11` is the actual read-only
+    stdio entrypoint.
+15. `.mcp.json:1-28`, `config/codex.inbox.example.toml:1-28`, and
+    `MCP_SETUP.md:144-169` support the two-token routing claim:
+    `INBOX_SERVER_TOKEN` protects the private backend and `INBOX_MCP_TOKEN`
+    protects the public MCP gateway.
+16. `.gitignore:12-24` supports the credential-storage claims for
+    `credentials.json`, `token.json`, `tokens/`, `github_token.txt`,
+    `google_maps_key.txt`, `gemini_api_key.txt`, `config/inbox.env`, and env
+    files.
+17. `docs/TESTING_FOR_AGENTS.md:1-43` documents a safe validation policy:
+    `INBOX_TEST_MODE=1 uv run pytest -m safe`, `uv run ruff check .`, and
+    `uv run pyright`, with live/local data requiring explicit opt-in.
+18. `inbox_test_mode.py:18-31` implements test mode and test-local data roots.
+    `tests/test_services.py:909-951` verifies representative live-write blocks,
+    but it does not cover every mutating service function.
+19. `inbox.py:1179-1196` is the authoritative current keybinding list:
+    `ctrl+6` is Reminders, `ctrl+7` GitHub, `ctrl+8` Drive, `ctrl+shift+6`
+    Ambient, `ctrl+9` Actionable, and `ctrl+0` Waiting On.
+20. `README.md:120-123` and `CLAUDE.md:193-196` still claim `Ctrl+6` toggles
+    ambient listening. This is stale relative to `inbox.py:1179-1196` and
+    `tests/test_inbox_app.py:706-718`.
+21. `tui_tabs.py:19-120` defines ten tabs: Now, Actionable, Waiting On,
+    iMessage, Gmail, Calendar, Notes, Reminders, GitHub, and Drive. README's
+    keybinding table still describes only the older All/iMessage/Gmail/Calendar
+    /Notes plus GitHub layout.
+22. `DOCS_INDEX.md:101-111` explicitly admits quickstart/changelog coverage is
+    Sheets-only; this is a useful non-claim for Gmail, Calendar, Drive,
+    iMessage, Notes/Reminders, and GitHub.
+23. `DOCS_INDEX.md:173-175` says total documentation is six files. Static local
+    inventory found 18 Markdown files, including `MCP_SETUP.md`,
+    `CONNECTOR_ROADMAP.md`, `PLAN.md`, `docs/TESTING_FOR_AGENTS.md`, and
+    `modes/*.md`.
+24. `CLAUDE.md:338-350` claims first-class `/inbox` slash commands with router
+    `.claude/skills/inbox/SKILL.md`; the file is missing in this checkout, and
+    `.gitignore:40-41` ignores `.claude/`.
+25. `modes/batch-archive.md:45-50` tells agents to archive Gmail with
+    `add_label_ids: ["ARCHIVED"]` and `remove_label_ids: ["INBOX"]`, while
+    `batch/batch-runner.sh:74-80` uses `add_label_ids: []` and
+    `remove_label_ids: ["INBOX"]`. The shell runner looks more consistent with
+    Gmail archive semantics than the mode prompt.
+
+## Supported Claims
+
+- The project is genuinely client-server: `inbox_server.py` owns FastAPI
+  endpoints and service access; `inbox_client.py` calls those endpoints; the TUI
+  in `inbox.py` uses the client. This matches README/CLAUDE architecture claims.
+- The repo has real Google Sheets API support at the service and server layers.
+  The endpoint set in `SHEETS.md` is mostly backed by `inbox_server.py` and
+  `services.py`.
+- The repo has real Google Docs support, though the docs surface is thinner than
+  Sheets and has a write-safety gap for text insertion.
+- The repo has real Google Tasks support despite older docs underemphasizing it:
+  `services.py:88-98` includes the tasks scope, `google_auth_all` returns a
+  tasks service dict, and `inbox_server.py:2006-2054` exposes task endpoints.
+- Token and credential non-commit claims are supported by `.gitignore`.
+- MCP read-only vs full surfaces exist and are enforced at registry registration
+  time for registry-backed tools.
+- The documented test-safety concept exists in code: test mode redirects data
+  roots and blocks many representative live writes.
+- The connector-roadmap account-routing direction is partly implemented:
+  `INBOX_DEFAULT_GOOGLE_ACCOUNT` is honored by shared service-resolution helpers
+  and covered by tests in `tests/test_server.py`.
+
+## Unsupported Or Stale Claims
+
+- Python version support is stale. `README.md:31-34` says Python 3.10+, but
+  `pyproject.toml:5` requires `>=3.12,<3.15`; `pyproject.toml:48-50` sets
+  pyright to Python 3.12.
+- The 736 passing test claim is stale or at least unevidenced in this checkout.
+  `DOCS_INDEX.md:40-45`, `DOCS_INDEX.md:134-140`, and
+  `SHEETS_CHANGELOG.md:38,114-121` cite 736 pass / production-ready. Static
+  local inventory found 31 test files and 864 `test_` definitions, and no test
+  run artifact was present in this audit.
+- Current keybindings are stale in README and CLAUDE. `Ctrl+6` no longer
+  toggles ambient; code and tests make it Reminders. Ambient moved to
+  `Ctrl+Shift+6`; Drive, Actionable, and Waiting On also have keybindings that
+  the old docs do not explain.
+- `CLAUDE.md:274-278` says `mcp_server.py` is stdio-based and agents can use MCP
+  without hitting the server HTTP API. Current code makes `mcp_server.py` an HTTP
+  Uvicorn app; the stdio wrapper is `inbox_mcp_stdio.py`, which imports the HTTP
+  tool surface and runs it over stdio.
+- "Exposes all inbox functionality" is too broad for MCP. The FastAPI app has
+  159 endpoint decorators; the central registry has 60 tools plus a few
+  hand-written memory/note tools. This is a curated surface, not all endpoints.
+- `DOCS_INDEX.md` is no longer a complete documentation index. It claims six
+  docs, but the repo contains 18 Markdown files and several operational docs are
+  not represented in the coverage table.
+- The slash-command claim is unsupported in this checkout because
+  `.claude/skills/inbox/SKILL.md` is absent.
+- "All mutations return operation stats" for Sheets is too broad:
+  create/get/delete/tab operations return metadata or `{"ok": bool}` in
+  `inbox_server.py:2612-2761`, while only values operations naturally return
+  Google update/append stats.
+- "Tests (stubs ML/macOS deps)" is broadly plausible from `conftest.py` and
+  test coverage, but `docs/TESTING_FOR_AGENTS.md` is the safer source for agent
+  validation because it distinguishes safe, local-data, and live-write classes.
+
+## Risks And Stale Assumptions
+
+1. Documentation can lead users to run with an unsupported Python version.
+   README's Python 3.10+ claim conflicts directly with `pyproject.toml`.
+2. Safe test-mode claims are too broad. Several mutating functions lack
+   `_assert_live_write_allowed`: `sheets_rename_sheet`, `sheets_format`,
+   `sheets_copy_to`, and `docs_insert_text`. Direct server endpoint calls can
+   reach those functions in test mode.
+3. MCP docs are split-brain. `MCP_SETUP.md` matches the current HTTP/stdout
+   architecture better than `CLAUDE.md`, so agents using `CLAUDE.md` may point
+   clients at the wrong entrypoint.
+4. The slash-command docs depend on ignored local state. A fresh clone or
+   isolated worktree will not have `.claude/skills/inbox/SKILL.md`, so `/inbox`
+   commands are not reproducible from tracked files alone.
+5. Test-count and "production-ready" claims look like release-note residue.
+   Static test inventory no longer lines up with the cited count, and the docs
+   do not say which commit produced the passing run.
+6. Keybinding drift is user-facing. Users following README/CLAUDE would press
+   `Ctrl+6` expecting ambient listening and land on Reminders instead.
+7. The batch archive mode prompt and shell runner disagree on Gmail archive
+   label mutation. Agents following the prompt could try to add a nonstandard
+   `ARCHIVED` label.
+8. Docs use broad "full API" language for Sheets and MCP. The implementation is
+   useful and broad, but not every Google Sheets API concept or every inbox
+   endpoint is exposed as a first-class safe tool.
+
+## Next Safe Work
+
+### Task 1: Refresh Core Docs To Match Current Runtime
+
+Acceptance criteria:
+- `README.md` says Python `>=3.12,<3.15` or links to `pyproject.toml` as the
+  source of truth.
+- README and CLAUDE keybindings match `inbox.py:1179-1196`.
+- README mentions Reminders, Drive, Actionable, Waiting On, and Ambient's
+  current `Ctrl+Shift+6` binding.
+- `CLAUDE.md` describes `mcp_server.py` as HTTP and
+  `inbox_mcp_stdio.py` / `inbox_mcp_readonly_stdio.py` as stdio.
+
+Validation candidates:
+- `git diff -- README.md CLAUDE.md`
+- `INBOX_TEST_MODE=1 uv run pytest tests/test_tui_tabs.py tests/test_inbox_app.py -q`
+- Expected status: docs diff should show only claim corrections; focused tests
+  are expected to pass if dependencies are installed.
+
+### Task 2: Close Test-Mode Write-Safety Gaps
+
+Acceptance criteria:
+- Add `_assert_live_write_allowed(...)` to every Google Sheets and Google Docs
+  mutating service function, including rename, format, copy, and insert text.
+- Extend `tests/test_services.py::test_test_mode_blocks_extended_live_writes`
+  or add focused tests so those paths are covered.
+- Update `docs/TESTING_FOR_AGENTS.md` only if the validation command changes.
+
+Validation candidates:
+- `INBOX_TEST_MODE=1 uv run pytest tests/test_services.py::test_test_mode_blocks_extended_live_writes -q`
+- `INBOX_TEST_MODE=1 uv run pytest -m safe`
+- Expected status: focused test should pass after implementation; full safe set
+  should pass if environment dependencies are installed.
+
+### Task 3: Make Docs Index A Real Inventory
+
+Acceptance criteria:
+- `DOCS_INDEX.md` lists all tracked Markdown docs or explicitly scopes itself
+  to "core user docs" and links to an operational-docs section.
+- Remove hard-coded "736 tests pass" and replace it with validation command
+  guidance plus "last verified" format that includes commit/date when known.
+- Reconcile `SHEETS_CHANGELOG.md` release-note claims so they do not state a
+  stale pass count as current fact.
+
+Validation candidates:
+- `rg --files -g '*.md'`
+- `rg -n "736|production-ready|Total documentation" DOCS_INDEX.md SHEETS_CHANGELOG.md`
+- Expected status: inventory command should match the index or the index should
+  explain its scope; stale pass-count search should return no current claims.
+
+### Task 4: Make Slash Commands Reproducible Or Downgrade The Claim
+
+Acceptance criteria:
+- Either commit a tracked skill/router equivalent for `/inbox` commands, or
+  change `CLAUDE.md` to say the tracked `modes/*.md` files are prompts and the
+  slash-command router is local-only if installed.
+- Document how a fresh worktree should invoke `modes/morning-brief.md`,
+  `modes/triage.md`, `modes/followup-sweep.md`, and `modes/batch-archive.md`
+  without relying on ignored `.claude/` state.
+
+Validation candidates:
+- `test -e .claude/skills/inbox/SKILL.md && echo present || echo missing`
+- `rg -n "Skill router|/inbox|modes/" CLAUDE.md modes`
+- Expected status: either router exists or docs no longer claim tracked
+  first-class slash commands.
+
+### Task 5: Reconcile Batch Archive Prompt With Runner
+
+Acceptance criteria:
+- `modes/batch-archive.md` uses the same Gmail archive payload as
+  `batch/batch-runner.sh`: remove `INBOX`, do not add `ARCHIVED`.
+- Document that iMessage archive is unsupported by the runner unless/until
+  implemented.
+
+Validation candidates:
+- `rg -n "ARCHIVED|batch-modify|unsupported source" modes/batch-archive.md batch/batch-runner.sh`
+- Expected status: mode and runner agree on the Gmail payload and unsupported
+  source behavior.
+
+## Validation Map
+
+Required queue validation:
+
+```bash
+git status --short
+```
+
+Expected final result after this report is written: the output should show only
+`docs/overnight/inbox-docs-claims.md` as an added/untracked report file.
+
+Agent-safe validation from tracked docs:
+
+```bash
+INBOX_TEST_MODE=1 uv run pytest -m safe
+uv run ruff check .
+uv run pyright
+```
+
+Expected status: not run for this docs-only audit because the queue item only
+requires `git status --short`, product code changes were out of scope, and a
+full test/type/lint loop may need dependencies and create local caches. These
+are the correct next commands for implementation tasks.
+
+Focused docs/safety commands:
+
+```bash
+INBOX_TEST_MODE=1 uv run pytest tests/test_inbox_test_mode.py -q
+INBOX_TEST_MODE=1 uv run pytest tests/test_tools_registry.py -q
+INBOX_TEST_MODE=1 uv run pytest tests/test_tui_tabs.py -q
+```
+
+Expected status: should pass if dependencies are installed. These target the
+specific docs-claim surfaces: test mode docs, MCP registry confirmation gates,
+and current tab metadata.
+
+## Non-Goals
+
+- No product-code changes.
+- No test, lint, or type fixes.
+- No external credential checks.
+- No live server startup.
+- No Google, GitHub, AppleScript, microphone, WhatsApp, Drive, Docs, Sheets, or
+  Calendar calls.
+- No PR, push, deploy, or tracker update.
+- No attempt to validate personal data paths under `~/Library`.
+
+## Unknowns
+
+- Whether the full test suite currently passes on a fully provisioned macOS
+  machine.
+- Which commit, if any, produced the "736 tests pass" claim.
+- Whether the ignored `.claude/skills/inbox/SKILL.md` exists in the user's
+  primary checkout outside this isolated worktree.
+- Whether all OAuth scopes are currently granted for the user's local tokens.
+- Whether remote/cloud MCP deployment is currently active; this audit only
+  checked tracked local code and examples.
+- Whether `repos.json` has sibling repos with overlapping docs; this queue item
+  was scoped to the `inbox` repo and did not require touching unrelated repos.
+
+## Handoff
+
+Changed files:
+- `docs/overnight/inbox-docs-claims.md`
+
+Commit SHA:
+- Current HEAD at audit time:
+  `2805b8400519da188ca7d3f6e39b19a8ca42b05a`
+
+PR URL:
+- None. PR creation was out of scope for this queue item.
+
+Blockers:
+- None for writing this report.
+
+Validation result:
+- Ran `git status --short`; exit code 0. Output:
+
+```text
+?? docs/overnight/
+```
+
+This is expected for a new untracked report directory containing only
+`docs/overnight/inbox-docs-claims.md`.

--- a/docs/overnight/inbox-risk-register.md
+++ b/docs/overnight/inbox-risk-register.md
@@ -1,0 +1,356 @@
+# inbox-risk-register
+
+Deep read-only risk-register audit for the `inbox` repo.
+
+## Scope And State
+
+- Queue item: `inbox-risk-register`
+- Repo path: `/Users/jwalinshah/projects/agent-stack/.agent-stack-worktrees/2026-05-07-overnight-marathon/inbox-risk-register`
+- Branch: `codex/goal-inbox-risk-register`
+- Starting HEAD: `2805b8400519da188ca7d3f6e39b19a8ca42b05a` (`Merge pull request #34 from jwalin-shah/codex/SYM-9-indexed-defaults`)
+- Starting dirty state: `git status --short --branch` returned only `## codex/goal-inbox-risk-register`.
+- Intended tracked change: this report only, at `docs/overnight/inbox-risk-register.md`.
+- Product code, generated data, credentials, deploys, pushes, and PR creation were out of scope.
+
+## Repo Purpose
+
+`inbox` is a local-first personal communication and productivity surface. The README describes a FastAPI backend plus Textual TUI and agent/MCP access for iMessage, Gmail, Google Calendar, Sheets, Docs, Drive, Tasks, Apple Notes, Apple Reminders, GitHub notifications, WhatsApp, ambient audio capture, dictation, local ML, and cross-silo search. The practical risk profile is high because the same repo reads local personal databases, stores derived indexes, holds OAuth/PAT/API-key material locally, and exposes many live-write operations through HTTP and MCP.
+
+## Commands Run And Observations
+
+- `llm-tldr tree .`: repo has one large Python app surface with `services.py`, `inbox_server.py`, `inbox_client.py`, MCP entrypoints, deployment examples, `tests/`, `batch/`, and config examples.
+- `git status --short --branch`: clean at audit start; no tracked or untracked files were reported before this report was written.
+- `git log --oneline -5`: recent HEAD is the indexed-defaults merge after thread rebuild and sync-health work.
+- `rg -n "@app\.|app\.(get|post|put|delete)\(" inbox_server.py`: found a broad REST surface, including message send, Gmail archive/delete/reply, Calendar, Reminders, Tasks, Drive, Sheets, Docs, scheduler, index sync, and workflow creation endpoints.
+- `llm-tldr search "TOKEN|SECRET|PASSWORD|OPENAI|GMAIL|GOOGLE|IMESSAGE|INBOX_SERVER_TOKEN|ANTHROPIC|GEMINI" .`: found token paths and env handling in `services.py`, `inbox_server.py`, `mcp_gateway.py`, `.mcp.json`, `.cursor/mcp.json`, config examples, and docs.
+- `rg -n "assert_live|INBOX_TEST_MODE|live_write|_assert_live_write_allowed" services.py inbox_test_mode.py tests`: found a central live-write blocker used across Gmail, Google, Apple, WhatsApp, GitHub, notifications, and test coverage.
+- `uv run python - <<'PY' ... tools_registry ...`: counted `60` MCP registry tools: `29` read-only and `31` mutating; all mutating registry tools currently have `confirm=True`. This command created an ignored local `.venv`, and `git status --short --branch` still reported no tracked dirt before this report.
+- `rg -n "pytestmark = pytest.mark.safe|@pytest.mark.safe|@pytest.mark.local_data|@pytest.mark.live_write|@pytest.mark.integration|@pytest.mark.slow" tests`: only `tests/test_inbox_test_mode.py` and `tests/test_mcp_gateway.py` are module-marked safe, despite many tests being deterministic mocks.
+- `rtk read docs/TESTING_FOR_AGENTS.md`: agent-safe command guidance exists and requires `INBOX_TEST_MODE=1`.
+- `rg -n "archive|bulk|confirm|INBOX_SERVER_TOKEN|curl|POST|DELETE|dry" batch modes unsubscribe_*.py organize_inbox.py organize-inbox-helper.sh`: found a batch archive runner whose default path executes live Gmail archive calls unless `--dry-run` is passed.
+
+`llm-tldr context inbox_server.py require_auth` and similar context calls failed with "unrecognized arguments"; the audit fell back to `rg`, `rtk read`, and line-numbered slices with `nl`.
+
+## Evidence Map
+
+### Authentication And Exposure
+
+- `inbox_server.py:213` defines `INBOX_SERVER_TOKEN`.
+- `inbox_server.py:1317-1329` treats an unset token as authorized and accepts either `Authorization: Bearer` or `X-API-Key` when the token exists.
+- `inbox_server.py:1332-1340` applies the auth middleware to the whole FastAPI app.
+- `tests/test_server.py:371-410` verifies the intended behavior: no auth is required when the token is unset; a token gates requests when configured.
+- `README.md:50` documents backend auth as optional for `localhost:9849`.
+- `mcp_gateway.py:32-45` applies the same optional-token pattern to public MCP auth using `INBOX_MCP_TOKEN`.
+- `mcp_gateway.py:48-58` always allows `/health` through the public MCP middleware.
+- `mcp_gateway.py:73-79` includes `memory_db` path and `auth_enabled` in the health payload.
+- `deploy/Caddyfile.example` reverse-proxies public-looking MCP hosts to `127.0.0.1:8000` and `127.0.0.1:8001` with no Caddy-side auth.
+- `deploy/inbox-mcp.service.example` and `deploy/inbox-backend.service.example` both use `EnvironmentFile=/Users/jwalinshah/projects/inbox/config/inbox.env`.
+
+### Credential And OAuth Surface
+
+- `.gitignore:12-25` ignores `credentials.json`, `token.json`, `tokens/`, `github_token.txt`, `google_maps_key.txt`, `gemini_api_key.txt`, env files, and secret-like suffixes.
+- `services.py:57-66` resolves Google credentials and token storage under the repo by default, or under `INBOX_TEST_DATA_DIR` in test mode.
+- `services.py:84-86` reads GitHub, Google Maps, and Gemini keys from local files.
+- `services.py:88-98` requests broad Google scopes: Gmail readonly/modify/send/settings, Calendar, Drive, Sheets, Docs, and Tasks.
+- `services.py:335-416` loads every JSON token in `tokens/` and builds per-account service maps.
+- `services.py:419-437` can add or reauth Google accounts through local browser OAuth and writes per-account token JSON.
+- `config/inbox.env.example:1-9` documents separate backend and public MCP bearer tokens.
+- `.mcp.json:1-28` and `.cursor/mcp.json:1-28` pass `INBOX_SERVER_TOKEN` into both full and read-only stdio MCP servers.
+
+### Backend Live Writes
+
+- `services.py:114-119` delegates live-write blocking to `inbox_test_mode.assert_live_writes_allowed`.
+- `inbox_test_mode.py:18-24` blocks writes only when `INBOX_TEST_MODE` is truthy.
+- `services.py:576-623` sends iMessages via AppleScript and `osascript`.
+- `services.py:970-1084` sends Gmail replies, archives Gmail, follows List-Unsubscribe URLs or mailto links, and then archives the message.
+- `services.py:1087-1095` moves Gmail messages to trash.
+- `services.py:1607-1716` creates, updates, and deletes Google Calendar events.
+- `services.py:2335-2377` sends WhatsApp messages using Accessibility and synthesized keystrokes.
+- `services.py:2868-3092` completes, uncompletes, creates, edits, and deletes Apple Reminders through AppleScript.
+- `services.py:3164-3225` creates, completes, deletes, and updates Google Tasks.
+- `services.py:3912-3949` creates Drive folders and trashes Drive files.
+- `services.py:4083-4248` creates Sheets and updates/appends/clears sheet values.
+- `services.py:5504-5512` treats desktop notifications as live writes in test mode.
+- `tests/test_services.py:909-951` covers representative and extended write blocking for Gmail, Calendar, Apple Reminders, Tasks, Drive, Sheets, Docs, GitHub, notifications, and WhatsApp.
+
+### REST Write Surface
+
+- `inbox_server.py:1434-1450` exposes `/messages/send` for iMessage and Gmail replies.
+- `inbox_server.py:1489-1589` exposes Gmail archive/delete/unsubscribe/star/read/compose/reply actions.
+- `inbox_server.py:1819-1889` exposes Calendar create, quick create, update, and delete.
+- `inbox_server.py:1944-1994` exposes Reminder complete/uncomplete/create/update/delete.
+- `inbox_server.py:2028-2053` exposes Google Task create/complete/update/delete.
+- `inbox_server.py:2548-2588` exposes Drive upload, folder create, and delete.
+- `inbox_server.py:2612-2757` exposes Sheet create/delete/value writes/tab writes/format writes.
+- `inbox_server.py:2940-2989` exposes Docs create/delete/text/export flows.
+- `inbox_server.py:3844-3853` exposes index bootstrap and incremental sync.
+- `inbox_server.py:3856-3884` exposes workflow folder/doc/sheet creation.
+
+### MCP Surface
+
+- `tools_registry.py:1-12` centralizes MCP tool definitions for both full and read-only servers.
+- `tools_registry.py:52-107` adds a `confirm` keyword to confirm-gated tools and blocks when `confirm` is false.
+- `tools_registry.py:110-119` filters non-read-only tools when `readonly_only=True`.
+- `tools_registry.py:126-260` begins a registry that includes Gmail read tools, Gmail send, Sheet create/append, Gmail archive/read, and more.
+- Command observation: the registry has 60 tools, 31 mutating, 29 read-only, and no mutating registry tools missing `confirm=True`.
+- `mcp_server.py:41-45` confirmation-gates hand-written memory and note mutation tools.
+- `mcp_server.py:142` registers the full registry with `readonly_only=False`.
+- `inbox_mcp_readonly.py:44-50` still reads daily notes from the Obsidian vault.
+- `inbox_mcp_readonly.py:77` registers registry tools with `readonly_only=True`.
+- `tests/test_tools_registry.py:41-53` verifies all mutating registry tools require confirm and are excluded from read-only registration.
+- `tests/test_mcp_gateway.py:36-53` verifies MCP health bypass and bearer rejection/acceptance when `INBOX_MCP_TOKEN` is set.
+
+### Local Data Stores And Derived Personal Data
+
+- `services.py:67-80` reads iMessage, Notes, and Reminders SQLite paths directly from `~/Library/...` outside test mode.
+- `contacts.py:38-59` discovers AddressBook database paths under `~/Library/Application Support/AddressBook`.
+- `contacts.py:65-129` reads contacts, phone numbers, and emails from AddressBook SQLite.
+- `message_index_store.py:12-14` defaults the message index to `.inbox_index.sqlite3` under the repo.
+- `message_index_store.py:100-120` stores `sender`, `recipients_json`, `subject`, `snippet`, `body_text`, labels, and raw pointers.
+- `memory_store.py:9-10` defaults memory to `.inbox_memory.sqlite3`.
+- `memory_store.py:50-62` stores memory type, subject, content, source, confidence, status, expiration, and metadata.
+- `scheduler.py:15-16` defaults scheduling state to `.inbox_scheduler.sqlite3`.
+- `scheduler.py:70-80` stores scheduled message source, conversation id, plaintext text, send time, status, account, sent time, and error.
+- `.gitignore:40-43` ignores Claude state, memory DB, and scheduler DB; `.gitignore:58` ignores the index DB.
+
+### Scheduler And Deferred Side Effects
+
+- `inbox_server.py:816-817` constructs a scheduler store and message index store in global server state.
+- `inbox_server.py:982-1045` sends any due scheduled Gmail/iMessage messages and marks them sent or failed.
+- `inbox_server.py:1179-1192` runs scheduler, follow-up, and departure checks every 30 seconds.
+- `inbox_server.py:1269-1272` starts the scheduler task by default in the app lifespan.
+- `inbox_server.py:2061-2082` exposes list/create/cancel scheduled-message endpoints.
+- `scheduler.py:118-148` persists scheduled message text immediately.
+- `scheduler.py:181-204` selects pending messages due at or before now.
+- `scheduler.py:206-225` marks scheduled messages sent or failed.
+
+### Batch And Bulk Operations
+
+- `batch/archive-input.tsv:1` currently has only the TSV header and no queued archive items.
+- `batch/batch-runner.sh:15-19` defaults to `MODE=archive`, `PARALLEL=1`, `DRY_RUN=false`, and retries disabled.
+- `batch/batch-runner.sh:61-65` constructs an unused `AUTH_HEADER`; the actual curl uses inline token expansion later.
+- `batch/batch-runner.sh:74-80` posts directly to `/gmail/batch-modify` to remove the `INBOX` label.
+- `batch/batch-runner.sh:126-133` only avoids mutation when `--dry-run` is explicitly provided.
+- `modes/batch-archive.md:32-39` says the workflow should show a "Proceed? [y/N]" confirmation before archiving.
+- `modes/batch-archive.md:43-49` documents archiving through `/gmail/batch-modify`.
+- `unsubscribe_all_newsletters.py` and `unsubscribe_bulk.py` both have interactive confirmation prompts before bulk unsubscribe/archive operations.
+
+### Validation And Tooling
+
+- `pyproject.toml:1-18` requires Python `>=3.12,<3.15` despite README quickstart saying Python 3.10+.
+- `pyproject.toml:53-61` defines pytest markers for safe, integration, local_data, slow, and live_write.
+- `pyproject.toml:64-66` configures Bandit but skips several subprocess/assert-related checks (`B101`, `B110`, `B112`, `B404`, `B603`, `B607`).
+- `.pre-commit-config.yaml` runs Ruff, Ruff format, basic pre-commit hooks, `detect-private-key`, and Bandit with `pyproject.toml`.
+- `docs/TESTING_FOR_AGENTS.md:8-18` recommends `INBOX_TEST_MODE=1 uv run pytest -m safe`, `uv run ruff check .`, and `uv run pyright`.
+- `docs/TESTING_FOR_AGENTS.md:23-43` forbids local-data, live-write, and provider-specific integration tests unless explicitly opted in.
+- Command observation: only two test modules are currently marked `safe`, so `pytest -m safe` proves the new test-mode/MCP-auth guardrails but does not exercise most deterministic endpoint mocks.
+
+## Risk Register
+
+### R1: Optional Auth On High-Impact Local Backend
+
+Severity: high.
+
+The backend and public MCP gateway both allow all requests when their token env vars are unset. This is intentional and tested, but it is risky because the backend has write endpoints for Gmail, Calendar, Reminders, Tasks, Drive, Sheets, Docs, iMessage, WhatsApp, scheduler, and index sync. The MCP Caddy examples expose `/mcp*` externally and rely entirely on `INBOX_MCP_TOKEN` being set correctly. `/health` is unauthenticated on the public MCP gateway and leaks local path/status details.
+
+Safe next direction: fail closed for public HTTP modes and provide an explicit dev-only no-auth mode.
+
+### R2: Runtime Write Confirmation Exists In MCP, Not At The REST Boundary
+
+Severity: high.
+
+MCP registry tools are confirm-gated, but the REST endpoints call service write functions directly. Any client that can reach the backend and pass backend auth can call write endpoints without a second write-intent check. The test-mode guard is only for `INBOX_TEST_MODE`; in production it intentionally allows writes.
+
+Safe next direction: add a backend write policy that can require per-action confirmation or a short-lived write-intent token for all mutating endpoints, independent of the MCP caller.
+
+### R3: Broad OAuth Scopes And Account Fallback Can Mutate The Wrong Account
+
+Severity: high.
+
+Google OAuth scopes cover Gmail modify/send/settings, Calendar, Drive, Sheets, Docs, and Tasks. Multi-account resolution falls back to `INBOX_DEFAULT_GOOGLE_ACCOUNT` or the first service key. Some write endpoints accept optional account values and otherwise rely on fallback. `preflight_google_write_payload` exists, but the endpoint layer does not require a preflight before all writes.
+
+Safe next direction: require explicit account on all Google writes unless a configured default is present and verified, and require preflight for Drive/Docs/Sheets/Tasks/Calendar workflow writes.
+
+### R4: Deferred Scheduler Can Turn A Low-Friction API Call Into A Later Live Send
+
+Severity: high.
+
+The `/scheduled` endpoint stores future message text and recipient/conversation data. The background scheduler starts by default and sends due Gmail/iMessage messages every 30 seconds. There is no human confirmation at send time in production; the original schedule call is the critical control point.
+
+Safe next direction: make scheduled sends reviewable by default, require confirmation when enqueueing and when firing, and store only the minimum plaintext required.
+
+### R5: Derived Local Caches Contain Personal Data With No Retention Boundary
+
+Severity: medium-high.
+
+The index store persists message body text, snippets, subjects, participants, labels, and raw pointers. The scheduler stores plaintext messages. The memory store stores arbitrary personal memory content. These files are ignored by git, but they live under the repo by default and are not encrypted, TTL-governed, or scrubbed by a documented cleanup flow.
+
+Safe next direction: centralize private data directory selection, document retention, add purge/export commands, and consider redaction for index body storage.
+
+### R6: Batch Archive Runner Defaults To Live Mutation Despite Docs Promising Confirmation
+
+Severity: medium-high.
+
+`modes/batch-archive.md` says the workflow should prompt before archiving. The shell runner defaults to `DRY_RUN=false` and executes pending archive rows immediately. The input file is currently empty, but this is a sharp edge once populated.
+
+Safe next direction: make batch archive dry-run by default, add an explicit `--execute` flag, and align docs/tests with the runner.
+
+### R7: List-Unsubscribe Follows Untrusted Header URLs
+
+Severity: medium.
+
+`gmail_unsubscribe` extracts List-Unsubscribe headers, performs HTTP GET/POST requests, can send mailto unsubscribe messages, and then archives the original message. This behavior touches untrusted URLs derived from email headers and creates external network traffic beyond Google APIs.
+
+Safe next direction: require explicit domain/method preview before URL unsubscribe, prefer one-click POST only when verified, and do not archive when unsubscribe fails unless separately requested.
+
+### R8: Local Apple Automation Depends On Full Disk Access And Accessibility Permissions
+
+Severity: medium.
+
+iMessage, Notes, Reminders, AddressBook, ambient notes, desktop notifications, and WhatsApp automation rely on direct SQLite reads, AppleScript, or Accessibility. This is appropriate for a local personal assistant but fragile: permission prompts, stale schemas, and background process restrictions can cause partial failure or unexpected UI actions.
+
+Safe next direction: add explicit preflight endpoints for Apple-data read/write permissions and require dry-run previews for AppleScript/Accessibility writes.
+
+### R9: Public Read-Only MCP Still Exposes Sensitive Read Surfaces
+
+Severity: medium.
+
+The read-only MCP server excludes mutating registry tools, but it still exposes Gmail search/thread reads, Sheet reads, notes reads, memory reads, and daily note reads. "Read-only" is not low-risk for a personal-data repo, especially if connected to cloud agents.
+
+Safe next direction: document "read-only means non-mutating, not non-sensitive"; add per-source allowlists and redaction limits for cloud agents.
+
+### R10: Validation Lane Is Good But Under-Applied
+
+Severity: medium.
+
+The repo has strong safe-test guidance and good representative write-block tests. However, only two modules are marked `safe`, so the advertised `pytest -m safe` command does not cover many deterministic endpoint tests that already mock providers. This can give a false sense of validation coverage.
+
+Safe next direction: classify deterministic mocked tests as `safe` and add a small risk-focused safe suite for auth, MCP confirmation, account resolution, and batch dry-run behavior.
+
+## Stale Assumptions And Claim Gaps
+
+- README says Python 3.10+; `pyproject.toml` requires Python `>=3.12,<3.15`.
+- README says "Local-first ML" and "no cloud dependencies"; the app also uses Google APIs, Gemini API/key paths, Google Maps keys, GitHub tokens, and optional public MCP deployment.
+- README says optional backend auth; that is accurate, but risky for a backend with live writes.
+- "Read-only MCP" is accurate for mutation exclusion, but it can still disclose very sensitive content.
+- "Multi-account Gmail routing" is partly supported, but fallback to first/default account remains a stale assumption risk for writes.
+- Batch archive docs promise a confirmation prompt; the shell runner does not prompt unless the caller uses `--dry-run`.
+
+## Next Safe Work
+
+### Task 1: Fail Closed For Public Auth
+
+Acceptance criteria:
+- HTTP MCP startup fails or refuses non-health `/mcp*` traffic when `INBOX_MCP_TOKEN` is unset in HTTP mode.
+- Backend startup has an explicit `INBOX_ALLOW_NO_AUTH=1` or equivalent dev-only override if `INBOX_SERVER_TOKEN` is unset.
+- Health payload no longer exposes local private paths unless authenticated or in dev mode.
+- Docs and deployment examples state which auth env vars are mandatory.
+
+Validation command candidates:
+- `INBOX_TEST_MODE=1 uv run pytest tests/test_mcp_gateway.py tests/test_server.py::TestAuth --no-cov -p no:cacheprovider`
+- `uv run ruff check mcp_gateway.py inbox_server.py tests/test_mcp_gateway.py tests/test_server.py`
+
+Expected status: should pass after implementation; current code would fail stricter no-token expectations because no-auth is tested as allowed.
+
+### Task 2: Add REST-Level Write Intent Guard
+
+Acceptance criteria:
+- Every mutating REST endpoint passes through one shared write-intent check.
+- `INBOX_TEST_MODE=1` remains a hard block.
+- MCP `confirm=True` is not the only write gate; direct REST calls need an equivalent explicit confirmation mechanism.
+- Tests cover at least Gmail reply/archive, Calendar create, Reminder create, Task create, Drive delete, Sheet append, Scheduler create, and Workflow doc/sheet/folder creation.
+
+Validation command candidates:
+- `INBOX_TEST_MODE=1 uv run pytest tests/test_services.py::test_test_mode_blocks_representative_live_writes tests/test_services.py::test_test_mode_blocks_extended_live_writes --no-cov -p no:cacheprovider`
+- `INBOX_TEST_MODE=1 uv run pytest tests/test_server.py tests/test_server_endpoints.py --no-cov -p no:cacheprovider`
+
+Expected status: current test-mode write blockers should pass; new REST write-intent tests would fail until implemented.
+
+### Task 3: Require Explicit Account Or Verified Default For Google Writes
+
+Acceptance criteria:
+- All Google write endpoints resolve a write account through one strict helper.
+- If no account is supplied, the helper only uses `INBOX_DEFAULT_GOOGLE_ACCOUNT` when it maps to the target service.
+- Falling back to `next(iter(services))` is allowed for reads but not writes.
+- Preflight responses are required or embedded for Drive/Docs/Sheets/Tasks/Calendar workflow writes.
+
+Validation command candidates:
+- `INBOX_TEST_MODE=1 uv run pytest tests/test_gmail_actions.py tests/test_calendar.py tests/test_drive.py --no-cov -p no:cacheprovider`
+- `uv run pyright`
+
+Expected status: existing tests may need updates because current write helpers permit fallback.
+
+### Task 4: Make Batch Archive Safe By Default
+
+Acceptance criteria:
+- `batch/batch-runner.sh` defaults to dry-run behavior and requires `--execute` for live archive.
+- The docs in `modes/batch-archive.md` match the implemented CLI.
+- The runner refuses to execute when `INBOX_SERVER_TOKEN` is unset unless an explicit local no-auth flag is supplied.
+- A shell-level smoke test or script check covers empty input, dry-run, and execute gating without contacting the live backend.
+
+Validation command candidates:
+- `bash batch/batch-runner.sh --mode archive --dry-run`
+- `bash -n batch/batch-runner.sh`
+- `uv run ruff check .`
+
+Expected status: current empty-input dry-run should exit cleanly; stricter execute-gating tests would fail until implemented.
+
+### Task 5: Document And Constrain Private Local Data Stores
+
+Acceptance criteria:
+- A single doc names every local private data store, file path, env override, retention expectation, and cleanup command.
+- `.inbox_index.sqlite3`, `.inbox_memory.sqlite3`, `.inbox_scheduler.sqlite3`, tokens, config files, Obsidian vault writes, and Apple local DB reads are all covered.
+- Index configuration can disable body-text persistence or cap retention.
+- Health endpoints avoid leaking exact private paths by default.
+
+Validation command candidates:
+- `uv run ruff check message_index_store.py memory_store.py scheduler.py mcp_gateway.py`
+- `INBOX_TEST_MODE=1 uv run pytest tests/test_memory_store.py tests/test_message_index_store.py tests/test_mcp_gateway.py --no-cov -p no:cacheprovider`
+
+Expected status: existing store tests should mostly pass; retention/redaction tests would be new.
+
+## Validation Notes
+
+Required queue validation:
+
+```bash
+git status --short
+```
+
+Observed after writing this report:
+
+```text
+?? docs/overnight/
+```
+
+Commit attempt blocker: `git add docs/overnight/inbox-risk-register.md && git commit -m "Add inbox risk register audit"` failed because the sandbox could not write `/Users/jwalinshah/projects/inbox/.git/worktrees/inbox-risk-register/index.lock` (`Operation not permitted`). The report is therefore intentionally left uncommitted in this worktree.
+
+Ignored local side effect: the `uv run python ... tools_registry ...` inspection command created `.venv/`. A cleanup attempt with `rm -rf .venv` was rejected by local command policy, so `.venv/` remains ignored local state.
+
+Additional candidate validations for future implementation work:
+
+- `INBOX_TEST_MODE=1 uv run pytest -m safe --no-cov -p no:cacheprovider` should pass but currently covers only two safe-marked modules.
+- `INBOX_TEST_MODE=1 uv run pytest tests/test_inbox_test_mode.py tests/test_mcp_gateway.py tests/test_tools_registry.py --no-cov -p no:cacheprovider` should pass and directly covers test-mode, public MCP auth, and registry confirmation.
+- `uv run ruff check .` should be the cheapest full lint proof.
+- `uv run pyright` should be run before product changes that touch shared service models or endpoint contracts.
+- `uv run bandit -c pyproject.toml -r .` should be used for security-oriented changes, with awareness that several subprocess/assert checks are intentionally skipped in `pyproject.toml`.
+
+## Non-Goals
+
+- No product code was changed.
+- No tests or lint commands were run beyond local inspection/counting commands.
+- No generated artifact was intended as a deliverable; the ignored `.venv/` was an inspection side effect and cleanup was policy-blocked.
+- No credentials, tokens, local Apple data, Gmail data, Google data, GitHub data, Obsidian vault data, or remote services were accessed intentionally.
+- No server was started.
+- No deploy, push, PR, or external tracker update was performed.
+- No attempt was made to fix the risks in this queue item.
+
+## Unknowns
+
+- Whether `INBOX_SERVER_TOKEN` and `INBOX_MCP_TOKEN` are always set in the user's real local and public deployments.
+- Whether Caddy or another upstream proxy adds auth, IP filtering, mTLS, or firewall rules outside this repo.
+- Whether local token files are encrypted or otherwise protected by filesystem policy outside git.
+- Whether `.inbox_index.sqlite3`, `.inbox_memory.sqlite3`, and `.inbox_scheduler.sqlite3` already exist in the real working repo and how large/sensitive they are.
+- Whether cloud agents are expected to use the full MCP server or only `inbox_mcp_readonly.py`.
+- Whether List-Unsubscribe network calls are acceptable product behavior or should require a preview step.
+- Whether scheduled sends are used operationally and what human approval expectation exists at enqueue and fire time.

--- a/docs/overnight/inbox-sym-115-dependency-surface.md
+++ b/docs/overnight/inbox-sym-115-dependency-surface.md
@@ -1,0 +1,522 @@
+# inbox-sym-115 dependency-surface audit
+
+Date: 2026-05-07
+Queue item: `inbox-sym-115-dependency-surface`
+Repo: `inbox-sym-115`
+Branch observed: `codex/goal-inbox-sym-115-dependency-surface`
+Starting HEAD observed: `2805b8400519da188ca7d3f6e39b19a8ca42b05a`
+
+## Scope and non-goals
+
+This is a read-only dependency-surface audit except for this report file. I did
+not touch product code, generated data, secrets, local service files, deploy
+targets, external services, GitHub PRs, or external trackers. I did not run
+setup scripts, start servers, load launch agents, expose MCP endpoints, execute
+live inbox operations, or run tests that would touch personal data.
+
+The required validation for this queue item is `git status --short`. Other
+commands below are evidence-gathering commands or candidate validation commands.
+
+## Repo purpose
+
+Inbox is a local-first Python personal inbox/control-plane app. The main shape
+is a Textual/Rich TUI backed by a local FastAPI server; agents can also reach
+the same backend through MCP stdio or HTTP gateways. The app integrates local
+macOS data stores, Google APIs, GitHub, local ML/audio, scheduling, memory, and
+batch inbox operations.
+
+Evidence:
+
+- [README.md](../../README.md) describes the unified TUI, FastAPI backend,
+  local ML, macOS data sources, OAuth token files, and dev commands.
+- [CLAUDE.md](../../CLAUDE.md) gives the strongest current architecture map:
+  `services.py` as data layer, `inbox_server.py` as FastAPI wrapper,
+  `inbox_client.py` as HTTP client, MCP entrypoints, scheduler, and local state.
+- [docs/TESTING_FOR_AGENTS.md](../TESTING_FOR_AGENTS.md) explicitly treats the
+  repo as personal-data-sensitive and requires `INBOX_TEST_MODE=1` for
+  agent-safe tests.
+
+## Current branch and dirty state
+
+Observed before writing this report:
+
+- `git branch --show-current` -> `codex/goal-inbox-sym-115-dependency-surface`
+- `git rev-parse HEAD` -> `2805b8400519da188ca7d3f6e39b19a8ca42b05a`
+- `git status --short` -> clean output
+- `git status --ignored --short` -> clean output
+- `git remote -v` -> `origin https://github.com/jwalin-shah/inbox.git`
+- `git ls-files docs/overnight` -> no existing overnight reports tracked before
+  this file
+
+Expected dirty state after this audit: only
+`docs/overnight/inbox-sym-115-dependency-surface.md`.
+
+## Dependency and runtime surface
+
+### Python and uv
+
+- [pyproject.toml](../../pyproject.toml) declares package `inbox`, version
+  `0.1.0`, Python `>=3.12,<3.15`, runtime deps, dev deps, Ruff, Pyright, Pytest,
+  and Bandit settings.
+- [.python-version](../../.python-version) is `3.12`.
+- [README.md](../../README.md) still says "Python 3.10+" while the manifest
+  requires Python 3.12+. That is a stale setup claim.
+- [uv.lock](../../uv.lock) is present and is about 432K.
+- `UV_CACHE_DIR=/tmp/uv-cache uv tree --locked` succeeded, used CPython
+  3.12.12, and resolved 149 packages.
+- `uv tree --locked` without `UV_CACHE_DIR` failed in this sandbox because uv
+  tried to initialize `/Users/jwalinshah/.cache/uv` and hit an operation-not-
+  permitted error. Local worker validation should set `UV_CACHE_DIR=/tmp/uv-cache`
+  in this environment.
+
+### Runtime deps from manifest and lock
+
+Main declared runtime dependencies in [pyproject.toml](../../pyproject.toml):
+
+- Web/API: `fastapi`, `uvicorn`, `httpx`, `python-multipart`, `pydantic`
+- Google: `google-api-python-client`, `google-auth-oauthlib`,
+  `google-generativeai`
+- MCP: `mcp[cli]`
+- TUI: `textual`, `rich`
+- ML/audio: `mlx-lm`, `mlx-whisper`, `numpy`, `outlines`, `sounddevice`
+- macOS input/accessibility: `pyobjc-framework-applicationservices`,
+  `pyobjc-framework-Quartz`
+- Logging: `loguru`
+
+`UV_CACHE_DIR=/tmp/uv-cache uv tree --locked` showed notable resolved versions:
+
+- `fastapi==0.135.3`, `starlette==1.0.0`, `uvicorn==0.44.0`
+- `mcp==1.27.0`
+- `textual==8.2.3`, `rich==14.3.3`
+- `google-api-python-client==2.194.0`, `google-auth==2.49.1`,
+  `google-generativeai==0.8.6`
+- `mlx-lm==0.31.2`, `mlx-whisper==0.4.3`, `mlx==0.31.1`, `torch==2.11.0`,
+  `numpy==2.4.4`
+- `pyobjc-framework-applicationservices==12.1`,
+  `pyobjc-framework-quartz==12.1`
+- Dev group: `pytest==9.0.3`, `pytest-cov==7.1.0`, `ruff==0.15.10`,
+  `pyright==1.1.408`, `bandit==1.9.4`, `pre-commit==4.5.1`
+
+### Direct imports that rely on transitive deps
+
+These are small but real packaging risks:
+
+- [services.py](../../services.py) imports `requests` inside
+  `gmail_unsubscribe`, but `requests` is not a direct dependency in
+  [pyproject.toml](../../pyproject.toml). It is currently available transitively
+  through Google packages in [uv.lock](../../uv.lock).
+- [mcp_gateway.py](../../mcp_gateway.py) imports Starlette objects directly
+  (`Starlette`, middleware, requests, responses, routing), and tests import
+  Starlette directly too. `starlette` is currently transitive through FastAPI
+  and MCP, not direct.
+- [inbox_server.py](../../inbox_server.py) also imports `starlette.responses`
+  in one route path.
+
+If a future dependency update removes those transitives, runtime import failures
+will be surprising because the source imports them directly.
+
+## Entrypoints, scripts, and service wrappers
+
+Primary Python entrypoints observed:
+
+- [inbox.py](../../inbox.py): Textual TUI. Reads `INBOX_POLL_INTERVAL`, launches
+  server through [inbox_client.py](../../inbox_client.py), opens downloads under
+  `~/Downloads`, and uses subprocesses for some UI actions.
+- [inbox_server.py](../../inbox_server.py): FastAPI app. Uses
+  `INBOX_SERVER_TOKEN`, `INBOX_SERVER_PORT`, `INBOX_PRE_WARM_CONVERSATIONS`, and
+  `INBOX_DISABLE_AMBIENT`. It instantiates `SchedulerStore()` and
+  `MessageIndexStore()` at runtime.
+- [mcp_server.py](../../mcp_server.py): full MCP HTTP/stdout-facing tool surface
+  plus memory and daily-note tools. Defaults HTTP port 8000.
+- [inbox_mcp_readonly.py](../../inbox_mcp_readonly.py): read-only MCP surface,
+  default HTTP port 8001, override via `INBOX_MCP_READONLY_PORT`.
+- [inbox_mcp_stdio.py](../../inbox_mcp_stdio.py) and
+  [inbox_mcp_readonly_stdio.py](../../inbox_mcp_readonly_stdio.py): local stdio
+  wrappers around the full/read-only MCP apps.
+- [message_sync.py](../../message_sync.py): materializes Gmail and iMessage into
+  [message_index_store.py](../../message_index_store.py); modes are
+  `bootstrap`, `incremental`, `rebuild`, and `summary`.
+
+Shell/service surfaces:
+
+- [dev.sh](../../dev.sh) runs `uv run python "${1:-inbox.py}"`, defaults the
+  worktree to `INBOX_SERVER_PORT=9850`, and derives `INBOX_SERVER_URL`.
+- [scripts/run_inbox_backend.sh](../../scripts/run_inbox_backend.sh),
+  [scripts/run_inbox_mcp_http.sh](../../scripts/run_inbox_mcp_http.sh),
+  [scripts/run_inbox_mcp_http_readonly.sh](../../scripts/run_inbox_mcp_http_readonly.sh),
+  [scripts/run_inbox_mcp_stdio.sh](../../scripts/run_inbox_mcp_stdio.sh), and
+  [scripts/run_inbox_mcp_stdio_readonly.sh](../../scripts/run_inbox_mcp_stdio_readonly.sh)
+  all set `UV_CACHE_DIR="${UV_CACHE_DIR:-/tmp/uv-cache}"` before `uv run`.
+- [scripts/setup_inbox_mcp.sh](../../scripts/setup_inbox_mcp.sh) is not a safe
+  audit command: it copies `config/inbox.env`, writes under
+  `~/Library/LaunchAgents`, and runs `launchctl load`.
+- [batch/batch-runner.sh](../../batch/batch-runner.sh) writes
+  `batch/archive-state.tsv` and `batch/logs/`, then uses curl against
+  `INBOX_SERVER_URL`. Its only implemented archive path is Gmail
+  `POST /gmail/batch-modify`.
+
+Deploy examples:
+
+- [deploy/inbox-backend.service.example](../../deploy/inbox-backend.service.example),
+  [deploy/inbox-mcp.service.example](../../deploy/inbox-mcp.service.example), and
+  [deploy/inbox-mcp-readonly.service.example](../../deploy/inbox-mcp-readonly.service.example)
+  hard-code `/Users/jwalinshah/projects/inbox`, not the current worktree.
+- [deploy/com.inbox.backend.plist.example](../../deploy/com.inbox.backend.plist.example),
+  [deploy/com.inbox.mcp.plist.example](../../deploy/com.inbox.mcp.plist.example), and
+  [deploy/com.inbox.mcp-readonly.plist.example](../../deploy/com.inbox.mcp-readonly.plist.example)
+  also hard-code `/Users/jwalinshah/projects/inbox` and log to `/tmp`.
+- [deploy/Caddyfile.example](../../deploy/Caddyfile.example) exposes only
+  `/health` and `/mcp` for full and read-only MCP hostnames.
+
+## Environment variables
+
+Observed env vars with local evidence:
+
+- `INBOX_SERVER_URL`: [config/inbox.env.example](../../config/inbox.env.example),
+  [.mcp.json](../../.mcp.json), [.cursor/mcp.json](../../.cursor/mcp.json),
+  [mcp_backend.py](../../mcp_backend.py), [inbox_client.py](../../inbox_client.py),
+  [MCP_SETUP.md](../../MCP_SETUP.md)
+- `INBOX_SERVER_TOKEN`: [config/inbox.env.example](../../config/inbox.env.example),
+  [inbox_server.py](../../inbox_server.py), [mcp_backend.py](../../mcp_backend.py),
+  [.gitignore](../../.gitignore), [MCP_SETUP.md](../../MCP_SETUP.md)
+- `INBOX_MCP_TOKEN`: [config/inbox.env.example](../../config/inbox.env.example),
+  [mcp_gateway.py](../../mcp_gateway.py), [MCP_SETUP.md](../../MCP_SETUP.md)
+- `INBOX_SERVER_PORT`: [dev.sh](../../dev.sh), [inbox_client.py](../../inbox_client.py),
+  [inbox_server.py](../../inbox_server.py), [CLAUDE.md](../../CLAUDE.md)
+- `INBOX_MCP_READONLY_PORT`: [inbox_mcp_readonly.py](../../inbox_mcp_readonly.py)
+- `INBOX_MEMORY_DB`: [config/inbox.env.example](../../config/inbox.env.example),
+  [mcp_gateway.py](../../mcp_gateway.py), [mcp_server.py](../../mcp_server.py)
+- `INBOX_TEST_MODE`, `INBOX_TEST_DATA_DIR`, `INBOX_TEST_NOW`:
+  [inbox_test_mode.py](../../inbox_test_mode.py) and
+  [docs/TESTING_FOR_AGENTS.md](../TESTING_FOR_AGENTS.md)
+- `INBOX_DEFAULT_GOOGLE_ACCOUNT`:
+  [google_account_resolution.py](../../google_account_resolution.py) and
+  [CONNECTOR_ROADMAP.md](../../CONNECTOR_ROADMAP.md)
+- `INBOX_PRE_WARM_CONVERSATIONS`, `INBOX_DISABLE_AMBIENT`:
+  [inbox_server.py](../../inbox_server.py)
+- `INBOX_HOME_ADDRESS`, `GOOGLE_CLOUD_API_KEY`, `GOOGLE_MAPS_API_KEY`:
+  [services.py](../../services.py)
+- `GEMINI_API_KEY`: [services.py](../../services.py)
+- `INBOX_POLL_INTERVAL`: [inbox.py](../../inbox.py)
+- `UV_CACHE_DIR`: all `scripts/run_inbox_*` wrappers and necessary in this
+  sandbox for uv commands.
+
+Risk note: [mcp_gateway.py](../../mcp_gateway.py) treats an empty
+`INBOX_MCP_TOKEN` as auth disabled for all non-health HTTP MCP requests. That
+is acceptable for local stdio, but unsafe if the HTTP MCP gateway is exposed.
+[MCP_SETUP.md](../../MCP_SETUP.md) says remote use should require
+`INBOX_MCP_TOKEN`.
+
+## Secrets, credentials, local state, and generated artifacts
+
+Gitignored local credential/state paths are clear in [.gitignore](../../.gitignore):
+
+- `credentials.json`, `token.json`, `token.json.lock`, `tokens/`
+- `github_token.txt`, `google_maps_key.txt`, `gemini_api_key.txt`
+- `config/inbox.env`, `.env`, `.env.local`, `.envrc`, `*.key`, `*.secret`
+- `.inbox_memory.sqlite3`, `.inbox_scheduler.sqlite3`, `.inbox_index.sqlite3`
+- `.coverage`, `htmlcov/`, `.tldr/`, `.venv`, `*.log`
+- `batch/triage-output.tsv`, `batch/archive-state.tsv`, `batch/logs/`,
+  `batch/.batch-state.lock`
+
+Runtime-created local stores:
+
+- [memory_store.py](../../memory_store.py) defaults to `.inbox_memory.sqlite3`
+  unless `INBOX_MEMORY_DB` overrides it.
+- [scheduler.py](../../scheduler.py) defaults to `.inbox_scheduler.sqlite3` and
+  persists scheduled messages, follow-up reminders, and task-message links.
+- [message_index_store.py](../../message_index_store.py) defaults to
+  `.inbox_index.sqlite3`, creates WAL-mode tables for sync state, indexed items,
+  threads, and sender stats.
+- [services.py](../../services.py) stores Google OAuth tokens under `tokens/`,
+  migrates legacy `token.json`, and writes token files under a lock.
+- [services.py](../../services.py) writes voice config under
+  `~/.config/inbox/voice.json` outside the repo unless test mode redirects it.
+- [ambient_notes.py](../../ambient_notes.py) defaults to an Obsidian-style vault
+  under `~/vault`.
+
+Tracked generated or runner-owned artifacts:
+
+- `git ls-files .factory` found 85 tracked `.factory` files.
+- `du -sh .factory` -> `424K`.
+- [.factory/services.yaml](../../.factory/services.yaml) defines install/test/
+  typecheck/lint commands and a service target that hard-codes
+  `/Users/jwalinshah/projects/inbox`.
+- [.factory/init.sh](../../.factory/init.sh) runs `uv sync`, creates
+  `~/.config/inbox`, and kills port 9849. It is not safe as a read-only audit
+  command.
+- [.factory/validation/**](../../.factory/validation) contains prior scrutiny
+  and user-testing JSON artifacts; this is useful historical evidence but also
+  a surface that can go stale relative to current code.
+
+## External-service and platform dependencies
+
+The app is tightly bound to local macOS and several external providers:
+
+- macOS SQLite stores:
+  - iMessage: `~/Library/Messages/chat.db`
+  - AddressBook:
+    `~/Library/Application Support/AddressBook/Sources/*/AddressBook-v22.abcddb`
+  - Notes:
+    `~/Library/Group Containers/group.com.apple.notes/NoteStore.sqlite`
+  - Reminders:
+    `~/Library/Group Containers/group.com.apple.reminders/Container_v1/Stores/Data-*.sqlite`
+- macOS write paths use AppleScript via `osascript` for iMessage, Notes,
+  Reminders, WhatsApp, and notifications in [services.py](../../services.py).
+- Dictation has hard-coded native binary/model assumptions in
+  [services.py](../../services.py):
+  `/opt/homebrew/bin/whisper-stream` and
+  `/opt/homebrew/Cellar/whisper-cpp/1.8.4/share/whisper-cpp/ggml-base.en-q8_0.bin`.
+- ML model names in [services.py](../../services.py) include
+  `mlx-community/whisper-base.en-mlx`,
+  `mlx-community/Qwen3.5-0.8B-MLX-4bit`, and
+  `mlx-community/Qwen2.5-3B-Instruct-4bit`.
+- Google API scopes in [services.py](../../services.py) include Gmail read,
+  Gmail modify, Gmail send, Gmail settings, Calendar, Drive, Sheets, Docs, and
+  Tasks.
+- GitHub token resolution in [services.py](../../services.py) tries
+  `gh auth token` first, then `github_token.txt`.
+- Google Maps features read `GOOGLE_CLOUD_API_KEY`, `GOOGLE_MAPS_API_KEY`, or
+  `google_maps_key.txt`.
+- Gemini features read `GEMINI_API_KEY` or `gemini_api_key.txt`.
+
+The test layer reduces some of this risk:
+
+- [tests/conftest.py](../../tests/conftest.py) stubs `mlx_lm`, `mlx_whisper`,
+  `sounddevice`, `outlines`, and `Quartz`.
+- [inbox_test_mode.py](../../inbox_test_mode.py) blocks live writes under
+  `INBOX_TEST_MODE=1`.
+- [tests/test_inbox_test_mode.py](../../tests/test_inbox_test_mode.py) and
+  [tests/test_services.py](../../tests/test_services.py) assert representative
+  live writes are blocked.
+
+## MCP dependency surface
+
+MCP is a separate product surface with its own risks:
+
+- [mcp_server.py](../../mcp_server.py) exposes full tools plus memory and daily
+  note mutation tools. It requires explicit `confirm=True` for its handwritten
+  write tools.
+- [inbox_mcp_readonly.py](../../inbox_mcp_readonly.py) registers only readonly
+  registry tools plus read-only memory/daily-note reads.
+- [tools_registry.py](../../tools_registry.py) centralizes HTTP-backed tool
+  definitions and flags each tool as `readonly` and/or `confirm`.
+- [mcp_gateway.py](../../mcp_gateway.py) adds public HTTP auth middleware, but
+  auth is disabled when `INBOX_MCP_TOKEN` is empty.
+- [.mcp.json](../../.mcp.json) and [.cursor/mcp.json](../../.cursor/mcp.json)
+  run `uv run python inbox_mcp_stdio.py` and
+  `uv run python inbox_mcp_readonly_stdio.py` with
+  `INBOX_SERVER_URL=http://127.0.0.1:9849`. They do not specify `cwd`, so client
+  working-directory behavior matters.
+- [config/codex.inbox.example.toml](../../config/codex.inbox.example.toml) and
+  [config/gemini-settings.inbox.example.json](../../config/gemini-settings.inbox.example.json)
+  hard-code the primary checkout by default and include comments/examples for
+  dev worktrees.
+
+Handoff risk: a dev worktree can run on 9850 via [dev.sh](../../dev.sh), but MCP
+configs default to 9849. [MCP_SETUP.md](../../MCP_SETUP.md) calls this out as a
+common failure mode where requests succeed but hit primary data.
+
+## Validation surface
+
+Observed commands:
+
+- `llm-tldr tree .` succeeded and showed a flat Python repo with `config/`,
+  `deploy/`, `docs/`, `modes/`, `scripts/`, `tests/`, root modules, and
+  `uv.lock`.
+- `rg --files -uu` showed hidden config and tracked factory files including
+  `.mcp.json`, `.cursor/mcp.json`, `.env.mcp.example`, `.pre-commit-config.yaml`,
+  `.factory/**`, and `.python-version`.
+- `UV_CACHE_DIR=/tmp/uv-cache uv tree --locked` passed and resolved 149 packages.
+- `uv tree --locked` failed because the sandbox could not use
+  `/Users/jwalinshah/.cache/uv`.
+- `rg -n "pytest.mark.safe|@pytest.mark.safe|pytestmark" tests` showed only
+  [tests/test_inbox_test_mode.py](../../tests/test_inbox_test_mode.py) and
+  [tests/test_mcp_gateway.py](../../tests/test_mcp_gateway.py) are marked
+  `safe`.
+- `du -sh .factory` -> `424K`; `du -sh tests` -> `568K`; `du -sh uv.lock` ->
+  `432K`.
+
+Exact validation command candidates:
+
+- Required queue validation: `git status --short`
+  - Expected after report: one added/modified report file before commit; clean
+    after commit.
+- Dependency graph smoke: `UV_CACHE_DIR=/tmp/uv-cache uv tree --locked`
+  - Observed pass in this sandbox.
+- Unsafe default in this sandbox: `uv tree --locked`
+  - Observed fail due uv cache permission under `/Users/jwalinshah/.cache/uv`.
+- Agent-safe tests: `INBOX_TEST_MODE=1 UV_CACHE_DIR=/tmp/uv-cache uv run pytest -m safe`
+  - Expected to run only currently marked safe tests. Not run in this audit
+    because the queue validation command is `git status --short` and `uv run`
+    may create a local virtualenv/cache surface.
+- Lint: `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check .`
+  - Expected to use configured Ruff rules. Not run in this audit.
+- Typecheck: `UV_CACHE_DIR=/tmp/uv-cache uv run pyright`
+  - Expected to use basic Pyright mode. Not run in this audit.
+- Full tests: `INBOX_TEST_MODE=1 UV_CACHE_DIR=/tmp/uv-cache uv run pytest`
+  - Expected to run with coverage because `pyproject.toml` has
+    `--cov=. --cov-report=term-missing`; may create `.coverage`.
+  - Should not run without `INBOX_TEST_MODE=1`.
+- Factory test command:
+  `UV_CACHE_DIR=/tmp/uv-cache uv run pytest --ignore=tests/test_audio.py --ignore=tests/test_llm.py -x -q`
+  - From [.factory/services.yaml](../../.factory/services.yaml). Expected to
+    skip heavy audio/LLM tests, but still broader than the queue validation.
+
+## Risks and stale assumptions
+
+1. README Python version is stale.
+   [README.md](../../README.md) says Python 3.10+, while
+   [pyproject.toml](../../pyproject.toml) and [.python-version](../../.python-version)
+   require/use Python 3.12. New workers can waste time debugging an unsupported
+   interpreter.
+
+2. Direct imports rely on transitive packages.
+   [services.py](../../services.py) uses `requests` directly and
+   [mcp_gateway.py](../../mcp_gateway.py) uses Starlette directly, but neither
+   is directly declared in [pyproject.toml](../../pyproject.toml). Current lock
+   resolves them transitively, but future dependency changes can break imports.
+
+3. HTTP MCP auth is opt-in by env var.
+   [mcp_gateway.py](../../mcp_gateway.py) allows all non-health HTTP MCP traffic
+   when `INBOX_MCP_TOKEN` is empty. This is easy to misconfigure if a local
+   gateway is later reverse-proxied.
+
+4. Primary-vs-dev routing is fragile.
+   [dev.sh](../../dev.sh) defaults worktrees to port 9850, while
+   [.mcp.json](../../.mcp.json), [.cursor/mcp.json](../../.cursor/mcp.json), and
+   service examples default to primary port 9849. A worker can believe it is
+   testing a worktree while mutating or reading primary state.
+
+5. Deploy/factory files hard-code the primary checkout.
+   `deploy/*.example`, [.factory/services.yaml](../../.factory/services.yaml),
+   and [.factory/init.sh](../../.factory/init.sh) reference
+   `/Users/jwalinshah/projects/inbox`. They are useful for the primary machine
+   but unsafe to run blindly in isolated worktrees.
+
+6. Local state is broad and partly outside the repo.
+   SQLite stores, OAuth tokens, GitHub token files, Google Maps/Gemini key files,
+   Obsidian vault writes, voice config, macOS SQLite data stores, and Homebrew
+   whisper binaries all sit outside normal package dependency boundaries.
+
+7. The `safe` marker is sparse.
+   Only two test modules are marked `safe`. [docs/TESTING_FOR_AGENTS.md](../TESTING_FOR_AGENTS.md)
+   recommends `INBOX_TEST_MODE=1 uv run pytest -m safe`, but that command may
+   prove less coverage than expected unless more tests are marked.
+
+8. Batch runner is stateful and mutation-oriented.
+   [batch/batch-runner.sh](../../batch/batch-runner.sh) creates state/log files
+   and performs Gmail archive operations. It should not be treated as a generic
+   read-only validation helper.
+
+9. ML/audio deps are large and platform-specific.
+   `mlx-lm`, `mlx-whisper`, `torch`, `sounddevice`, PyObjC, and hard-coded
+   whisper-stream paths make dependency resolution and local validation machine-
+   dependent. Tests stub some deps, but runtime setup remains fragile.
+
+10. The lock is current, but manifest constraints are broad lower bounds.
+    [pyproject.toml](../../pyproject.toml) uses `>=` lower bounds for runtime
+    and dev dependencies. The lock protects `uv` workflows, but non-locked
+    installs may pick newer packages with changed APIs.
+
+## Independently grabbable next tasks
+
+### Task 1: Declare direct transitive imports explicitly
+
+Acceptance criteria:
+
+- Add direct dependencies for any runtime imports that are used directly but
+  currently only present transitively, at minimum `requests` and `starlette`.
+- Keep [uv.lock](../../uv.lock) updated.
+- Do not widen dependency versions beyond existing lock-compatible versions.
+
+Validation:
+
+- `UV_CACHE_DIR=/tmp/uv-cache uv sync --locked`
+- `UV_CACHE_DIR=/tmp/uv-cache uv tree --locked`
+- `INBOX_TEST_MODE=1 UV_CACHE_DIR=/tmp/uv-cache uv run pytest -m safe`
+
+### Task 2: Align setup docs with actual Python and uv requirements
+
+Acceptance criteria:
+
+- Update [README.md](../../README.md), [CLAUDE.md](../../CLAUDE.md), and
+  [MCP_SETUP.md](../../MCP_SETUP.md) where needed so Python version, uv cache
+  expectations, worktree ports, and primary-vs-dev MCP routing are consistent.
+- Explicitly document `UV_CACHE_DIR=/tmp/uv-cache` for sandboxed agent commands.
+- Keep changes docs-only.
+
+Validation:
+
+- `rg -n "Python 3.10|Python 3.12|UV_CACHE_DIR|9850|9849" README.md CLAUDE.md MCP_SETUP.md docs config`
+- `git diff -- README.md CLAUDE.md MCP_SETUP.md docs config`
+
+### Task 3: Expand agent-safe validation coverage
+
+Acceptance criteria:
+
+- Review unmarked tests and mark deterministic, mocked tests as `safe`.
+- Do not mark tests safe if they touch local user data, live providers, audio
+  hardware, notification mutation, or live writes.
+- Update [docs/TESTING_FOR_AGENTS.md](../TESTING_FOR_AGENTS.md) with any refined
+  safe-test policy.
+
+Validation:
+
+- `rg -n "pytest.mark.safe|pytestmark = pytest.mark.safe" tests`
+- `INBOX_TEST_MODE=1 UV_CACHE_DIR=/tmp/uv-cache uv run pytest -m safe -q`
+
+### Task 4: Add a config drift check for MCP/dev routing
+
+Acceptance criteria:
+
+- Add a script or test that checks MCP config examples for primary vs dev port
+  consistency and catches missing `cwd` where a client requires it.
+- The check should not start servers or touch tokens.
+- It should fail with clear messages when a config points at primary 9849 while
+  describing a dev worktree.
+
+Validation:
+
+- `INBOX_TEST_MODE=1 UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/test_mcp_gateway.py -q`
+- New focused test/script command chosen by implementer.
+
+### Task 5: Quarantine destructive local setup commands from worker workflows
+
+Acceptance criteria:
+
+- Document that [scripts/setup_inbox_mcp.sh](../../scripts/setup_inbox_mcp.sh)
+  and [.factory/init.sh](../../.factory/init.sh) are not agent-default commands.
+- If appropriate, add a dry-run or confirmation guard to setup scripts before
+  they copy launch agents, run `launchctl`, or kill port 9849.
+- Keep default runtime scripts unchanged unless the task explicitly scopes it.
+
+Validation:
+
+- `bash -n scripts/setup_inbox_mcp.sh .factory/init.sh`
+- Review of script output in dry-run mode if added.
+
+## Unknowns
+
+- I did not inspect real local token files or secret files; they are gitignored
+  and intentionally out of scope.
+- I did not inspect whether primary `~/projects/inbox` is running on port 9849.
+- I did not run live backend health checks, MCP calls, Google API calls, GitHub
+  API calls, AppleScript operations, or audio/ML runtime loading.
+- I did not verify whether the hard-coded Homebrew whisper paths exist on this
+  machine.
+- I did not compare against sibling repos from `repos.json`; this queue item is
+  scoped to the current repo/worktree and the local repo was substantial enough
+  for a standalone audit.
+- I did not run full tests/lint/typecheck because the queue validation is
+  `git status --short` and broader validation can create local caches or require
+  deeper product judgment about safe coverage.
+
+## Morning handoff
+
+Changed file expected from this queue item:
+
+- [docs/overnight/inbox-sym-115-dependency-surface.md](inbox-sym-115-dependency-surface.md)
+
+No PR was opened. No external tracker was marked Done. No product code was
+modified.

--- a/docs/overnight/inbox-sym-115-risk-register.md
+++ b/docs/overnight/inbox-sym-115-risk-register.md
@@ -1,0 +1,379 @@
+# inbox-sym-115 Risk Register Audit
+
+Queue item: `inbox-sym-115-risk-register`
+Repo path: `/Users/jwalinshah/projects/agent-stack/.agent-stack-worktrees/2026-05-07-overnight-marathon/inbox-sym-115-risk-register`
+Audit date: 2026-05-07
+Focus area: `risk-register`
+
+## Scope And State
+
+This is a read-only risk audit of the Inbox personal assistant repo. Product code, generated data, live provider calls, deploys, pushes, and PR creation were out of scope. The only intended repo write is this report.
+
+Observed repo purpose:
+
+- `README.md` describes a privacy-first Python/Textual terminal inbox that consolidates iMessage, Gmail, Google Calendar, Sheets, Notes, Reminders, GitHub notifications, and Drive through a local FastAPI backend and optional MCP access.
+- `CLAUDE.md` describes the same client-server split plus worktree routing: primary checkout on port `9849`, dev worktrees on `9850+`, and shared macOS personal-data stores across worktrees.
+- `pyproject.toml` defines a Python `>=3.12,<3.15` app with FastAPI, Google APIs, MCP, MLX, Textual, sounddevice, ruff, pyright, pytest, coverage, Hypothesis, and Bandit.
+
+Branch and dirty state observations:
+
+- `git branch --show-current` -> `codex/goal-inbox-sym-115-risk-register`.
+- `git rev-parse HEAD` -> `2805b8400519da188ca7d3f6e39b19a8ca42b05a`.
+- Initial `git status --short` returned no output, so the worktree started clean.
+- `rg --files ... tokens credentials.json config/inbox.env ...` found only `.gitignore` and `.mcp.json`; no live token files, `credentials.json`, or `config/inbox.env` were present in the worktree.
+- `git ls-files | rg "(credentials\.json|token\.json|tokens/|github_token|google_maps_key|gemini_api_key|config/inbox\.env|\.env|\.inbox_.*sqlite|batch/.*state)"` returned only `.env.mcp.example` and `config/inbox.env.example`, so secret paths are ignored but examples are tracked.
+
+Command notes:
+
+- `llm-tldr tree .` showed the repo has a flat Python service/TUI layout, `tests/`, `scripts/`, `deploy/`, `config/`, `modes/`, and one existing docs file.
+- `rg -n "pytest\.mark\.(safe|integration|local_data|live_write|slow)|pytestmark" tests` found only `tests/test_inbox_test_mode.py` and `tests/test_mcp_gateway.py` marked `safe`.
+- `INBOX_TEST_MODE=1 uv run pytest -m safe --collect-only -q` failed before collection because the default uv cache at `/Users/jwalinshah/.cache/uv` is outside the sandbox.
+- `UV_CACHE_DIR=/tmp/uv-cache INBOX_TEST_MODE=1 uv run pytest -m safe --collect-only -q` created an ignored `.venv/`, then failed because network access is unavailable while resolving `mlx-whisper==0.4.3`.
+- Cleanup of the generated `.venv/` with `rm -rf .venv` was blocked by policy. It is ignored by `.gitignore` and was 68K when observed with `du -sh .venv`.
+
+## Risk Register
+
+### 1. Raw REST Write Surface Is Broad And Not Confirmation-Gated
+
+Risk: MCP write tools are confirmation-gated, but the underlying FastAPI endpoints mutate once HTTP auth passes. Any local client, misrouted MCP backend, browser automation, or script with access to the backend can invoke writes without `confirm=True`.
+
+Evidence:
+
+- `tools_registry.py:67-78` enforces `confirm=True` inside MCP handler generation.
+- `tools_registry.py:157-164`, `tools_registry.py:250-256`, `tools_registry.py:807-812` describe confirmation-gated MCP tools such as Gmail reply, archive, and Docs text insert.
+- `inbox_server.py:1434-1450` sends iMessage or Gmail from `/messages/send` with no request-level confirmation.
+- `inbox_server.py:1489-1552` exposes Gmail archive, delete, unsubscribe, star, read, and unread endpoints directly.
+- `inbox_server.py:1819-1892` exposes calendar create, quick-create, update, and delete directly.
+- `inbox_server.py:2548-2590`, `inbox_server.py:2612-2761`, and `inbox_server.py:2940-2983` expose Drive upload/folder/delete, Sheets writes, and Docs create/delete/insert directly.
+
+Why it matters:
+
+The user-facing safety model is split by transport. MCP callers see confirmation prompts, but the REST API and TUI path do not share the same gate. This is especially risky because `README.md` and `CLAUDE.md` advertise agents hitting the local server directly.
+
+Next safe work:
+
+- Add a shared write-policy layer at the FastAPI boundary for all mutating endpoints.
+- Require either explicit `confirm` metadata, a local interactive TUI origin, or a stronger internal-only credential for raw REST mutations.
+- Add endpoint tests proving direct REST write endpoints reject missing confirmation in agent-safe mode.
+
+### 2. Backend And MCP Auth Fail Open When Tokens Are Unset
+
+Risk: Both the private backend and MCP gateway allow unauthenticated access when their token env vars are empty. This is convenient for local dev, but dangerous if a launchd/systemd/Caddy/ngrok path is exposed before env setup is complete.
+
+Evidence:
+
+- `inbox_server.py:1313-1320` returns authorized when `INBOX_SERVER_TOKEN` is unset.
+- `mcp_gateway.py:32-45` returns authorized when `INBOX_MCP_TOKEN` is unset.
+- `mcp_gateway.py:48-58` exempts `/health` from public auth.
+- `config/inbox.env.example` contains placeholder tokens but real `config/inbox.env` is absent in this worktree.
+- `MCP_SETUP.md` recommends two different tokens and warns the backend should never be internet-facing.
+- `deploy/Caddyfile.example` exposes `/health` and `/mcp` for both full and read-only MCP hostnames.
+
+Why it matters:
+
+If the full MCP HTTP gateway is exposed with missing `INBOX_MCP_TOKEN`, every registered full MCP tool is callable. If the private backend is exposed with missing `INBOX_SERVER_TOKEN`, raw REST write endpoints are callable.
+
+Next safe work:
+
+- Make HTTP MCP fail closed by default unless `INBOX_MCP_ALLOW_UNAUTH_LOCAL=1` is explicitly set.
+- Make backend startup print or expose a red warning when auth is disabled.
+- Keep `/health` public only for read-only status, and redact backend details from public health responses.
+
+### 3. Live-Write Guard Coverage Has Concrete Gaps
+
+Risk: `INBOX_TEST_MODE=1` blocks many representative writes, but not all mutating service functions call `_assert_live_write_allowed`.
+
+Evidence:
+
+- `services.py:114-119` centralizes `_assert_live_write_allowed`.
+- `tests/test_services.py:909-951` tests representative live-write blocking.
+- `rg -n "def (drive_upload|sheets_rename_sheet|sheets_format|sheets_copy_to|docs_insert_text|calendar_rsvp_event)|_assert_live_write_allowed" services.py` showed guard calls around many writes, but the following mutators have definitions without nearby guards:
+  - `services.py:3864-3909` `drive_upload`
+  - `services.py:4315-4338` `sheets_rename_sheet`
+  - `services.py:4341-4355` `sheets_format`
+  - `services.py:4358-4388` `sheets_copy_to`
+  - `services.py:4476-4495` `docs_insert_text`
+  - `services.py:6236-6259` `calendar_rsvp_event`
+- `tests/test_drive.py:69-112` exercises `drive_upload`, but there is no `INBOX_TEST_MODE` block assertion for that path.
+
+Why it matters:
+
+Agent-safe validation can accidentally hit a live provider if a test or endpoint touches one of these uncovered helpers. Some gaps are direct user data writes, including file upload, raw spreadsheet batch updates, document insertion, and RSVP mutation.
+
+Next safe work:
+
+- Add `_assert_live_write_allowed(...)` to every mutating service helper listed above.
+- Add a parametrized test that enumerates all mutators and proves they raise `LiveWriteBlocked` before touching mock provider chains.
+- Add a grep/check script that fails if known write verbs are introduced without a live-write guard.
+
+### 4. OAuth Scope Blast Radius Is High
+
+Risk: One Google OAuth token set carries broad read/write access across Gmail, Calendar, Drive, Sheets, Docs, and Tasks. The same token directory powers local UI, backend, and MCP flows.
+
+Evidence:
+
+- `services.py:88-98` includes `gmail.readonly`, `gmail.modify`, `gmail.send`, `gmail.settings.basic`, full `calendar`, full `drive`, full `spreadsheets`, full `documents`, and `tasks`.
+- `services.py:330-416` loads every token in `tokens/` and builds service clients for all providers.
+- `services.py:341-358` auto-reauths legacy tokens missing scopes when `credentials.json` exists.
+- `CLAUDE.md:265-272` documents multi-account tokens and fallback write routing.
+- `.gitignore` excludes `credentials.json`, `token.json`, `tokens/`, `github_token.txt`, `google_maps_key.txt`, and `gemini_api_key.txt`.
+
+Why it matters:
+
+A leaked token, exposed gateway, or wrong account selection has full cross-product impact. The app needs a different risk posture for read-only agents, local trusted TUI usage, and remote write-capable clients.
+
+Next safe work:
+
+- Split read-only and write-capable OAuth profiles.
+- Require explicit reauth for full Drive/Docs/Sheets write scopes.
+- Store token metadata with scope class and refuse write endpoints when only read profile is active.
+
+### 5. Primary-Vs-Dev Routing Can Mutate The Daily Driver
+
+Risk: Docs warn that primary runs at `9849` and dev worktrees run at `9850+`, but repo-local MCP configs still point to `9849` by default. Misconfigured agent clients can appear to test a dev branch while mutating the primary daily-driver backend.
+
+Evidence:
+
+- `CLAUDE.md:16-21` says primary checkout `~/projects/inbox` on `9849` is the daily driver.
+- `CLAUDE.md:54-56` warns macOS data-source paths are shared across worktrees and MCP defaults to `9849`.
+- `.mcp.json` points both `inbox` and `inbox-readonly` at `http://127.0.0.1:9849`.
+- `config/codex.inbox.example.toml` also defaults to `9849`, with dev override shown only as a commented example.
+- `dev.sh` correctly sets `INBOX_SERVER_PORT=9850` and `INBOX_SERVER_URL=http://127.0.0.1:9850`.
+
+Why it matters:
+
+Wrong-port mutation is a credible failure mode already documented in `MCP_SETUP.md`. It is worse when raw REST writes are not confirmation-gated.
+
+Next safe work:
+
+- Add `/health` fields for repo root, branch, port, and `INBOX_TEST_MODE`.
+- Add a client-side startup check that refuses writes when `cwd` and `INBOX_SERVER_URL` do not match the expected worktree.
+- Provide generated per-worktree MCP config instead of repo-default `9849` examples for active development.
+
+### 6. Local Personal Data Is Copied Into Plaintext App Stores
+
+Risk: The app reads sensitive local stores in read-only mode, but also creates its own plaintext caches and notes that can contain message bodies, contact details, commitments, and transcripts.
+
+Evidence:
+
+- `services.py:67-80` resolves iMessage, Notes, and Reminders DBs under `~/Library/...` unless `INBOX_TEST_MODE` redirects paths.
+- `contacts.py:38-75` reads AddressBook SQLite files directly with `mode=ro`.
+- `message_sync.py:452-469` reads iMessage messages from `chat.db` in `mode=ro`.
+- `message_index_store.py:100-120` stores `sender`, `recipients_json`, `subject`, `snippet`, and full `body_text` in `.inbox_index.sqlite3`.
+- `memory_store.py:9-39` creates `.inbox_memory.sqlite3` in the repo by default.
+- `ambient_notes.py:14-38` writes daily notes under `~/vault/daily/`.
+
+Why it matters:
+
+The repo-level `.gitignore` prevents accidental commits, but the local artifacts remain sensitive. A backup, agent file read, prompt, or support bundle can leak raw message bodies and transcripts.
+
+Next safe work:
+
+- Add a data-retention doc with exact local files, plaintext fields, and cleanup commands.
+- Add optional redaction for indexed body text and memory entries.
+- Add a health/status endpoint that reports cache locations without revealing sensitive content.
+
+### 7. Ambient Listening And Dictation Have Permission And Data-Leak Risks
+
+Risk: Ambient capture reads microphone input and writes transcripts/summaries to disk. Dictation injects recognized text into the current macOS focus using CGEvent. These are high-trust local automations with limited guardrails at the REST boundary.
+
+Evidence:
+
+- `services.py:4525-4537` configures MLX Whisper, whisper-stream paths, sample rate, chunk length, and silence threshold.
+- `services.py:4613-4620` starts ambient capture and flush threads.
+- `services.py:4628-4696` records audio through `sounddevice`, transcribes it, and calls the note writer.
+- `services.py:4702-4714` injects typed text via Quartz CGEvent.
+- `services.py:4750-4812` starts `whisper-stream` and types new transcript segments into the focused app.
+- `inbox_server.py:3047-3113` exposes `/ambient/start`, `/ambient/stop`, `/dictation/start`, and `/dictation/stop`.
+- `inbox_server.py:1249-1267` can auto-start ambient listening when voice config enables it, unless `INBOX_DISABLE_AMBIENT` is set.
+- `services.py:6090-6118` persists voice config under `~/.config/inbox/voice.json`.
+
+Why it matters:
+
+Accidental remote/local invocation can start microphone capture or keyboard injection. The persisted transcript and vault notes can include private conversations.
+
+Next safe work:
+
+- Require explicit local confirmation for ambient/dictation start endpoints.
+- Include running state and last-start origin in health/status.
+- Add tests ensuring `INBOX_TEST_MODE` blocks ambient/dictation start and voice config mutations unless explicitly opted in.
+
+### 8. Bulk Helper Scripts Can Mutate Without Shared Auth/Policy
+
+Risk: Several scripts directly target `http://localhost:9849`; some do not pass `INBOX_SERVER_TOKEN`, and some perform bulk archive/unsubscribe workflows after only a terminal prompt.
+
+Evidence:
+
+- `batch/batch-runner.sh` reads `INBOX_SERVER_URL` and `INBOX_SERVER_TOKEN`, supports `--dry-run`, and posts `/gmail/batch-modify`.
+- `unsubscribe_bulk.py` hardcodes `http://localhost:9849` and posts `/messages/gmail/bulk-unsubscribe` without token handling.
+- `unsubscribe_interactive.py` hardcodes `http://localhost:9849` and posts individual unsubscribe endpoints without token handling.
+- `unsubscribe_all_newsletters.py` hardcodes `http://localhost:9849`, scans up to 500 conversations, then batches `/messages/gmail/bulk-unsubscribe`.
+- `organize_inbox.py` uses the first Gmail account returned by `google_auth_all()` rather than `INBOX_DEFAULT_GOOGLE_ACCOUNT`.
+
+Why it matters:
+
+Scripts either fail against an authenticated backend or succeed against an unauthenticated/misconfigured backend. They bypass MCP confirmation and can mutate the wrong account if the first token is not the intended account.
+
+Next safe work:
+
+- Convert scripts to `InboxClient`, including token and URL handling.
+- Make dry-run the default for bulk scripts.
+- Require account display and typed confirmation that includes account plus operation count.
+
+### 9. Deployment And Logs Expose Operational Details
+
+Risk: Deployment examples are helpful but expose health publicly, source env files through shell, and write logs to `/tmp`. Errors may include account names, paths, provider IDs, and operational traces.
+
+Evidence:
+
+- `deploy/Caddyfile.example` exposes `/health` and `/mcp` for full and read-only hostnames.
+- `mcp_gateway.py:61-82` health includes backend health, memory DB path, and whether public auth is enabled.
+- `deploy/com.inbox.backend.plist.example`, `deploy/com.inbox.mcp.plist.example`, and `deploy/com.inbox.mcp-readonly.plist.example` use `source config/inbox.env` through `/bin/bash -lc`.
+- The launchd plists log to `/tmp/inbox-*.out.log` and `/tmp/inbox-*.err.log`.
+- `scripts/setup_inbox_mcp.sh` installs all three launch agents and starts them with `launchctl load`.
+
+Why it matters:
+
+Public health can reveal filesystem layout and backend state. `/tmp` logs may be readable depending on host policy and can collect sensitive traces over time.
+
+Next safe work:
+
+- Split public health from private diagnostics.
+- Add log redaction and log rotation guidance.
+- Prefer system service environment mechanisms over shell-sourcing env files where possible.
+
+### 10. External Compute Retry Script Is Out Of Band
+
+Risk: `oci_retry.sh` is unrelated to inbox runtime and can launch OCI compute instances in an infinite loop with hardcoded compartment, subnet, image, public IP, and SSH key path.
+
+Evidence:
+
+- `oci_retry.sh` loops forever until `oci compute instance launch` succeeds.
+- It requests `VM.Standard.A1.Flex`, 4 OCPUs, 24 GB RAM, 200 GB boot volume, and public IP.
+- It logs to `/Users/jwalinshah/projects/inbox/oci_retry.log`.
+
+Why it matters:
+
+This is a cost/external-service risk living in a personal inbox repo. It is not protected by the app's auth, test-mode, or confirmation conventions.
+
+Next safe work:
+
+- Move it out of the repo or quarantine it under a clearly labeled manual-ops directory.
+- Add an explicit prompt/confirmation and max attempt count.
+- Document provider, region, expected cost, and stop conditions.
+
+## Stale Or Weak Assumptions
+
+- `README.md` says Python 3.10+ is required, but `pyproject.toml` requires `>=3.12,<3.15`.
+- `MCP_V1_PLAN.md` says write tools are confirmation-gated, which is true for MCP tools but not for raw REST endpoints or TUI/client methods.
+- `README.md` says all data processing happens on-device, but the repo also uses Google APIs, GitHub REST, optional Google Maps, and optional Gemini.
+- `docs/TESTING_FOR_AGENTS.md` recommends `INBOX_TEST_MODE=1 uv run pytest -m safe`, but only two test modules are marked `safe` today.
+- `CLAUDE.md` says organization does not archive/delete, but adjacent scripts such as `unsubscribe_all_newsletters.py` explicitly bulk unsubscribe and archive.
+- The read-only MCP surface filters the shared registry by `readonly=True`, but public health can still disclose backend and memory DB information.
+
+## Validation Surface
+
+Observed available validation commands:
+
+- Required queue validation: `git status --short`.
+- Agent-safe test loop in `docs/TESTING_FOR_AGENTS.md`: `INBOX_TEST_MODE=1 uv run pytest -m safe`, `uv run ruff check .`, `uv run pyright`.
+- Full default pytest command from `pyproject.toml`: `uv run pytest`, with coverage addopts.
+- Lint/type commands in `README.md` and `CLAUDE.md`: `uv run ruff check --fix .`, `uv run pyright`.
+- Security scanner dependency is present in `pyproject.toml` as `bandit`; Bandit config skips several subprocess/assert-related rules.
+
+Validation blockers observed:
+
+- `INBOX_TEST_MODE=1 uv run pytest -m safe --collect-only -q` failed because uv tried to use `/Users/jwalinshah/.cache/uv`, which is outside the sandbox.
+- `UV_CACHE_DIR=/tmp/uv-cache INBOX_TEST_MODE=1 uv run pytest -m safe --collect-only -q` failed because dependencies were not cached and network is unavailable for downloading `mlx-whisper`.
+- The second `uv` attempt created an ignored `.venv/`; cleanup was blocked by command policy.
+
+Exact validation command candidates:
+
+- `git status --short` should pass locally and is the only required queue validation.
+- `UV_CACHE_DIR=/tmp/uv-cache INBOX_TEST_MODE=1 uv run pytest -m safe -q` is expected to fail in this worker until dependencies are already cached or network is available.
+- `UV_CACHE_DIR=/tmp/uv-cache INBOX_TEST_MODE=1 uv run pytest tests/test_inbox_test_mode.py tests/test_mcp_gateway.py -q` is the cheapest current safe-test candidate after dependency resolution.
+- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check .` is expected to be a useful lint command after dependency resolution.
+- `UV_CACHE_DIR=/tmp/uv-cache uv run pyright` is expected to be useful after dependency resolution, but may surface existing type debt because the repo uses many dynamic provider clients.
+
+## Next Grabbable Tasks
+
+### Task 1: Add Endpoint-Level Write Policy
+
+Acceptance criteria:
+
+- All FastAPI mutating endpoints require explicit confirmation or an approved local trusted origin.
+- MCP confirmation and REST confirmation use one shared policy helper.
+- Tests prove direct calls to Gmail, calendar, reminders, Drive, Sheets, Docs, Tasks, ambient/dictation, notifications, and GitHub write endpoints reject missing confirmation.
+
+Validation:
+
+- `UV_CACHE_DIR=/tmp/uv-cache INBOX_TEST_MODE=1 uv run pytest tests/test_server.py tests/test_mcp_gateway.py -q`
+- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check .`
+
+### Task 2: Close Live-Write Guard Gaps
+
+Acceptance criteria:
+
+- Add `_assert_live_write_allowed` to `drive_upload`, `sheets_rename_sheet`, `sheets_format`, `sheets_copy_to`, `docs_insert_text`, and `calendar_rsvp_event`.
+- Add parametrized tests that each function raises `LiveWriteBlocked` before touching provider mocks when `INBOX_TEST_MODE=1`.
+- Add a grep-based test or static test listing known mutators.
+
+Validation:
+
+- `UV_CACHE_DIR=/tmp/uv-cache INBOX_TEST_MODE=1 uv run pytest tests/test_services.py tests/test_drive.py tests/test_calendar.py -q`
+
+### Task 3: Harden HTTP MCP And Health Exposure
+
+Acceptance criteria:
+
+- HTTP MCP fails closed when `INBOX_MCP_TOKEN` is unset unless an explicit local-dev env var is set.
+- Public health no longer exposes memory DB path or private backend error details.
+- Docs and examples explain fail-closed behavior and local dev override.
+
+Validation:
+
+- `UV_CACHE_DIR=/tmp/uv-cache INBOX_TEST_MODE=1 uv run pytest tests/test_mcp_gateway.py -q`
+- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check mcp_gateway.py mcp_server.py inbox_mcp_readonly.py`
+
+### Task 4: Make Agent-Safe Validation Boring
+
+Acceptance criteria:
+
+- Expand `pytest.mark.safe` coverage or add a curated safe test target file/list.
+- Document `UV_CACHE_DIR=/tmp/uv-cache` for sandboxed workers.
+- Add a no-network collect smoke command that does not create `.venv` in restricted environments unless explicitly requested.
+
+Validation:
+
+- `UV_CACHE_DIR=/tmp/uv-cache INBOX_TEST_MODE=1 uv run pytest -m safe --collect-only -q`
+- `UV_CACHE_DIR=/tmp/uv-cache INBOX_TEST_MODE=1 uv run pytest -m safe -q`
+
+### Task 5: Normalize Bulk Scripts Through The Client
+
+Acceptance criteria:
+
+- `unsubscribe_bulk.py`, `unsubscribe_interactive.py`, and `unsubscribe_all_newsletters.py` use `InboxClient` or shared URL/token config.
+- Dry-run is default for all bulk operations.
+- Confirmation includes account, operation, number of messages, and whether archive/trash/unsubscribe will occur.
+
+Validation:
+
+- `UV_CACHE_DIR=/tmp/uv-cache INBOX_TEST_MODE=1 uv run pytest tests/test_client.py tests/test_gmail_actions.py -q`
+- Manual dry-run only; no live provider calls.
+
+## Non-Goals
+
+- No product code edits.
+- No live Gmail, Calendar, Drive, Docs, Sheets, Tasks, iMessage, Reminders, GitHub, Maps, microphone, desktop notification, or external compute calls.
+- No secrets, token files, or local personal data stores were opened.
+- No deploys, service starts, pushes, PRs, or external tracker updates.
+- No attempt to resolve all docs-claim drift; only risk-relevant stale assumptions were recorded.
+
+## Unknowns
+
+- Whether the daily-driver host currently has `INBOX_SERVER_TOKEN` or `INBOX_MCP_TOKEN` configured.
+- Whether the HTTP MCP gateway is exposed through Caddy/ngrok or only used locally.
+- Whether user intent is to keep raw REST endpoints friendly for local TUI use or to make every write confirmation-gated.
+- Whether `.inbox_index.sqlite3`, `.inbox_memory.sqlite3`, vault notes, and `/tmp/inbox-*.log` are backed up or synced elsewhere.
+- Whether broad Google scopes are required for near-term workflows or can be split now.
+- Whether the ignored `.venv/` created by the validation attempt should be cleaned manually outside the policy-restricted worker.

--- a/docs/overnight/inbox-sym-116-architecture-map.md
+++ b/docs/overnight/inbox-sym-116-architecture-map.md
@@ -1,0 +1,469 @@
+# inbox-sym-116 architecture-map audit
+
+Date: 2026-05-07
+Queue item: inbox-sym-116-architecture-map
+Focus area: architecture-map
+Repo path: `/Users/jwalinshah/projects/agent-stack/.agent-stack-worktrees/2026-05-07-overnight-marathon/inbox-sym-116-architecture-map`
+
+## Scope and state
+
+This was a read-only architecture audit. I did not touch product code, generated data, secrets, external services, deploys, pushes, or PRs. The only intended repository mutation is this report at `docs/overnight/inbox-sym-116-architecture-map.md`.
+
+Observed repository state:
+
+- Branch: `codex/goal-inbox-sym-116-architecture-map`.
+- Starting HEAD: `2805b8400519da188ca7d3f6e39b19a8ca42b05a`.
+- Starting dirty state: `git status --short --branch` returned only `## codex/goal-inbox-sym-116-architecture-map`, so the worktree was clean before this report.
+- `llm-tldr tree .` showed a flat Python application with top-level service, UI, MCP, indexing, scheduler, and test modules rather than a package directory hierarchy.
+- `fd -t f . docs` showed only `docs/TESTING_FOR_AGENTS.md` before this report, so `docs/overnight/` is new for this queue item.
+
+## Repo purpose
+
+`inbox-sym-116` is a local-first personal communication and productivity control plane. The intended user-facing shape is a Textual TUI and local FastAPI server that consolidate iMessage, Gmail, Calendar, Docs, Sheets, Drive, Notes, Reminders, GitHub notifications, audio/LLM helpers, and MCP access for agents.
+
+The intended architecture is documented as a client-server split:
+
+- `README.md:128-144` says `services.py` is the data layer, `inbox_server.py` is the FastAPI wrapper, `inbox_client.py` is the HTTP client, and `inbox.py` is the Textual TUI.
+- `CLAUDE.md:74-88` expands that map with MCP, scheduler, contacts, ambient notes, local memory, token files, and local credential files.
+- `CONNECTOR_ROADMAP.md:15-24` states the target layering more explicitly: source adapters, normalization layer, policy layer, and intent tools.
+
+The implemented architecture is close to that intent at the outer boundaries, but internally it is still dominated by two large hubs:
+
+- `services.py` is 6,467 lines and explicitly says "All data fetching, auth, mutation, audio, and LLM logic lives here" at `services.py:1-4`.
+- `inbox.py` is 4,279 lines and owns most UI models, screens, key bindings, background workers, and assistant-control-plane calls.
+- `inbox_server.py` is 3,940 lines and imports a very broad service surface directly from `services.py` at `inbox_server.py:61-141`.
+
+## Commands run
+
+Architecture and state commands:
+
+- `llm-tldr tree .`
+- `git status --short --branch`
+- `git log --oneline -5`
+- `git branch --show-current`
+- `git rev-parse HEAD`
+- `wc -l *.py tests/*.py`
+- `rg -n "^(class|def|async def) " *.py`
+- `llm-tldr search "if __name__|FastAPI|uvicorn|MCP|FastMCP|class .*App|Textual|@app|@mcp" .`
+- `rg --files | rg '^agents/'`
+- `rg -n "from agents|import agents|agents/" .`
+
+Docs, config, and validation commands:
+
+- `rtk read pyproject.toml`
+- `rtk read README.md`
+- `rtk read CLAUDE.md`
+- `rtk read CONNECTOR_ROADMAP.md`
+- `rtk read MCP_V1_PLAN.md`
+- `rtk read DOCS_INDEX.md`
+- `rtk read docs/TESTING_FOR_AGENTS.md`
+- `rg -n "Python 3\\.10|requires-python|736|production-ready|All .*tests pass|TUI tab|Complete|local-first|no cloud|Qwen|Gemini|default 9849|port 9849" README.md DOCS_INDEX.md CLAUDE.md pyproject.toml CONNECTOR_ROADMAP.md`
+- `rg -n "addopts|markers|safe|pytest|ruff|pyright|bandit" pyproject.toml docs/TESTING_FOR_AGENTS.md tests/conftest.py`
+- `rg --files -uu | rg '(^|/)(\\.gitignore|credentials\\.json|token\\.json|tokens|github_token\\.txt|google_maps_key\\.txt|gemini_api_key\\.txt|\\.env|\\.inbox_.*\\.sqlite3|server\\.log)$'`
+- `nl -ba .gitignore | sed -n '1,160p'`
+
+Focused code reads:
+
+- `nl -ba inbox_server.py | sed -n '1,140p'`
+- `nl -ba inbox_server.py | sed -n '750,860p'`
+- `nl -ba inbox_server.py | sed -n '1198,1368p'`
+- `nl -ba inbox_server.py | sed -n '1363,1605p'`
+- `nl -ba inbox_server.py | sed -n '2900,3035p'`
+- `nl -ba inbox_server.py | sed -n '3670,3905p'`
+- `nl -ba services.py | sed -n '1,140p'`
+- `nl -ba services.py | sed -n '315,433p'`
+- `nl -ba services.py | sed -n '3800,3990p'`
+- `nl -ba services.py | sed -n '4020,4368p'`
+- `nl -ba services.py | sed -n '4390,4510p'`
+- `nl -ba google_account_resolution.py | sed -n '1,330p'`
+- `nl -ba inbox_client.py | sed -n '1,520p'`
+- `nl -ba inbox.py | sed -n '1138,1218p'`
+- `nl -ba inbox.py | sed -n '4030,4288p'`
+- `nl -ba mcp_backend.py | sed -n '1,220p'`
+- `nl -ba mcp_server.py | sed -n '1,190p'`
+- `nl -ba tools_registry.py | sed -n '1,120p'`
+- `nl -ba mcp_gateway.py | sed -n '1,115p'`
+- `nl -ba message_index_store.py | sed -n '1,520p'`
+- `nl -ba message_sync.py | sed -n '1,120p'`
+- `nl -ba message_sync.py | sed -n '181,240p'`
+- `nl -ba message_sync.py | sed -n '498,668p'`
+- `nl -ba thread_classifier.py | sed -n '1,180p'`
+- `nl -ba gmail_triage.py | sed -n '1,130p'`
+- `nl -ba gmail_triage.py | sed -n '203,330p'`
+- `nl -ba scheduler.py | sed -n '1,300p'`
+- `nl -ba memory_store.py | sed -n '1,140p'`
+- `nl -ba ambient_notes.py | sed -n '1,120p'`
+- `nl -ba tests/test_server.py | sed -n '1,160p'`
+- `nl -ba tests/test_api_contract.py | sed -n '1,180p'`
+- `nl -ba tests/test_mcp_gateway.py | sed -n '1,130p'`
+
+## Architecture map
+
+### Outer entrypoints
+
+- `inbox.py:4277-4279` is the TUI entrypoint. It instantiates `InboxApp` and runs Textual.
+- `inbox_server.py:1288-1310` builds the FastAPI app through `create_app()` and binds module-level `app`.
+- `mcp_server.py:148-155` starts an HTTP MCP gateway on `127.0.0.1:8000`.
+- `inbox_mcp_readonly.py:83-91` starts a read-only HTTP MCP gateway, defaulting to port 8001.
+- `inbox_mcp_stdio.py:13-21` and `inbox_mcp_readonly_stdio.py:7-15` wrap those MCP surfaces for stdio clients.
+- `message_sync.py:638-659` provides a CLI for `bootstrap`, `incremental`, `rebuild`, and `summary` index operations.
+- `main.py:1-6` is a placeholder that prints "Hello from inbox!" and is not aligned with the documented entrypoints.
+- `dev.sh:1-11` is the worktree launcher and defaults dev copies to port 9850.
+- `scripts/run_inbox_backend.sh:1-9` and `scripts/run_inbox_mcp_http.sh:1-9` launch backend and MCP with `UV_CACHE_DIR` defaulted to `/tmp/uv-cache`.
+
+There is no `[project.scripts]` section in `pyproject.toml`; `rg -n "\\[project\\.scripts\\]|scripts|entry-points|console_scripts" pyproject.toml` returned no matches. Operational entrypoints are therefore file/script based, not installed console commands.
+
+### UI and client boundary
+
+`inbox.py` is intended to be a thin client, but it carries substantial local behavior:
+
+- `inbox.py:1147-1218` defines `InboxApp`, CSS, key bindings, polling constants, and UI state.
+- `inbox.py:4030-4067` directly imports `save_favorites` from `services.py`, so the UI is not purely HTTP-backed.
+- `inbox.py:4070-4163` owns assistant modal flow and calls `from agents.runner import Supervisor` at `inbox.py:4131`.
+- `rg --files | rg '^agents/'` returned no tracked `agents/` package, while `rg -n "from agents|import agents|agents/" .` found only memory-context references in `AGENTS.md` and the runtime import in `inbox.py:4131`. That makes the assistant-control-plane path ambiguous in this checkout.
+- `inbox_client.py:21-77` wraps `httpx.Client`, injects `INBOX_SERVER_TOKEN` when present, can auto-start `inbox_server.py`, and writes `server.log`.
+- `inbox_client.py:81-520` exposes a broad sync API mirroring many server endpoints.
+
+The practical boundary is "mostly HTTP client", not "strict HTTP client". A future worker should not assume UI changes are isolated from backend modules.
+
+### FastAPI backend boundary
+
+`inbox_server.py` is the orchestration layer and API surface:
+
+- It imports models, services, and helpers directly from many modules, with the broadest import fan-in from `services.py` at `inbox_server.py:61-141`.
+- `ServerState` centralizes live service handles, caches, background services, scheduler, index store, and adapters at `inbox_server.py:802-818`.
+- Module-level global state is created at `inbox_server.py:821-822`.
+- `InboxServerRuntime` at `inbox_server.py:825-834` is an important test seam. Tests can inject fake state, fake auth, disabled scheduler, and disabled ambient autostart.
+- `make_lifespan()` performs startup work: contact load, Google auth, optional conversation prewarm, optional ambient autostart, and scheduler launch at `inbox_server.py:1198-1272`.
+- Auth is optional: `_is_authorized()` returns true when `INBOX_SERVER_TOKEN` is empty at `inbox_server.py:1317-1320`.
+
+This layer successfully gives tests a controlled runtime seam, but it still owns enough runtime state and route logic that it is a second hub rather than only a thin transport wrapper.
+
+### Source adapters and data layer
+
+`services.py` is the current all-source integration layer:
+
+- `services.py:54-99` defines credential paths, local macOS DB paths, token paths, and broad Google OAuth scopes.
+- `services.py:109-120` provides contact initialization and the `INBOX_TEST_MODE` live-write guard hook.
+- `services.py:330-416` loads all Google accounts and builds Gmail, Calendar, Drive, Sheets, Docs, and Tasks services.
+- The file also contains iMessage, Gmail, Calendar, Notes, WhatsApp, Reminders, Tasks, Gemini, Maps, GitHub, Drive, Sheets, Docs, audio, LLM, search, notifications, favorites, contacts, and calendar availability logic.
+
+`service_models.py` is a cleaner boundary:
+
+- `service_models.py:11-153` defines dataclass models for Contact, Msg, CalendarEvent, Note, Reminder, GoogleTask, GitHubNotification, DriveFile, Spreadsheet, Document, and ThreadSummary.
+
+`google_account_resolution.py` is a partial policy extraction:
+
+- `google_account_resolution.py:24-33` centralizes default Google account selection using `INBOX_DEFAULT_GOOGLE_ACCOUNT` when available.
+- `google_account_resolution.py:85-107` resolves Gmail message/thread ownership by explicit account, cache, provider probe, then default account.
+- `google_account_resolution.py:160-304` implements preflight payloads for doc, sheet, Drive folder, task, and calendar writes.
+
+The data-layer direction is good, but extraction is incomplete. Some server paths still bypass the helper:
+
+- `inbox_server.py:1419-1424` falls back to `next(iter(state.gmail_services.values()))` for Gmail message reads.
+- `inbox_server.py:1555-1558` lists labels by using `next(iter(state.gmail_services))` rather than `_get_gmail_service_for_account`.
+
+### MCP and agent boundary
+
+MCP is split into backend client, gateway auth/app, full server, read-only server, stdio wrappers, and a registry:
+
+- `mcp_backend.py:18-56` routes MCP tool calls to the private HTTP server and forwards `INBOX_SERVER_TOKEN`.
+- `mcp_gateway.py:32-45` checks `INBOX_MCP_TOKEN`, but permits requests when the token is unset.
+- `mcp_gateway.py:87-94` mounts `/health` and `/mcp` with the public-auth middleware.
+- `mcp_server.py:41-45` defines confirmation errors for hand-written write tools.
+- `mcp_server.py:142-145` registers the shared registry and creates the app.
+- `inbox_mcp_readonly.py:77-80` registers the same registry with `readonly_only=True`.
+- `tools_registry.py:1-12` documents the important design decision: one table drives full and read-only MCP servers to reduce drift.
+- `tools_registry.py:52-107` dynamically builds tool handlers, including `confirm=True` enforcement at `tools_registry.py:73-78`.
+
+Command observation: `rg -c "Tool\\(" tools_registry.py` returned 60 tools, `rg -c "readonly=True" tools_registry.py` returned 29 read-only tools, and `rg -c "confirm=True" tools_registry.py` returned 34 confirmation-gated tools.
+
+This is one of the healthier boundaries in the repo. The main risk is deployment/auth posture: docs describe the MCP server as public assistant-facing, but code makes token auth optional.
+
+### Index, ranking, and workflow boundary
+
+The newest architecture direction is the local index and workflow read model:
+
+- `message_index_store.py:12-14` defaults to `.inbox_index.sqlite3`.
+- `message_index_store.py:80-170` initializes `sync_state`, `items`, `threads`, and `sender_stats`.
+- `message_index_store.py:407-520` rebuilds thread rows from indexed items and classifies them.
+- `message_sync.py:181-240` bootstraps Gmail by calling `google_auth_all()` and paginating Gmail messages.
+- `message_sync.py:498-582` bootstraps and incrementally syncs local iMessage by rowid.
+- `message_sync.py:602-627` combines Gmail and iMessage sync, then rebuilds changed thread scopes.
+- `thread_classifier.py:18-47` scores/classifies indexed threads with deterministic heuristics.
+- `gmail_triage.py:17-31` defines normalized `GmailThreadSummaryOut`.
+- `gmail_triage.py:203-225` ranks threads using recency, reply need, action items, workflow, and message count.
+- `inbox_server.py:3805-3853` exposes index threads, status, health, views, and sync endpoints.
+
+This boundary is promising because it moves the model-facing read path away from raw provider payloads. It is still limited to Gmail and iMessage, while `inbox/needs-action` only combines indexed threads with Tasks and Calendar at `inbox_server.py:3739-3802`.
+
+### Persistence and background work
+
+Local stores and background behavior are spread across several modules:
+
+- `scheduler.py:15-17` stores scheduler state in `.inbox_scheduler.sqlite3`.
+- `scheduler.py:59-114` creates scheduled message, follow-up, and task-message-link tables.
+- `memory_store.py:9-10` stores local MCP memory in `.inbox_memory.sqlite3`.
+- `memory_store.py:46-70` creates the memory table and lookup index.
+- `ambient_notes.py:14-17` writes daily and ambient notes under `~/vault`.
+- `ambient_notes.py:28-38` appends to today's daily note.
+
+These modules are clearer than `services.py`, but they write local user state outside the repo or to ignored local SQLite files. That is correct for the product, but future validation must stay in test mode or use temp paths.
+
+### Config, secrets, and generated state
+
+The repo has a reasonable ignore posture:
+
+- `.gitignore:12-25` ignores credentials, Google tokens, GitHub/Maps/Gemini key files, env files, and key/secret patterns.
+- `.gitignore:34-35` ignores logs.
+- `.gitignore:40-43` ignores `.claude/`, `.inbox_memory.sqlite3`, and `.inbox_scheduler.sqlite3`.
+- `.gitignore:45-49` keeps batch inputs but ignores generated batch outputs/logs/state.
+- `.gitignore:58` ignores `.inbox_index.sqlite3`.
+- `rg --files -uu` for likely secret/state paths only returned `.gitignore`, so no obvious credential or local DB file was visible in this worktree.
+
+## Working boundaries
+
+1. Test runtime injection exists and is useful. `InboxServerRuntime` lets tests bypass real contacts, Google auth, scheduler, and ambient startup. Tests use it in `tests/test_server.py:29-56` and `tests/test_api_contract.py:46-72`.
+
+2. MCP registry is centralized. `tools_registry.py` drives both full and read-only MCP surfaces, and `tests/test_api_contract.py:75-88` verifies every registered tool path maps to a FastAPI route.
+
+3. Account policy is no longer prompt-only. `google_account_resolution.py` has real helpers for default account, message ownership, per-service account lookup, and preflight payloads.
+
+4. The index read model is its own subsystem. `message_index_store.py`, `message_sync.py`, `thread_classifier.py`, and `gmail_triage.py` form a separable path for compact, classified inbox reads.
+
+5. Agent-safe testing is documented. `docs/TESTING_FOR_AGENTS.md:8-18` gives safe commands, and `inbox_test_mode.py:18-31` implements test-mode detection and temp test data root.
+
+## Risks and stale assumptions
+
+### Risk 1: `services.py` is a high-blast-radius integration hub
+
+Evidence:
+
+- `services.py:1-4` explicitly puts data fetching, auth, mutation, audio, and LLM logic in one file.
+- `wc -l *.py tests/*.py` reported `services.py` at 6,467 lines.
+- `inbox_server.py:61-141` imports a very large set of functions/classes directly from `services.py`.
+
+Why it matters:
+
+Small changes to one provider can import or initialize unrelated provider dependencies. This increases test setup cost, makes ownership unclear, and encourages bypassing emerging boundaries like `google_account_resolution.py` or the index read model.
+
+Next safe direction:
+
+Extract one source at a time behind existing function names or adapter protocols, starting with Drive/Docs/Sheets because they share Google account policy and have clear endpoint clusters.
+
+### Risk 2: Write safety is inconsistently enforced at the service layer
+
+Evidence:
+
+- `services.py:114-120` defines `_assert_live_write_allowed`.
+- Many write functions call it, as shown by `rg -n "_assert_live_write_allowed" services.py`.
+- But mutating functions are present without visible guard calls in their function bodies: `drive_upload` at `services.py:3864`, `sheets_rename_sheet` at `services.py:4315`, `sheets_format` at `services.py:4341`, `sheets_copy_to` at `services.py:4358`, and `docs_insert_text` at `services.py:4476`.
+- These are exposed through server endpoints including `upload_to_drive` at `inbox_server.py:2549`, `rename_sheet_tab` at `inbox_server.py:2733`, `copy_sheet_tab` at `inbox_server.py:2741`, `format_spreadsheet` at `inbox_server.py:2755`, and `insert_doc_text` at `inbox_server.py:2979`.
+
+Why it matters:
+
+`INBOX_TEST_MODE=1` is the repo's safety contract for deterministic agent runs. If some write paths bypass the service-layer guard, future tests or tools may mutate live Google/Drive/Docs/Sheets state unexpectedly.
+
+Next safe direction:
+
+Add service-level guards to every mutating provider function and add focused tests that assert `LiveWriteBlocked` for each exposed write cluster.
+
+### Risk 3: Auth defaults are open unless environment variables are set
+
+Evidence:
+
+- `inbox_server.py:1317-1320` authorizes all private server requests when `INBOX_SERVER_TOKEN` is unset.
+- `mcp_gateway.py:36-45` authorizes public MCP requests when `INBOX_MCP_TOKEN` is unset.
+- `MCP_V1_PLAN.md:14-21` describes a security model where the public MCP auth uses `INBOX_MCP_TOKEN`.
+- `mcp_server.py:148-151` binds to `127.0.0.1`, but `MCP_V1_PLAN.md:39-50` documents exposing the gateway through ngrok.
+
+Why it matters:
+
+The default is convenient for local development but dangerous if a launch script or tunnel exposes MCP without `INBOX_MCP_TOKEN`. The docs state the security model, but the runtime does not fail closed.
+
+Next safe direction:
+
+Add a startup health warning or strict mode for public MCP when `INBOX_MCP_TOKEN` is missing, and make deploy scripts opt into dev-open behavior explicitly.
+
+### Risk 4: Account-routing extraction is incomplete
+
+Evidence:
+
+- `google_account_resolution.py:24-33` centralizes default account selection.
+- `google_account_resolution.py:85-107` handles Gmail ownership resolution.
+- `inbox_server.py:1419-1424` still uses a direct fallback to the first Gmail service for message reads.
+- `inbox_server.py:1555-1558` still uses direct first-account selection for label reads.
+- `CONNECTOR_ROADMAP.md:30-40` says Google writes should default to `jshah1331@gmail.com` through `INBOX_DEFAULT_GOOGLE_ACCOUNT`, and object ownership should be explicit.
+
+Why it matters:
+
+The repo has already had account-routing issues historically, and partial extraction makes future regressions likely. Any route that bypasses the helper can disagree with preflight, MCP, or workflow tools.
+
+Next safe direction:
+
+Create an account-routing audit test that enumerates all Google endpoints and fails on direct `next(iter(state.*_services))` fallback outside the policy helper.
+
+### Risk 5: Startup has side effects that complicate validation
+
+Evidence:
+
+- `inbox_server.py:1213-1230` loads contacts and authenticates every Google service during lifespan startup.
+- `inbox_server.py:1249-1267` may autostart ambient listening depending on voice config and availability.
+- `inbox_server.py:1269-1272` starts the scheduler loop unless runtime disables it.
+- `tests/test_server.py:29-56` shows tests need explicit fake runtime setup to avoid these side effects.
+
+Why it matters:
+
+Running `uv run python inbox_server.py` in a worktree is not a neutral validation command. It can touch local contacts, OAuth tokens, audio, and scheduler state. Architecture workers should use tests with injected runtime or `INBOX_TEST_MODE=1`, not live server boot.
+
+Next safe direction:
+
+Document and enforce a "no live startup in agent validation" rule near server entrypoints, or add a `--test-runtime`/`INBOX_SAFE_SERVER=1` mode for local server smoke checks.
+
+### Risk 6: Documentation has stale or unsupported operational claims
+
+Evidence:
+
+- `pyproject.toml:5` requires Python `>=3.12,<3.15`, while `README.md:32` says Python 3.10+.
+- `DOCS_INDEX.md:44` and `DOCS_INDEX.md:140` claim 736 tests pass and production readiness, but this audit did not run the full suite and current tests are not counted there.
+- `DOCS_INDEX.md:137` says "TUI tab for Sheets - coming later", while the TUI key bindings and client/server surface have moved beyond the original Sheets-only documentation.
+- `README.md:25` says local-first ML has no cloud dependencies, while `CLAUDE.md:294` and `services.py` include optional Gemini API behavior.
+
+Why it matters:
+
+Future agents will use docs as a task contract. Stale runtime/version/test claims can send workers to the wrong validation lane or make them trust unverified behavior.
+
+Next safe direction:
+
+Split "current verified state" from roadmap claims and update version/test claims with command outputs.
+
+### Risk 7: Assistant control plane appears referenced but not tracked
+
+Evidence:
+
+- `inbox.py:4131` imports `Supervisor` from `agents.runner`.
+- `rg --files | rg '^agents/'` returned no tracked `agents/` package.
+- `AGENTS.md` memory context references prior `agents/` scaffolding work, but the files are not present in this worktree.
+
+Why it matters:
+
+The TUI assistant modal may be dead code in a clean checkout, or it may rely on ignored/local-only files. Either case is an ownership risk because future workers cannot reason about or test that path from tracked repo state alone.
+
+Next safe direction:
+
+Either restore the tracked `agents/` package, move the assistant bridge behind an optional import boundary with tests, or remove/docs-gate the feature until the dependency is available.
+
+## Independently grabbable next tasks
+
+### Task 1: Complete service-level live-write guard coverage
+
+Acceptance criteria:
+
+- Every mutating function in `services.py` starts by calling `_assert_live_write_allowed(...)`.
+- At minimum, add guards for `drive_upload`, `sheets_rename_sheet`, `sheets_format`, `sheets_copy_to`, and `docs_insert_text`.
+- Add tests that set `INBOX_TEST_MODE=1` and assert these functions raise `LiveWriteBlocked`.
+- No live credentials, Google API calls, or local user data are touched by tests.
+
+Validation candidates:
+
+- `INBOX_TEST_MODE=1 uv run pytest tests/test_inbox_test_mode.py tests/test_services.py -q` - expected pass after tests are updated.
+- `uv run ruff check services.py tests/test_services.py` - expected pass.
+
+### Task 2: Finish Google account-routing consolidation
+
+Acceptance criteria:
+
+- Replace direct first-account fallbacks in `inbox_server.py` with helpers from `google_account_resolution.py`.
+- Add coverage for Gmail message reads, labels, compose/reply, Docs, Sheets, Drive, Calendar, and Tasks account selection.
+- Add a regression test that fails if `next(iter(state.*_services))` appears in server endpoint code outside the policy helper.
+- Returned Google objects preserve or expose account/ownership consistently.
+
+Validation candidates:
+
+- `INBOX_TEST_MODE=1 uv run pytest tests/test_gmail_actions.py tests/test_server.py tests/test_api_contract.py -q` - expected pass after route tests are updated.
+- `uv run ruff check inbox_server.py google_account_resolution.py tests/test_gmail_actions.py tests/test_server.py tests/test_api_contract.py` - expected pass.
+
+### Task 3: Make the MCP public-auth posture fail-safe
+
+Acceptance criteria:
+
+- Public MCP startup or health clearly distinguishes dev-open mode from token-protected mode.
+- Exposing the MCP gateway without `INBOX_MCP_TOKEN` requires an explicit env var such as `INBOX_MCP_ALLOW_NO_AUTH=1`.
+- Read-only and full MCP servers share the same auth behavior.
+- Docs and launch scripts are updated to mention the token requirement before ngrok/public exposure.
+
+Validation candidates:
+
+- `INBOX_TEST_MODE=1 uv run pytest tests/test_mcp_gateway.py -q` - expected pass with new auth cases.
+- `uv run ruff check mcp_gateway.py mcp_server.py inbox_mcp_readonly.py tests/test_mcp_gateway.py` - expected pass.
+
+### Task 4: Decide the tracked assistant-control-plane boundary
+
+Acceptance criteria:
+
+- The `agents.runner` import in `inbox.py` is either backed by tracked code, moved behind an optional integration adapter, or removed from active UI paths.
+- TUI behavior when the dependency is absent is tested and documented.
+- No local-only `.claude/` or ignored package is required to import and run the TUI.
+
+Validation candidates:
+
+- `INBOX_TEST_MODE=1 uv run pytest tests/test_inbox_app.py -q` - expected pass after optional dependency behavior is covered.
+- `uv run pyright` - expected pass or known existing type blockers documented.
+
+### Task 5: Create a module ownership map before splitting `services.py`
+
+Acceptance criteria:
+
+- Add a docs-only ownership map that groups `services.py` functions by provider and side-effect class.
+- Identify extraction order, adapter protocol shape, and tests for the first provider slice.
+- Do not move code in this planning task.
+
+Validation candidates:
+
+- `git status --short` - expected docs-only change.
+- `INBOX_TEST_MODE=1 uv run pytest -m safe` - expected pass, but note current `safe` marker coverage is narrow.
+
+## Validation command candidates
+
+Required queue validation:
+
+- `git status --short` - expected to exit 0. Actual run after writing this report exited 0 and returned `?? docs/overnight/`, which is the untracked report directory containing this file.
+
+Safe architecture-proof commands for future code changes:
+
+- `INBOX_TEST_MODE=1 uv run pytest -m safe` - expected pass for currently marked safe tests. Important caveat: `rg -n "pytestmark = pytest.mark.safe|@pytest.mark.safe" tests` found only `tests/test_inbox_test_mode.py` and `tests/test_mcp_gateway.py` marked safe, so this is a cheap smoke proof, not broad coverage.
+- `INBOX_TEST_MODE=1 uv run pytest tests/test_api_contract.py tests/test_tools_registry.py tests/test_mcp_gateway.py -q` - expected pass after MCP/API-route changes.
+- `INBOX_TEST_MODE=1 uv run pytest tests/test_server.py tests/test_gmail_actions.py -q` - expected pass after server/account-routing changes.
+- `INBOX_TEST_MODE=1 uv run pytest tests/test_message_index_store.py tests/test_message_sync.py -q` - expected pass after index/read-model changes.
+- `uv run ruff check .` - expected pass for code style, but it was not required or run for this docs-only audit.
+- `uv run pyright` - expected candidate for type-sensitive refactors, but existing type state was not verified in this audit.
+
+Commands to avoid as routine agent validation:
+
+- `uv run python inbox_server.py` - not a neutral smoke test because server lifespan loads contacts, authenticates Google accounts, may autostart ambient listening, and may start scheduler background work.
+- Live provider tests or routes without `INBOX_TEST_MODE=1` - not safe for overnight read-only audit work.
+
+## Non-goals
+
+- No product-code edits.
+- No refactors.
+- No live server startup.
+- No OAuth, token, credential, or local personal-data reads.
+- No Google, GitHub, MCP, ngrok, or other external-service calls.
+- No generated data cleanup.
+- No PR creation, pushes, merges, or external tracker updates.
+
+## Unknowns
+
+- I did not run full pytest, ruff, pyright, or bandit. This audit only identifies candidate commands and architecture risks.
+- I did not verify live server health, Google account availability, local macOS data stores, Obsidian vault contents, audio stack, or MCP client connectivity.
+- I could not determine whether the missing `agents/` package is intentionally ignored/local-only, accidentally omitted, or obsolete.
+- I did not inspect sibling repos from `repos.json` because this repo is large enough for a full standalone architecture audit and the queue item is scoped to this repo only.
+- I did not verify the exact current test count behind the docs' "736 tests pass" claim.
+
+## Decision notes
+
+- Treat `inbox_server.py` as the current API orchestration boundary, not as a thin wrapper.
+- Treat `services.py` as a legacy integration hub that needs staged extraction, not a stable long-term source-adapter layer.
+- Treat `google_account_resolution.py`, `tools_registry.py`, and the message index modules as the most promising existing seams for safer future work.
+- Treat live server startup as out of scope for agents unless a task explicitly opts into local personal-data integration testing.

--- a/docs/overnight/inbox-sym-116-dependency-surface.md
+++ b/docs/overnight/inbox-sym-116-dependency-surface.md
@@ -1,0 +1,431 @@
+# inbox-sym-116 dependency-surface audit
+
+Queue item: `inbox-sym-116-dependency-surface`
+Repo: `inbox-sym-116`
+Focus area: dependency surface
+Audit date: 2026-05-07
+
+## Scope and decision
+
+This is a read-only dependency-surface audit. I did not touch product code,
+credentials, generated runtime data, external services, deploys, pushes, or
+external trackers. The only intended change is this report.
+
+Decision: do not run `uv run ...` validation during the audit. The repository
+is dependency-heavy, `uv run` may create `.venv` or cache state, and this queue
+item's required validation command is `git status --short`. I treated tests,
+lint, typecheck, and lock checks as validation candidates instead of executing
+them.
+
+## Repo purpose and state
+
+The repo is a local-first personal inbox TUI and private API. `README.md` says
+it consolidates iMessage, Gmail, Calendar, Sheets, Apple Notes, Apple Reminders,
+GitHub notifications, Google Drive, ambient listening, dictation, and AI
+autocomplete into a keyboard-driven Textual app. The architecture is a FastAPI
+backend (`inbox_server.py`), a sync client (`inbox_client.py`), a Textual TUI
+(`inbox.py`), MCP adapters (`mcp_server.py`, `inbox_mcp_readonly.py`), and a
+large service module (`services.py`) that owns most external data access.
+
+Observed git state before writing this report:
+
+```text
+git branch --show-current
+codex/goal-inbox-sym-116-dependency-surface
+
+git rev-parse HEAD
+2805b8400519da188ca7d3f6e39b19a8ca42b05a
+
+git status --short
+<empty>
+```
+
+The final validation is expected to show this new report as the only dirty
+worktree state.
+
+## Evidence inventory
+
+| Evidence | Observation |
+| --- | --- |
+| `llm-tldr tree .` | Repo is a flat Python app with `services.py`, `inbox_server.py`, `inbox.py`, MCP entrypoints, `tests/`, `config/`, `deploy/`, `.factory/`, and `uv.lock`. |
+| `git status --short --branch` | Started on `codex/goal-inbox-sym-116-dependency-surface` with no dirty file output. |
+| `pyproject.toml:5-26` | Runtime requires Python `>=3.12,<3.15` and declares 19 runtime dependencies, including FastAPI, Google APIs, MCP, MLX, Outlines, pyobjc, Textual, Uvicorn, and sounddevice. |
+| `pyproject.toml:28-66` | Dev dependencies and tooling are ruff, pyright, pytest, pytest-cov, bandit, hypothesis, pre-commit, and python-dotenv; pytest always adds coverage via `--cov=. --cov-report=term-missing`. |
+| `uv.lock` command observation | `rg '^name = ' uv.lock | wc -l` returned `149`, so the lockfile brings in a large transitive closure. |
+| `uv.lock:860-935` | The locked `inbox` package mirrors `pyproject.toml`; direct package metadata does not include `requests`, CoreLocation, or UserNotifications. |
+| `uv.lock:1171-1248` and `uv.lock:2658-2745` | ML/audio dependencies pull platform-specific MLX wheels and `torch`; the lockfile also contains Linux CUDA/NVIDIA packages behind markers. |
+| `README.md:31-33` vs `pyproject.toml:5` | README claims Python 3.10+, but package metadata requires Python 3.12 through below 3.15. |
+| `README.md:144-150` and `services.py:65-86` | Runtime reads local macOS SQLite databases, local OAuth token files, and local API key files from user and repo paths. |
+| `services.py:88-98` | Google OAuth scopes include Gmail readonly/modify/send/settings, Calendar, Drive, Sheets, Docs, and Tasks. |
+| `services.py:330-390` | `google_auth_all()` creates `tokens/`, migrates `token.json`, may launch an OAuth local server, and builds Gmail, Calendar, Drive, Sheets, Docs, and Tasks services. |
+| `services.py:576-623` and `services.py:2819-2845` | iMessage and Reminders writes shell out to `osascript`, guarded by `INBOX_TEST_MODE` checks. |
+| `services.py:3488-3504` and `services.py:3510-3522` | Location and Maps behavior depend on optional `CoreLocation`, `INBOX_HOME_ADDRESS`, `GOOGLE_CLOUD_API_KEY`, `GOOGLE_MAPS_API_KEY`, or `google_maps_key.txt`. |
+| `services.py:5429-5584` and `services.py:6088-6118` | User preferences write to `~/.config/inbox/notifications.json`, `favorites.json`, and `voice.json`, with test-mode path redirection available. |
+| `inbox_client.py:16-25` | Clients default to `INBOX_SERVER_PORT`/`INBOX_SERVER_URL` and attach `INBOX_SERVER_TOKEN` only when present. |
+| `inbox_server.py:1313-1325` | Backend auth is optional; if `INBOX_SERVER_TOKEN` is empty, all requests are authorized. |
+| `mcp_gateway.py:18-44` | Public MCP auth is also optional through `INBOX_MCP_TOKEN`; empty token allows access. |
+| `.mcp.json` and `.cursor/mcp.json` | Both checked-in MCP configs point to `http://127.0.0.1:9849` and inherit `${INBOX_SERVER_TOKEN}`. |
+| `config/inbox.env.example` and `.env.mcp.example` | Example env files define `INBOX_SERVER_URL`, `INBOX_SERVER_TOKEN`, `INBOX_MCP_TOKEN`, and optional `INBOX_MEMORY_DB`. |
+| `scripts/run_inbox_*.sh` | Service launchers set `UV_CACHE_DIR=${UV_CACHE_DIR:-/tmp/uv-cache}` and run `uv run python ...`, so service startup can write cache state outside the repo. |
+| `deploy/*.service.example` and `deploy/*.plist.example` | Deployment examples hard-code `/Users/jwalinshah/projects/inbox`, source `config/inbox.env`, and write logs under `/tmp`. |
+| `.gitignore` | Secrets, `.venv`, coverage, logs, `.tldr/`, `.claude/`, `.inbox_memory.sqlite3`, `.inbox_scheduler.sqlite3`, `.inbox_index.sqlite3`, and batch generated outputs are ignored. |
+| `.factory/services.yaml` | Factory metadata defines `uv sync`, pytest, pyright, ruff, and a port-9849 service; its test command differs from agent testing docs. |
+| `docs/TESTING_FOR_AGENTS.md:9-18` | Agent-safe validation should use `INBOX_TEST_MODE=1 uv run pytest -m safe`, `uv run ruff check .`, `uv run pyright`, or a focused test mode test. |
+| `tests/conftest.py:15-35` | Tests stub heavy ML/hardware modules (`mlx_lm`, `mlx_whisper`, `sounddevice`, `outlines`, `Quartz`), which is good for CI but can hide runtime dependency drift. |
+| `inbox_mcp_readonly.py:44-50` | `read_daily_note()` references `ambient_notes.VAULT_DIR`, but `ambient_notes.py` defines `VAULT_PATH`, `DAILY_DIR`, and `AMBIENT_DIR`; this looks like a stale symbol. |
+| Command observation | `git ls-files | wc -l` returned `196`; `git ls-files .factory | wc -l` returned `85`; `du -sh .factory uv.lock tests .` returned `424K`, `432K`, `568K`, `2.4M`. |
+
+## Dependency surface map
+
+### Python and package management
+
+- Package manager: `uv`; lockfile: `uv.lock`; local Python pin file:
+  `.python-version` contains `3.12`.
+- Runtime dependencies are centralized in `pyproject.toml`, but runtime imports
+  also include transitive or optional packages not directly declared:
+  `requests` (`services.py:1052`), `CoreLocation` (`services.py:3488`),
+  `UserNotifications` through dynamic import (`services.py:5524-5528`), and
+  `objc` through dynamic import (`services.py:5524`).
+- `requests` is present in `uv.lock` as a transitive package (`uv.lock:2200`),
+  but relying on it transitively is fragile if Google dependency versions move.
+- The lockfile contains expensive ML packages (`mlx`, `mlx-lm`, `mlx-whisper`,
+  `torch`, CUDA/NVIDIA packages behind Linux markers). These are runtime deps
+  even though tests stub many of them.
+- The README and package metadata disagree on Python support:
+  `README.md:31-33` says Python 3.10+, while `pyproject.toml:5` says
+  `>=3.12,<3.15`.
+- `.factory/library/environment.md:12` claims Python 3.12+ and says
+  "currently 3.14.3 installed", which is another environment claim that may be
+  local and stale.
+
+### Runtime entrypoints and scripts
+
+- `README.md:36-45` documents `uv run python inbox.py` and
+  `uv run python inbox_server.py`.
+- `dev.sh` defaults worktrees to `INBOX_SERVER_PORT=9850` and derives
+  `INBOX_SERVER_URL` from it, then execs `uv run python`.
+- `scripts/run_inbox_backend.sh`, `scripts/run_inbox_mcp_http.sh`,
+  `scripts/run_inbox_mcp_http_readonly.sh`,
+  `scripts/run_inbox_mcp_stdio.sh`, and
+  `scripts/run_inbox_mcp_stdio_readonly.sh` all set `UV_CACHE_DIR` to
+  `/tmp/uv-cache` by default and launch the corresponding Python entrypoint.
+- `scripts/setup_inbox_mcp.sh` copies `config/inbox.env.example` to
+  `config/inbox.env`, chmods it to 600, and installs launchd agents on macOS.
+  That is useful but mutates user-level service state and should not be run by
+  unattended audit workers.
+- `batch/batch-runner.sh` maintains `batch/archive-state.tsv` and `batch/logs/`
+  and performs Gmail archive operations via curl. Its generated outputs are
+  ignored, while `batch/archive-input.tsv` is tracked and currently only has a
+  header.
+- `organize-inbox-helper.sh` can start the backend in the background and then
+  invoke `uv run python organize_inbox.py`; this is a live Gmail label workflow,
+  not an agent-safe validation command.
+
+### Environment variables and secret files
+
+Known env vars from code and config:
+
+- `INBOX_SERVER_PORT`: backend port defaulting to 9849.
+- `INBOX_SERVER_URL`: client/MCP backend target defaulting to
+  `http://127.0.0.1:9849`.
+- `INBOX_SERVER_TOKEN`: optional private REST API bearer token.
+- `INBOX_MCP_TOKEN`: optional public MCP bearer token.
+- `INBOX_MCP_READONLY_PORT`: read-only HTTP MCP port defaulting to 8001.
+- `INBOX_MEMORY_DB`: optional MCP memory sqlite path.
+- `INBOX_DEFAULT_GOOGLE_ACCOUNT`: write-routing override for Google services.
+- `INBOX_TEST_MODE`, `INBOX_TEST_DATA_DIR`, `INBOX_TEST_NOW`: test safety and
+  deterministic data controls.
+- `INBOX_PRE_WARM_CONVERSATIONS`: startup pre-warm switch.
+- `INBOX_DISABLE_AMBIENT`: disables ambient autostart.
+- `INBOX_HOME_ADDRESS`: fallback origin for maps/departure features.
+- `GOOGLE_CLOUD_API_KEY`, `GOOGLE_MAPS_API_KEY`, `GEMINI_API_KEY`: optional
+  API-backed feature keys.
+- `MLX_LARGE_MODEL`: alternate MLX model setting.
+- `INBOX_POLL_INTERVAL`: TUI polling interval.
+
+Secret/local files:
+
+- `credentials.json`: Google OAuth client secret.
+- `token.json`: legacy Google token.
+- `tokens/*.json`: per-account Google tokens.
+- `github_token.txt`: GitHub PAT.
+- `google_maps_key.txt`: Google Maps key fallback.
+- `gemini_api_key.txt`: Gemini key fallback.
+- `config/inbox.env`: local private env file.
+- `.env`, `.env.local`, `.envrc`, `*.key`, and `*.secret`: ignored.
+
+### Local data, generated artifacts, and caches
+
+Local personal data paths:
+
+- `~/Library/Messages/chat.db`
+- `~/Library/Group Containers/group.com.apple.notes/NoteStore.sqlite`
+- `~/Library/Group Containers/group.com.apple.reminders/Container_v1/Stores/Data-*.sqlite`
+- `~/Library/Application Support/AddressBook/Sources/*/AddressBook-v22.abcddb`
+- `~/vault/daily/` and `~/vault/ambient/`
+- `~/Downloads/` for Drive downloads
+- `~/.config/inbox/notifications.json`
+- `~/.config/inbox/favorites.json`
+- `~/.config/inbox/voice.json`
+
+Repo-local generated or persistent state:
+
+- `.inbox_memory.sqlite3`
+- `.inbox_scheduler.sqlite3`
+- `.inbox_index.sqlite3`
+- `server.log`
+- `.coverage`, `htmlcov/`
+- `batch/archive-state.tsv`, `batch/logs/`, `batch/.batch-state.lock`
+- `.venv`, `.tldr/`, `.claude/`
+
+Tracked generated-looking state:
+
+- `.factory/` contains 85 tracked files and about 424K of library and validation
+  outputs. It is part of the current handoff surface even though much of it
+  looks derived. `.factory/services.yaml` also contains commands that differ
+  from `docs/TESTING_FOR_AGENTS.md`, so future agents may choose different
+  proof commands depending on which file they read first.
+
+### MCP and service exposure
+
+- Private backend binds to `127.0.0.1` in `inbox_server.py:3939-3940`.
+- Full MCP HTTP server uses `mcp_server.py`; read-only HTTP server uses
+  `inbox_mcp_readonly.py`.
+- `mcp_gateway.py` has optional bearer auth. If `INBOX_MCP_TOKEN` is absent, the
+  public MCP layer authorizes requests.
+- `.mcp.json` and `.cursor/mcp.json` are checked in and point at port 9849.
+  That is convenient for primary local use but easy to misuse in a worktree if
+  `INBOX_SERVER_URL` is not overridden.
+- `deploy/Caddyfile.example` exposes only `/health` and `/mcp` for full and
+  read-only hostnames; deployment examples source `config/inbox.env`.
+
+## Risks and stale assumptions
+
+1. Python version claims conflict.
+   README says Python 3.10+ (`README.md:31-33`), `.python-version` says 3.12,
+   `.factory/library/environment.md:12` says Python 3.12+ with a local 3.14.3
+   note, and `pyproject.toml:5` requires `>=3.12,<3.15`. A new agent or user
+   following README on Python 3.10/3.11 will hit resolver or syntax failures.
+
+2. Heavy runtime dependencies are not separated from core server/TUI paths.
+   `mlx-lm`, `mlx-whisper`, `sounddevice`, `outlines`, `torch`, and platform
+   wheels are part of the base runtime lock. Tests stub several of them, so CI
+   may pass while a fresh runtime install fails or becomes much larger than
+   expected. This matters for simple backend/MCP use cases that do not need
+   ambient audio or local LLM features.
+
+3. Some imports are transitive or optional but not explicitly declared.
+   `services.py` imports `requests` directly, but `pyproject.toml` does not
+   declare it. CoreLocation and UserNotifications are also used without direct
+   pyobjc framework declarations. Because `pyproject.toml:51` enables
+   `reportMissingImports`, this is likely to surface in typecheck or fresh
+   installs.
+
+4. Auth defaults are permissive when tokens are unset.
+   `inbox_server.py:1317-1325` and `mcp_gateway.py:36-45` both allow all
+   requests if their token env vars are empty. That is acceptable for a loopback
+   private service, but dangerous if deployment or Caddy exposure happens before
+   `INBOX_SERVER_TOKEN` and `INBOX_MCP_TOKEN` are set.
+
+5. Worktree routing can silently talk to the primary inbox.
+   `dev.sh` supports alternate ports, but checked-in MCP configs point at
+   `127.0.0.1:9849`. The docs warn about this, but there is no validation guard
+   proving an MCP client's `cwd` and `INBOX_SERVER_URL` match the target
+   worktree. This is especially risky because the app operates on personal data.
+
+6. Validation instructions disagree and may be stale.
+   `docs/TESTING_FOR_AGENTS.md` recommends `INBOX_TEST_MODE=1 uv run pytest -m
+   safe`, while `.factory/services.yaml` recommends pytest with audio/LLM tests
+   ignored, and `DOCS_INDEX.md:42-44` claims `uv run pytest` had 736 passing
+   tests. The repo currently has 31 test files, and this audit did not verify
+   that 736-pass claim.
+
+7. Read-only MCP has a stale ambient note path symbol.
+   `inbox_mcp_readonly.py:47` references `ambient_notes.VAULT_DIR`, but
+   `ambient_notes.py:14-16` defines `VAULT_PATH`, `DAILY_DIR`, and
+   `AMBIENT_DIR`. This is a narrow runtime break in the supposedly safer
+   read-only surface.
+
+8. Local state creation is broad and partly hidden behind "read" paths.
+   `google_auth_all()` creates `tokens/`, memory/index/scheduler constructors
+   create sqlite files, notification/voice config loaders create config files,
+   and service wrappers create `/tmp` logs/caches. That is manageable but should
+   be explicit in any automated validation or deploy runner.
+
+## Validation command candidates
+
+Required validation for this queue item:
+
+```bash
+git status --short
+```
+
+Observed status after this report was written: exit 0 with only
+`docs/overnight/` shown as untracked, because the report itself is the sole
+worktree change.
+
+```text
+?? docs/overnight/
+```
+
+Useful follow-up validation candidates:
+
+| Command | Expected status | Notes |
+| --- | --- | --- |
+| `git status --short --untracked-files=all` | Pass | Should identify `docs/overnight/inbox-sym-116-dependency-surface.md` exactly. |
+| `uv lock --check` | Probably pass | Confirms `pyproject.toml` and `uv.lock` agree without changing the lock. Run before dependency edits. |
+| `INBOX_TEST_MODE=1 uv run pytest tests/test_inbox_test_mode.py -q` | Should pass | Focused safety test for env redirection and live-write blocking. May create local uv/venv cache if deps are missing. |
+| `INBOX_TEST_MODE=1 uv run pytest -m safe` | Should pass if safe markers are complete | Agent-safe suite per docs, but coverage addopts and dependency install cost may be nontrivial. |
+| `uv run ruff check .` | Unknown, intended pass | Lint command from docs and factory metadata. |
+| `uv run pyright` | Risk of failure | Potential missing direct deps/imports: `requests`, CoreLocation, UserNotifications, and dynamic optional modules. |
+| `uv run pytest --ignore=tests/test_audio.py --ignore=tests/test_llm.py -x -q` | Unknown | Factory's faster test command, but differs from agent-safe docs and may still touch broad service code. |
+| `INBOX_TEST_MODE=1 INBOX_TEST_DATA_DIR=$(mktemp -d) uv run pytest tests/test_inbox_test_mode.py tests/test_mcp_gateway.py -q` | Should pass | Good proof that test-mode state stays out of personal paths and MCP auth behavior remains covered. |
+
+## Next safe work
+
+1. Normalize Python/runtime dependency declarations.
+   Acceptance criteria: README, `.python-version`, `.factory/library/environment.md`,
+   and `pyproject.toml` agree on Python support; direct imports have direct
+   dependencies or explicit optional import guards; lockfile remains consistent.
+   Suggested validation: `uv lock --check`, `uv run pyright`, and
+   `INBOX_TEST_MODE=1 uv run pytest tests/test_inbox_test_mode.py -q`.
+
+2. Split heavy ML/audio dependencies into optional extras or a documented
+   profile.
+   Acceptance criteria: backend/MCP/text TUI install path does not require
+   audio/LLM wheels; ambient/dictation/autocomplete paths fail with clear
+   feature-unavailable messages when optional deps are absent; tests still stub
+   hardware dependencies deliberately.
+   Suggested validation: a fresh sync for core deps, `uv run pyright`, and
+   focused tests in `tests/test_audio.py`, `tests/test_llm.py`, and
+   `tests/test_voice_pipeline.py` under `INBOX_TEST_MODE=1`.
+
+3. Add a dependency/state manifest for agent-safe runs.
+   Acceptance criteria: one docs page lists env vars, secret files, local data
+   paths, generated repo files, user-home writes, external APIs, and commands
+   that can mutate personal data; `docs/TESTING_FOR_AGENTS.md` links to it.
+   Suggested validation: `uv run ruff check .` if docs-only lint is configured,
+   plus `git status --short --untracked-files=all`.
+
+4. Make MCP routing self-checking for worktrees.
+   Acceptance criteria: a cheap health or diagnostic command reports backend
+   URL, repo cwd, port, and auth-enabled state; docs/config examples guide
+   primary vs dev routing without hardcoded stale paths.
+   Suggested validation: unit test around MCP config/health payload and
+   `INBOX_TEST_MODE=1 uv run pytest tests/test_mcp_gateway.py -q`.
+
+5. Fix and test read-only MCP ambient note path.
+   Acceptance criteria: `read_daily_note()` uses a defined ambient notes path,
+   returns missing-note responses without exceptions, and remains read-only.
+   Suggested validation: add or extend a focused read-only MCP test, then run
+   `INBOX_TEST_MODE=1 uv run pytest tests/test_mcp_gateway.py tests/test_ambient_notes.py -q`.
+
+6. Reconcile validation docs.
+   Acceptance criteria: README, DOCS_INDEX, `.factory/services.yaml`, and
+   `docs/TESTING_FOR_AGENTS.md` distinguish required full validation from
+   agent-safe validation; stale "736 pass" style claims are either refreshed
+   with dates/commands or removed.
+   Suggested validation: `INBOX_TEST_MODE=1 uv run pytest tests/test_inbox_test_mode.py -q`
+   and a docs review diff.
+
+## Non-goals
+
+- No product code edits.
+- No dependency upgrades or lockfile changes.
+- No `uv sync`, `uv run`, pytest, pyright, ruff, or pre-commit execution.
+- No server startup, MCP startup, launchd/systemd setup, Caddy setup, or curl
+  calls to localhost services.
+- No OAuth flow, token inspection, personal data access, microphone access,
+  AppleScript writes, Gmail/Calendar/Drive/Sheets/Docs/Tasks writes, GitHub API
+  calls, or external network calls.
+- No commits, pushes, PRs, or external tracker updates.
+
+## Unknowns
+
+- Whether a fresh `uv sync` currently succeeds on Python 3.12, 3.13, and 3.14
+  across macOS and non-macOS platforms.
+- Whether all current tests pass; this audit did not run test/lint/typecheck
+  commands beyond the required git-status validation.
+- Whether the checked-in `.factory` validation artifacts are current or stale.
+- Whether local secret files exist in the primary checkout or this worktree; I
+  did not inspect ignored files or user-home credential paths.
+- Whether the read-only MCP HTTP surface is deployed anywhere, and if so whether
+  `INBOX_MCP_TOKEN` is always set.
+- Whether heavy ML model downloads already exist in `~/.cache/huggingface/`; no
+  user cache paths were inspected.
+
+## Commands run
+
+```bash
+llm-tldr tree .
+git status --short --branch
+rtk read pyproject.toml
+rtk read README.md
+rtk read AGENTS.md
+git status --ignored --short
+rtk grep "os\\.environ|getenv|load_dotenv|INBOX_|GOOGLE|GITHUB|TOKEN|CREDENTIAL|Path.home|~/|subprocess|Popen|uv run|pytest|ruff|pyright" .
+git ls-files | sort
+rg --files -uu -g '!/.git/**' | sort
+rg '^name = ' uv.lock | wc -l
+rtk read CLAUDE.md
+rtk read docs/TESTING_FOR_AGENTS.md
+rtk read .gitignore
+rtk read .pre-commit-config.yaml
+rtk read .python-version
+rtk read config/inbox.env.example
+rtk read .env.mcp.example
+rtk read .mcp.json
+rtk read .cursor/mcp.json
+rtk read config/codex.inbox.example.toml
+rtk read config/gemini-settings.inbox.example.json
+rtk read dev.sh
+rtk read scripts/setup_inbox_mcp.sh
+rtk read batch/batch-runner.sh
+rtk read organize-inbox-helper.sh
+rtk read deploy/*.example
+rg -n "os\\.environ|getenv|os\\.getenv" -g '*.py'
+rg -n "TOKEN_FILE|TOKENS_DIR|credentials\\.json|github_token|google_maps_key|gemini_api_key|\\.sqlite|\\.json|\\.lock|Downloads|vault|Obsidian" -g '*.py' -g '*.md'
+rg -n "subprocess\\.run|subprocess\\.Popen|osascript|curl|launchctl|open\\(|webbrowser|requests|httpx" -g '*.py' -g '*.sh'
+rg -n "pytest|ruff|pyright|bandit|pre-commit|uv run|safe|live_write|local_data" -g '*.md' -g '*.toml' -g '*.yaml' -g '*.py'
+rg -o --no-filename '^(from|import) [A-Za-z0-9_\\.]+' -g '*.py' | sed -E 's/^(from|import) ([A-Za-z0-9_\\.]+).*/\\2/' | cut -d. -f1 | sort -u
+rg -n "import (requests|CoreLocation|AppKit|Foundation|Quartz|ApplicationServices|mlx|mlx_lm|mlx_whisper|outlines|sounddevice|textual|rich|fastapi|uvicorn|mcp|google|httpx|pydantic|loguru|numpy)" -g '*.py'
+nl -ba pyproject.toml | sed -n '1,80p'
+sed -n '1,80p' uv.lock
+rg -n '^name = "(inbox|requests|CoreLocation|pyobjc-framework-corelocation|pyobjc-framework-quartz|pyobjc-framework-applicationservices|mlx|mlx-metal|mlx-lm|mlx-whisper|nvidia|cuda|torch|outlines|sounddevice|fastapi|mcp|uvicorn|textual|rich)"' uv.lock
+nl -ba services.py | sed -n '50,130p'
+nl -ba services.py | sed -n '330,390p'
+nl -ba services.py | sed -n '540,660p'
+nl -ba services.py | sed -n '2810,2875p'
+nl -ba services.py | sed -n '3490,3565p'
+nl -ba tests/conftest.py | sed -n '1,120p'
+nl -ba inbox_test_mode.py | sed -n '1,90p'
+nl -ba tests/test_inbox_test_mode.py | sed -n '1,90p'
+nl -ba memory_store.py | sed -n '1,80p'
+nl -ba message_index_store.py | sed -n '1,70p'
+nl -ba scheduler.py | sed -n '1,80p'
+nl -ba ambient_notes.py | sed -n '1,90p'
+nl -ba services.py | sed -n '5418,5585p'
+nl -ba services.py | sed -n '6088,6135p'
+nl -ba inbox_server.py | sed -n '212,245p'
+nl -ba inbox_server.py | sed -n '1224,1325p'
+nl -ba inbox_server.py | sed -n '3928,3948p'
+nl -ba inbox_client.py | sed -n '14,65p'
+nl -ba mcp_backend.py | sed -n '1,70p'
+nl -ba mcp_gateway.py | sed -n '1,90p'
+nl -ba mcp_server.py | sed -n '1,80p'
+nl -ba inbox_mcp_readonly.py | sed -n '1,95p'
+nl -ba tools_registry.py | sed -n '1,180p'
+git ls-files | wc -l
+git ls-files .factory | wc -l
+du -sh .factory uv.lock tests . 2>/dev/null
+rtk read .factory/services.yaml
+rtk read .factory/library/environment.md
+rtk read batch/archive-input.tsv
+rtk read .tldrignore
+rtk read DOCS_INDEX.md
+rtk read MCP_SETUP.md
+git rev-parse HEAD
+git branch --show-current
+git status --short
+mkdir -p docs/overnight
+```

--- a/docs/overnight/inbox-sym-116-docs-claims.md
+++ b/docs/overnight/inbox-sym-116-docs-claims.md
@@ -1,0 +1,343 @@
+# inbox-sym-116 docs-claims audit
+
+Queue item: `inbox-sym-116-docs-claims`
+Branch: `codex/goal-inbox-sym-116-docs-claims`
+HEAD at audit start: `2805b8400519da188ca7d3f6e39b19a8ca42b05a`
+Focus area: docs-claims
+
+## Scope
+
+This is a read-only product audit plus one report file. I did not change product
+code, generated data, credentials, deploy config, external trackers, or remote
+services. I did not push, open a PR, or mark any tracker Done.
+
+Non-goals:
+
+- Do not validate live Gmail, Calendar, Drive, Docs, Sheets, Reminders, iMessage,
+  GitHub, WhatsApp, microphone, or notification behavior.
+- Do not start the inbox server or MCP gateways.
+- Do not repair the docs in this slice.
+- Do not create, delete, archive, send, or mutate personal data.
+
+## Repo Purpose And State
+
+The repo is a local personal inbox/control-plane application. The docs describe a
+Python Textual TUI backed by a local FastAPI server, with data adapters for
+iMessage, Gmail, Google Calendar, Google Sheets, Google Docs, Google Drive,
+Apple Notes, Apple Reminders, GitHub, local ML/audio, MCP gateways, and workflow
+tools.
+
+Observed repo state:
+
+- `git rev-parse --show-toplevel` -> `/Users/jwalinshah/projects/agent-stack/.agent-stack-worktrees/2026-05-07-overnight-marathon/inbox-sym-116-docs-claims`
+- `git branch --show-current` -> `codex/goal-inbox-sym-116-docs-claims`
+- `git rev-parse HEAD` -> `2805b8400519da188ca7d3f6e39b19a8ca42b05a`
+- Initial `git status --short --branch` was clean.
+- `llm-tldr tree .` showed a flat Python app plus root docs, `docs/TESTING_FOR_AGENTS.md`, `modes/`, `scripts/`, `deploy/`, `config/`, and 31 test files.
+
+## Commands And Observations
+
+- `llm-tldr tree .`: repo has root app modules (`inbox.py`, `inbox_server.py`,
+  `services.py`, `mcp_server.py`, `tools_registry.py`), docs, deploy examples,
+  mode prompts, scripts, and tests.
+- `rg --files -g '*.md' | wc -l`: 18 markdown docs before this report, which
+  conflicts with `DOCS_INDEX.md` saying total documentation is 6 files.
+- `rg --files tests | wc -l`: 31 test files.
+- `rg -n "^(async )?def test_" tests | wc -l`: 250 statically visible test
+  functions, not 736.
+- `rg -n "@pytest.mark.safe|pytestmark = pytest.mark.safe" tests`: only
+  `tests/test_inbox_test_mode.py` and `tests/test_mcp_gateway.py` are marked
+  safe.
+- `rg -n "@app\\.(get|post|put|patch|delete)\\(" inbox_server.py | wc -l`: 159
+  FastAPI route decorators, much broader than README and CLAUDE endpoint lists.
+- `rg -n "Tool\\(" tools_registry.py | wc -l`: 60 MCP registry tool entries.
+- `INBOX_TEST_MODE=1 uv run pytest --collect-only -q -p no:cacheprovider` failed
+  because the default uv cache path under `~/.cache/uv` is not writable in this
+  sandbox.
+- `INBOX_TEST_MODE=1 UV_CACHE_DIR=/tmp/uv-cache uv run pytest --collect-only -q -p no:cacheprovider`
+  created a temporary `.venv` and then failed because network access is blocked
+  while trying to download `mlx-whisper==0.4.3`. The generated `.venv` was moved
+  out of the repo to `/tmp/inbox-sym-116-docs-claims-venv`.
+
+## Supported Claims
+
+1. Client-server architecture is real.
+   - `README.md` and `CLAUDE.md` describe FastAPI server plus thin TUI/client.
+   - Local evidence: `inbox_server.py` defines the FastAPI app and routes;
+     `inbox_client.py` is the HTTP client; `inbox.py` is the Textual TUI;
+     `dev.sh` sets alternate worktree ports.
+
+2. Google account routing exists in code.
+   - `google_account_resolution.py:24` selects `INBOX_DEFAULT_GOOGLE_ACCOUNT`
+     when it is present in a service map, then falls back to first service key.
+   - `inbox_server.py:1460`, `1477`, `1481`, `1485`, `2767`, and `3389` delegate
+     Gmail, Sheets, Drive, Tasks, Docs, and Calendar account lookup to that
+     helper module.
+   - `tests/test_server.py` contains default-account tests for Calendar, Drive,
+     Docs, Tasks, and preflight paths.
+
+3. Sheets implementation exists and is broad.
+   - `services.py:4026` through `4358` includes listing, metadata, create,
+     trash, values get/update/append/clear, batch values, tabs, formatting, and
+     copy.
+   - `inbox_server.py:2596` through `2754` exposes `/sheets` endpoints.
+   - `tools_registry.py:176` through `235` exposes list/read/create/append
+     Sheets tools, with writes confirmation-gated.
+
+4. Google Docs exists even though some docs treat Sheets as the newest surface.
+   - `services.py:4394` through `4508` implements docs list/get/create/delete,
+     export, insert text, and text extraction.
+   - `inbox_server.py:2932` through `2986` exposes `/docs` endpoints.
+   - `tools_registry.py:751` through `817` exposes Docs tools over MCP.
+
+5. MCP setup claims are substantially backed by local files.
+   - `.mcp.json` and `.cursor/mcp.json` exist and configure full plus read-only
+     stdio servers.
+   - `mcp_backend.py:19` reads `INBOX_SERVER_URL` and `INBOX_SERVER_TOKEN`.
+   - `mcp_gateway.py:18` uses `INBOX_MCP_TOKEN`; `mcp_gateway.py:48` protects
+     non-health MCP routes; `mcp_gateway.py:87` mounts `/health` and `/mcp`.
+   - `deploy/Caddyfile.example` proxies only `/health` and `/mcp` for full and
+     read-only hosts.
+
+6. Read-only MCP separation is backed by registry filtering.
+   - `inbox_mcp_readonly.py:77` calls `register_all(..., readonly_only=True)`.
+   - `tools_registry.py:110` skips non-readonly tools when `readonly_only` is
+     true.
+   - `tests/test_tools_registry.py:46` verifies readonly registration excludes
+     write tools.
+
+7. Live-write test mode is real, but not comprehensively documented in every
+   command claim.
+   - `inbox_test_mode.py` defines `INBOX_TEST_MODE` and `LiveWriteBlocked`.
+   - `services.py:114` defines `_assert_live_write_allowed`.
+   - `services.py` calls the guard before many live writes, including Gmail,
+     Calendar, Reminders, Tasks, Drive, Sheets, Docs, GitHub notifications, and
+     desktop notifications.
+
+8. Apple Notes docs are partly true.
+   - `services.py:1872` lists Apple Notes from `NoteStore.sqlite`.
+   - `services.py:1922` fetches full note body via AppleScript, not direct
+     SQLite parsing.
+   - `inbox_server.py:1898` and `1904` expose `/notes` and `/notes/{id}`.
+
+9. The index-driven inbox direction in `PLAN.md` is backed by code.
+   - `message_index_store.py` and `message_sync.py` exist.
+   - `inbox_server.py:3739` exposes `/inbox/needs-action`.
+   - `inbox_server.py:3805` through `3850` exposes index status, views, health,
+     bootstrap sync, and incremental sync endpoints.
+   - `tests/test_server.py` has index endpoint and health tests.
+
+## Unsupported Or Stale Claims
+
+1. Python version claim is stale.
+   - `README.md:32` says Python 3.10+.
+   - `pyproject.toml:5` requires `>=3.12,<3.15`, and Ruff/Pyright are configured
+     for Python 3.12.
+
+2. Test pass-count claims are unsupported in this checkout.
+   - `DOCS_INDEX.md:44`, `DOCS_INDEX.md:140`, `SHEETS_CHANGELOG.md:38`, and
+     `SHEETS_CHANGELOG.md:114` claim all 736 tests pass.
+   - Static local count found 250 `test_` functions across 31 test files.
+   - Pytest collection could not run in this sandbox because uv needed package
+     downloads and network is disabled.
+
+3. "Total documentation: 6 files" is false.
+   - `DOCS_INDEX.md:175` says total documentation is 6 files.
+   - `rg --files -g '*.md'` found 18 markdown files before this report, including
+     `PLAN.md`, `MCP_SETUP.md`, `MCP_V1_PLAN.md`, `docs/TESTING_FOR_AGENTS.md`,
+     and five mode/profile docs.
+
+4. TUI keybinding docs are stale.
+   - `README.md:120` and `CLAUDE.md:195` say Ctrl+6 toggles ambient listening.
+   - `inbox.py:1188` maps Ctrl+6 to Reminders.
+   - `inbox.py:1193` maps Ctrl+Shift+6 to Ambient.
+   - `tui_tabs.py:19` through `120` also shows current tabs include Now,
+     Actionable, Waiting On, Reminders, GitHub, and Drive, beyond the README's
+     older Ctrl+1-5 framing.
+
+5. Local-only privacy wording is overbroad.
+   - `README.md:25` says "Local-first ML" with "no cloud dependencies".
+   - `README.md:171` says all data processing happens on-device.
+   - `pyproject.toml:10` depends on `google-generativeai`.
+   - `services.py:3249` through `3288` defines a Gemini backend.
+   - `inbox_server.py:2197` through `2261` exposes Gemini-backed AI endpoints.
+   - The app also intentionally talks to Google, GitHub, and optional Google
+     Maps APIs. A safer claim is "local default for ML/autocomplete where MLX is
+     used; provider APIs and optional Gemini/Maps are cloud surfaces."
+
+6. `SHEETS_CHANGELOG.md` tuple claims are stale.
+   - `SHEETS_CHANGELOG.md:14`, `30`, and `35` say `google_auth_all()` changed
+     from a 3-tuple to a 4-tuple and tests were updated to a 4-tuple.
+   - `services.py:330` through `416` returns a 6-tuple: Gmail, Calendar, Drive,
+     Sheets, Docs, Tasks.
+   - `inbox_server.py:1216`, `3334`, and `3351` unpack six values.
+
+7. MCP V1 plan is historical, not current.
+   - `MCP_V1_PLAN.md:17` says Calendar stays on the built-in ChatGPT Google
+     connector for now.
+   - `tools_registry.py:481` through `521` exposes calendar/maps conflict and
+     travel tools; `inbox_server.py` exposes extensive calendar routes.
+   - `MCP_V1_PLAN.md:28` lists a narrow V1 tool set, while `tools_registry.py`
+     currently has 60 tool entries, including Sheets, Drive, Docs, Tasks,
+     WhatsApp, task links, memory extraction, and GitHub.
+
+8. API references are incomplete and internally inconsistent.
+   - `README.md` lists a useful subset of endpoints, but `inbox_server.py`
+     contains 159 route decorators.
+   - `CLAUDE.md:130` lists `POST /preflight/write`, while the actual route is
+     `GET /preflight/google-write` at `inbox_server.py:3009`.
+   - README omits Google Tasks, Docs, index endpoints, workflow endpoints,
+     WhatsApp, memory extraction, contacts, query, voice config, extended
+     Calendar endpoints, and several Gmail actions.
+
+9. Account-default wording is inconsistent.
+   - `SHEETS.md:195` and `SHEETS_QUICKSTART.md:130` say omitted account uses the
+     first available account.
+   - `CONNECTOR_ROADMAP.md:38` says writes should default to
+     `INBOX_DEFAULT_GOOGLE_ACCOUNT`.
+   - Code does both: environment default if present, first service key otherwise.
+     Docs should state the actual precedence.
+
+10. Sheets "production-ready" is not locally evidenced.
+   - `DOCS_INDEX.md:140` says all 736 tests pass and production-ready.
+   - `SHEETS_CHANGELOG.md:114` says all 736 tests pass, then immediately notes
+     "Sheets functionality not directly tested in test suite".
+   - There are unit tests for routing, account helpers, and MCP registry guards,
+     but I did not find direct service-level fake Sheets API tests for every
+     claimed operation.
+
+11. "All operations available via API" for Sheets needs precision.
+   - `DOCS_INDEX.md:136` says all operations are available via API.
+   - Local code supports broad CRUD/ranges/tabs/raw `batchUpdate`, but "all
+     Sheets API operations" is too broad unless it means "all operations this
+     app currently exposes".
+
+## Risks And Stale Assumptions
+
+1. Setup risk: a new worker following `README.md` may use Python 3.10 and fail
+   before any product validation because the package requires Python 3.12+.
+
+2. Validation risk: docs repeatedly cite "736 pass" and recommend full pytest,
+   but this worktree cannot collect tests without a provisioned dependency cache
+   or network. The `safe` marker also currently covers only two modules, so
+   `pytest -m safe` is not equivalent to "all deterministic local tests".
+
+3. Operator risk: stale keybinding docs can cause live-user mistakes. Ctrl+6 is
+   no longer ambient; it switches to Reminders. Ambient is Ctrl+Shift+6.
+
+4. Privacy/security risk: unqualified "no cloud dependencies" and "all data
+   processing on-device" understate Google/GitHub/Maps/Gemini cloud surfaces and
+   may mislead users about data movement.
+
+5. API-handoff risk: agents using README/CLAUDE endpoint references may miss
+   current routes or call stale ones such as `POST /preflight/write`.
+
+6. Product-status risk: `CONNECTOR_ROADMAP.md`, `PLAN.md`, `MCP_V1_PLAN.md`,
+   `DOCS_INDEX.md`, and `SHEETS_CHANGELOG.md` mix current truth, roadmap intent,
+   and historical release notes without labeling lifecycle state.
+
+7. Safety risk: write surfaces are extensive. MCP registry confirmation gates
+   are supported by tests, but direct REST endpoints still rely on
+   `INBOX_TEST_MODE` or external client discipline; docs should separate REST
+   write risk from MCP write confirmation.
+
+## Next Safe Work
+
+1. Documentation truth pass for runtime and TUI claims.
+   - Files: `README.md`, `CLAUDE.md`, `DOCS_INDEX.md`.
+   - Acceptance criteria: Python version says 3.12+; keybindings match
+     `inbox.py`; docs count no longer claims 6; test count/pass claims are
+     removed or generated; privacy wording distinguishes local ML from provider
+     APIs and optional Gemini/Maps.
+   - Validation: `git diff --check README.md CLAUDE.md DOCS_INDEX.md` and
+     `rg -n "Python 3.10|736|Total documentation: 6|Ctrl\\+6.*Ambient|no cloud dependencies|all data processing happens on-device" README.md CLAUDE.md DOCS_INDEX.md`.
+     Expected after fix: no stale hits except intentionally quoted history.
+
+2. API docs reconciliation check.
+   - Files: add or update a docs test around `inbox_server.py`, `README.md`,
+     `CLAUDE.md`, and `tools_registry.py`.
+   - Acceptance criteria: there is one canonical generated or checked list of
+     FastAPI routes and MCP tools; stale `POST /preflight/write` is removed or
+     mapped to `GET /preflight/google-write`; docs clearly mark summary versus
+     exhaustive endpoint tables.
+   - Validation: `INBOX_TEST_MODE=1 UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/test_api_contract.py tests/test_tools_registry.py -q`.
+     Expected in provisioned env: pass. Expected in this sandbox: blocked until
+     dependencies are available locally.
+
+3. Agent-safe test marker cleanup.
+   - Files: `docs/TESTING_FOR_AGENTS.md`, `pyproject.toml`, relevant tests.
+   - Acceptance criteria: either mark deterministic tests with `safe` or change
+     docs so `pytest -m safe` is explicitly a small smoke suite; add a test that
+     prevents docs from claiming an unverified global pass count.
+   - Validation: `INBOX_TEST_MODE=1 UV_CACHE_DIR=/tmp/uv-cache uv run pytest -m safe --collect-only -q -p no:cacheprovider`.
+     Expected after dependency setup: collection succeeds and selected count is
+     intentional.
+
+4. Mark historical docs explicitly.
+   - Files: `MCP_V1_PLAN.md`, `SHEETS_CHANGELOG.md`, maybe `CONNECTOR_ROADMAP.md`.
+   - Acceptance criteria: historical tuple/pass-count statements are labeled as
+     old or corrected to six-service auth; MCP V1 plan states whether it is
+     archival or current; roadmap items that are already partially implemented
+     link to current endpoints/tests.
+   - Validation: `rg -n "4-tuple|3-tuple|736|Calendar stays on the built-in|V1 Tools" MCP_V1_PLAN.md SHEETS_CHANGELOG.md CONNECTOR_ROADMAP.md`.
+     Expected after fix: no unlabeled stale claims.
+
+5. Sheets confidence upgrade.
+   - Files: `tests/test_server.py`, `tests/test_services.py`, possibly a new
+     `tests/test_sheets.py`.
+   - Acceptance criteria: service-level fake Sheets/Drive tests cover create,
+     values update/append/clear, tabs, formatting, trash, and account selection;
+     docs avoid "production-ready" until those tests exist and pass.
+   - Validation: `INBOX_TEST_MODE=1 UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/test_server.py tests/test_services.py -k "sheet or sheets" -q`.
+     Expected after implementation: pass in provisioned env.
+
+## Validation Candidates
+
+- Required queue validation: `git status --short`. Expected now: one untracked
+  report file under `docs/overnight/`.
+- Formatting check for this docs-only slice: `git diff --check docs/overnight/inbox-sym-116-docs-claims.md`.
+  Expected: pass.
+- Full local safe loop from docs: `INBOX_TEST_MODE=1 uv run pytest -m safe`;
+  expected in this sandbox: blocked by uv cache/network unless dependencies are
+  already provisioned. Expected after setup: should pass, but currently exercises
+  only safe-marked modules.
+- API/docs contract candidate: `INBOX_TEST_MODE=1 UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/test_api_contract.py tests/test_tools_registry.py -q`.
+  Expected in this sandbox: blocked by dependency download; expected in a
+  provisioned local env: should pass if current tests are green.
+- Static stale-claim scan: `rg -n "Python 3.10|736|Total documentation: 6|Ctrl\\+6|no cloud dependencies|4-tuple|POST /preflight/write" README.md CLAUDE.md DOCS_INDEX.md SHEETS_CHANGELOG.md MCP_V1_PLAN.md`.
+  Expected now: fail with known stale claims; expected after docs cleanup: no
+  unlabeled stale hits.
+
+## Unknowns
+
+- I did not know whether the user's primary checkout has a populated `.venv` or
+  warm uv cache where pytest can run without network.
+- I did not verify live Google, Apple, GitHub, MCP, Gemini, Maps, WhatsApp, MLX,
+  audio, or notification behavior.
+- I did not inspect external issue state, PRs, deployment hosts, or live Caddy
+  configuration.
+- I did not determine whether `MCP_V1_PLAN.md` is intended to remain archival or
+  should be updated in place as current architecture.
+
+## Handoff
+
+Changed files:
+
+- `docs/overnight/inbox-sym-116-docs-claims.md`
+
+Commit SHA:
+
+- No commit created by this worker. Audit base/head SHA:
+  `2805b8400519da188ca7d3f6e39b19a8ca42b05a`
+
+PR URL:
+
+- None. PR creation is out of scope for this Goal Pack item.
+
+Blockers:
+
+- Pytest collection could not run in this sandbox because uv needed to download
+  `mlx-whisper==0.4.3` and network/DNS is unavailable.
+- Cleanup note: `rm -rf .venv` was blocked by command policy after the failed uv
+  attempt created a temporary virtualenv, so I moved `.venv` out of the repo to
+  `/tmp/inbox-sym-116-docs-claims-venv`.

--- a/docs/overnight/inbox-sym-116-risk-register.md
+++ b/docs/overnight/inbox-sym-116-risk-register.md
@@ -1,0 +1,279 @@
+# inbox-sym-116 risk register audit
+
+Queue item: `inbox-sym-116-risk-register`
+
+Focus area: security, credentials, data, deployment, destructive-command, and external-service risks.
+
+## Repo State
+
+- Repo path: `/Users/jwalinshah/projects/agent-stack/.agent-stack-worktrees/2026-05-07-overnight-marathon/inbox-sym-116-risk-register`
+- Purpose: local-first personal communications/productivity TUI and FastAPI backend for iMessage, Gmail, Calendar, Drive, Sheets, Docs, Tasks, Apple Notes, Reminders, GitHub, ambient audio, dictation, and MCP access. Evidence: `README.md:1`, `README.md:5`, `CLAUDE.md:1`, `CLAUDE.md:80`.
+- Branch: `codex/goal-inbox-sym-116-risk-register`.
+- HEAD at audit start: `2805b8400519da188ca7d3f6e39b19a8ca42b05a`.
+- Remote: `origin https://github.com/jwalin-shah/inbox.git`.
+- Dirty state at audit start: `git status --short --branch` returned only `## codex/goal-inbox-sym-116-risk-register`, so no pre-existing tracked or untracked changes were visible.
+- Scope decision: this audit only writes this report. No product code, generated data, secrets, deploys, external service calls, pushes, or PR creation were performed.
+
+## Commands Run
+
+- `llm-tldr tree .` to inventory repo structure.
+- `rg --files -g '!*__pycache__*' -g '!*.pyc'` to list tracked visible source files.
+- `rtk read README.md`, `rtk read CLAUDE.md`, `rtk read pyproject.toml`, `rtk read docs/TESTING_FOR_AGENTS.md`, and focused `nl -ba ... | sed -n ...` reads for code evidence.
+- `rg -n "@app\\.(post|put|patch|delete)" inbox_server.py | wc -l` observed 95 mutating FastAPI routes.
+- `rg -n "_assert_live_write_allowed" services.py | wc -l` observed 44 live-write guard call sites.
+- `rg -n "confirm=True" tools_registry.py | wc -l` observed 34 confirmation-gated registry tools.
+- `rg -n "readonly=True" tools_registry.py | wc -l` observed 29 read-only registry tools.
+- `wc -l services.py inbox_server.py tools_registry.py tests/test_server.py tests/test_tools_registry.py` observed `services.py` at 6467 lines and `inbox_server.py` at 3940 lines.
+- `fd -H -E .git -t f . | rg -n "(credentials|token|tokens|github_token|gemini_api_key|google_maps_key|inbox\\.env|server\\.log|\\.inbox_.*\\.sqlite3|archive-state|triage-output)"` found no live credential files; visible matches were a token-safety validation artifact and `config/inbox.env.example`.
+- `rg -n "BEGIN|PRIVATE KEY|ghp_|AIza|ya29|refresh_token|client_secret" -g '!uv.lock' -g '!docs/overnight/**' .` found only test placeholders and code references, not real secrets.
+
+## Local Evidence
+
+1. `services.py:56` stores runtime secrets and local data paths relative to the repo for credentials, tokens, GitHub token, Google Maps key, Gemini key, and local sqlite state.
+2. `services.py:88` requests broad Google scopes: Gmail read/modify/send/settings, Calendar, Drive, Sheets, Docs, and Tasks.
+3. `inbox_server.py:1317` makes backend token auth optional; if `INBOX_SERVER_TOKEN` is unset, `_is_authorized` returns true.
+4. `mcp_gateway.py:36` makes public MCP token auth optional; if `INBOX_MCP_TOKEN` is unset, non-health requests are allowed.
+5. `mcp_gateway.py:67` returns backend health, memory DB path, and `auth_enabled` from `/health`.
+6. `tools_registry.py:73` enforces `confirm=True` at the MCP registry handler layer for tools marked `confirm`.
+7. `tools_registry.py:110` supports `readonly_only=True`, and `inbox_mcp_readonly.py:77` registers only readonly registry tools.
+8. `mcp_server.py:142` registers the full registry with `readonly_only=False`; full MCP can reach mutating tools when confirmed.
+9. `inbox_server.py:1434`, `inbox_server.py:1738`, `inbox_server.py:1819`, `inbox_server.py:2548`, `inbox_server.py:2612`, and `inbox_server.py:2940` expose direct REST write routes for messaging, Gmail, Calendar, Drive, Sheets, and Docs.
+10. `services.py:114` defines test-mode live-write blocking, but production write calls proceed when `INBOX_TEST_MODE` is not set.
+11. `services.py:576`, `services.py:970`, `services.py:998`, `services.py:1607`, `services.py:2867`, `services.py:3164`, `services.py:3732`, `services.py:3912`, `services.py:4083`, and `services.py:4437` show representative live-write surfaces.
+12. `services.py:1044` executes unsubscribe URLs from email headers and then archives the message at `services.py:1083`.
+13. `scheduler.py:70` stores scheduled message text in `.inbox_scheduler.sqlite3`; `inbox_server.py:982` sends due messages from the background loop.
+14. `services.py:2804` executes AppleScript with retries; `services.py:2309` and `services.py:4702` inject text via macOS keyboard events.
+15. `inbox_mcp_readonly.py:45` defines a readonly daily-note tool, but `inbox_mcp_readonly.py:47` references `ambient_notes.VAULT_DIR`; `ambient_notes.py:14` defines `VAULT_PATH`, `DAILY_DIR`, and `AMBIENT_DIR`, not `VAULT_DIR`.
+16. `.gitignore:12` ignores credential/token files, environment files, logs, and local sqlite state. `config/inbox.env.example:3` and `config/inbox.env.example:6` document separate backend and MCP tokens.
+17. `docs/TESTING_FOR_AGENTS.md:8` recommends `INBOX_TEST_MODE=1 uv run pytest -m safe`, plus ruff and pyright. Only `tests/test_inbox_test_mode.py:8` and `tests/test_mcp_gateway.py:18` are marked `safe`, so the safe marker currently covers a narrow guardrail subset.
+18. `MCP_SETUP.md:248` says expose readonly MCP first, keep the raw backend private, require `INBOX_MCP_TOKEN`, and keep `INBOX_SERVER_TOKEN` private to the MCP host.
+
+## Risk Register
+
+### R1 - Raw backend is powerful and auth is fail-open when token is unset
+
+Severity: high.
+
+The backend guards all routes with `_is_authorized`, but `inbox_server.py:1317` returns allowed when `INBOX_SERVER_TOKEN` is empty. This is acceptable only if the backend is always bound to loopback and never exposed. The same codebase contains 95 mutating FastAPI routes, including message send, Gmail label/filter changes, Calendar CRUD, Drive upload/delete, Sheets/Docs writes, Tasks/Reminders, ambient/dictation control, and index sync. The backend binds to `127.0.0.1` in `inbox_server.py:3939`, and deployment docs say never expose it (`MCP_SETUP.md:269`), but the runtime still fails open locally.
+
+Risk event: any local process, misrouted MCP client, reverse proxy mistake, or dev worktree pointed at the primary backend can mutate personal accounts without per-operation confirmation.
+
+Current controls: loopback bind; optional bearer or `x-api-key` token; `.gitignore` for secrets; MCP confirmation gating.
+
+Gap: REST has no mandatory auth-by-default and no central write confirmation/preflight layer.
+
+### R2 - Public MCP token auth is also optional
+
+Severity: high for remote deployment, medium for local-only use.
+
+`mcp_gateway.py:36` allows all non-health MCP requests when `INBOX_MCP_TOKEN` is empty. The Caddy example exposes `/health` and `/mcp` (`deploy/Caddyfile.example:1`), and service examples load `config/inbox.env` (`deploy/inbox-mcp.service.example:7`). Docs warn to require `INBOX_MCP_TOKEN` (`MCP_SETUP.md:256`), but the process itself does not fail closed.
+
+Risk event: an HTTP MCP gateway is exposed before `INBOX_MCP_TOKEN` is set; readonly mode still leaks personal data, and full mode exposes write tools subject only to MCP `confirm=True`.
+
+Current controls: `config/inbox.env.example` has placeholders for separate tokens; `MCP_SETUP.md:144` explicitly says to use different backend and MCP tokens.
+
+Gap: no startup refusal for externally exposed full or readonly MCP when token env is missing.
+
+### R3 - Confirmation gating is MCP-only, not REST-wide
+
+Severity: high.
+
+`tools_registry.py:73` blocks mutating MCP tools unless `confirm=True`, and tests assert all non-readonly registry tools are confirm-gated (`tests/test_tools_registry.py:41`). Direct REST endpoints do not require a `confirm` field. For example, `/messages/send`, `/gmail/batch-modify`, `/calendar/events`, `/drive/upload`, `/docs/{document_id}/text`, `/scheduled`, and `/tasks/from-message` execute based on backend auth alone.
+
+Risk event: a local agent or script bypasses MCP and calls REST directly with a valid token or no token in fail-open mode.
+
+Current controls: service-layer `INBOX_TEST_MODE` blocks representative live writes during tests.
+
+Gap: no central REST write policy decorator, no write-intent audit log, and preflight is advisory only for some Google writes.
+
+### R4 - Google OAuth blast radius is broad and shared across accounts
+
+Severity: high.
+
+`services.py:88` requests full write scopes for Gmail, Calendar, Drive, Sheets, Docs, and Tasks. `google_auth_all()` loads every JSON token in `tokens/` (`services.py:367`) and builds all available services. Account fallback helpers use `INBOX_DEFAULT_GOOGLE_ACCOUNT` if set, then first service key (`google_account_resolution.py:24`). Connector roadmap documents this as a known source-of-truth risk (`CONNECTOR_ROADMAP.md:32`, `CONNECTOR_ROADMAP.md:216`).
+
+Risk event: a write goes to the wrong Google account or an unnecessarily powerful token is compromised.
+
+Current controls: account resolution helpers, preflight endpoint for selected Google write destinations, docs requiring default account policy.
+
+Gap: scope separation is not enforced at token level; readonly clients still depend on tokens that may have write scopes; fallback to first account remains possible when defaults are absent.
+
+### R5 - Unsubscribe follows arbitrary email-provided URLs and archives regardless
+
+Severity: medium-high.
+
+`gmail_unsubscribe()` parses `List-Unsubscribe` headers, then performs a `requests.post` or `requests.get` to the header URL (`services.py:1059`) and archives the message afterward (`services.py:1083`). This makes external calls to sender-provided URLs from the local host. It also archives even if the unsubscribe call fails.
+
+Risk event: a malicious or compromised sender uses unsubscribe headers for tracking, SSRF-like local network probing, or unwanted state changes, then the original message is archived.
+
+Current controls: timeout of 10 seconds; action goes through live-write guard in test mode.
+
+Gap: no URL allowlist/blocklist, no scheme/host filtering, no dry-run mode, and archive is unconditional.
+
+### R6 - Local macOS automation has high side-effect potential
+
+Severity: medium-high.
+
+iMessage sends use AppleScript (`services.py:576` and `services.py:622`), Reminders mutations use AppleScript with retries (`services.py:2804`), WhatsApp sends use Accessibility plus CGEvent keyboard injection (`services.py:2335`), and dictation injects text into the active cursor (`services.py:4702`). These are powerful local automations that can affect user-visible apps outside the repo.
+
+Risk event: wrong conversation selection, active-window confusion, duplicate AppleScript retries, or dictation injection into the wrong app.
+
+Current controls: test mode can block live writes; WhatsApp checks Accessibility before send.
+
+Gap: no production dry-run/preview gate for direct REST callers; no explicit app/window assertion for every keyboard-injection path.
+
+### R7 - Scheduler stores plaintext message content and auto-sends later
+
+Severity: medium-high.
+
+`scheduler.py:70` stores scheduled message text in local sqlite. `inbox_server.py:982` checks due messages every 30 seconds and sends Gmail/iMessage without a new confirmation at send time. `inbox_server.py:2066` lets REST create scheduled messages.
+
+Risk event: stale scheduled messages send after context changes; local sqlite leaks sensitive draft content; accidental issue/worktree shares `.inbox_scheduler.sqlite3` if ignore controls are bypassed.
+
+Current controls: `.gitignore` excludes `.inbox_scheduler.sqlite3`; cancel endpoint exists; service-layer send functions retain test-mode blocking.
+
+Gap: no send-time revalidation, no redacted list mode, no expiry, no "pending message digest" requirement before daemon startup.
+
+### R8 - Readonly MCP has a concrete daily-note bug and limited coverage
+
+Severity: medium.
+
+`inbox_mcp_readonly.py:47` references `ambient_notes.VAULT_DIR`, which does not exist. This breaks dated `read_daily_note(date=...)` requests in the safer surface recommended for cloud agents. Existing tests cover `ambient_notes.read_daily_note()` and MCP auth middleware, but not the readonly MCP daily-note handler.
+
+Risk event: morning review or cloud-agent read-only setup fails on note reads and falls back to the full MCP server.
+
+Current controls: separate readonly MCP entrypoint; registry readonly filtering is tested.
+
+Gap: no test imports/runs readonly MCP hand-written tools.
+
+### R9 - Health and logs can expose sensitive metadata
+
+Severity: medium.
+
+Backend `/health` returns account email lists and GitHub token configured status (`inbox_server.py:1346`). MCP `/health` returns backend health and memory DB path (`mcp_gateway.py:67`). `_log_service_failure()` formats arbitrary context (`services.py:139`) and many callers include email addresses, message ids, file paths, account names, and object titles.
+
+Risk event: health endpoint or logs leak account inventory and local paths to remote clients or shared logs.
+
+Current controls: backend health is token-protected when token is configured; MCP health is intentionally unauthenticated.
+
+Gap: no redaction layer for health payloads or structured logs; no documented log retention policy for `/tmp/inbox-*.log`.
+
+### R10 - Upload/download endpoints lack resource limits
+
+Severity: medium.
+
+`inbox_server.py:2548` reads the full upload body into memory before writing a temp file. Gmail attachment download returns base64 JSON (`inbox_server.py:1565`) and Drive download returns raw bytes (`inbox_server.py:2524`). These are convenient but have no visible size ceilings or streaming controls.
+
+Risk event: large files or attachments exhaust memory or produce oversized responses through MCP/REST clients.
+
+Current controls: upload temp file is unlinked in `finally`; Drive API handles storage-side file data.
+
+Gap: no max upload size, no max attachment size, no streaming response, and no content-type/file-name policy.
+
+## Stale Assumptions
+
+- "Localhost means safe" is baked into both backend and MCP auth behavior. That assumption is fragile once Caddy, LaunchAgents, worktrees, or cloud agents enter the path.
+- "Readonly MCP is the remote-safe surface" is directionally right, but hand-written readonly tools are not covered enough; the dated daily-note handler currently references a missing attribute.
+- "One Google OAuth token set is simpler" conflicts with least-privilege operation. Read-only, write, and high-risk settings scopes are currently bundled.
+- "MCP confirmation is enough" is stale because direct REST, TUI, local scripts, and scheduler paths can mutate state without MCP.
+- "Safe validation is broad" is stale because only two test modules currently carry the `safe` marker.
+
+## Next Safe Work
+
+### Task 1 - Fail closed when exposed auth tokens are missing
+
+Acceptance criteria:
+- Backend exposes explicit `auth_enabled` and startup logs distinguish "loopback dev without token" from "service mode with token required".
+- HTTP MCP full and readonly entrypoints refuse to start in service/public mode unless `INBOX_MCP_TOKEN` is set.
+- Tests cover missing-token behavior for `mcp_gateway.py` and backend health/auth mode.
+
+Validation command:
+- `INBOX_TEST_MODE=1 uv run pytest tests/test_mcp_gateway.py tests/test_server.py -k "auth or health" -q`
+
+### Task 2 - Add REST write policy metadata and confirmation/preflight coverage
+
+Acceptance criteria:
+- Every mutating FastAPI route is classified as local-state, external-write, destructive, or automation.
+- High-risk REST routes require either a typed preflight token/operation id or an explicit `confirm` field, not just bearer auth.
+- Tests prove representative routes reject missing confirmation while safe read routes continue to work.
+
+Validation command:
+- `INBOX_TEST_MODE=1 uv run pytest tests/test_server.py tests/test_tools_registry.py -q`
+
+### Task 3 - Fix and test readonly MCP hand-written tools
+
+Acceptance criteria:
+- `inbox_mcp_readonly.read_daily_note(date=...)` delegates to `ambient_notes.read_daily_note()` or uses `DAILY_DIR`, not a missing `VAULT_DIR`.
+- Tests import readonly MCP, exercise `read_daily_note()` for today and a dated note, and confirm registry writes are absent.
+- The readonly MCP health payload remains useful without leaking more than intended.
+
+Validation command:
+- `INBOX_TEST_MODE=1 uv run pytest tests/test_mcp_gateway.py tests/test_ambient_notes.py -q`
+
+### Task 4 - Harden unsubscribe execution
+
+Acceptance criteria:
+- `gmail_unsubscribe()` validates scheme and host, blocks localhost/private network targets, and supports dry-run/preflight.
+- Archive happens only after a successful unsubscribe or explicit archive confirmation.
+- Tests cover URL, mailto, invalid scheme, private-address URL, timeout, and failed unsubscribe without archive.
+
+Validation command:
+- `INBOX_TEST_MODE=1 uv run pytest tests/test_gmail_actions.py -k unsubscribe -q`
+
+### Task 5 - Split Google scopes by capability lane
+
+Acceptance criteria:
+- Read-only MCP can use read-only Google scopes where possible.
+- Write scopes are requested only for enabled write features.
+- Reauth messaging and token migration make scope expansion explicit.
+
+Validation command:
+- `INBOX_TEST_MODE=1 uv run pytest tests/test_server.py tests/test_services.py -k "auth or account or scope" -q`
+
+### Task 6 - Add scheduler safety checks
+
+Acceptance criteria:
+- Scheduled messages validate account, recipient/conversation, send time, and source at creation.
+- List endpoints redact message body by default, with explicit opt-in for full text.
+- Startup exposes a pending scheduled-message summary before background sends are enabled.
+
+Validation command:
+- `INBOX_TEST_MODE=1 uv run pytest tests/test_server.py -k "scheduled or followup" -q`
+
+## Validation Candidates
+
+- Required queue validation: `git status --short`
+  - Expected status after this report is committed or intentionally left as the only dirty file: pass, exit 0.
+- Agent-safe smoke: `INBOX_TEST_MODE=1 uv run pytest -m safe`
+  - Expected status: pass, but coverage is narrow because only two modules are marked safe.
+- Focused readonly MCP regression: `INBOX_TEST_MODE=1 uv run pytest tests/test_mcp_gateway.py tests/test_ambient_notes.py -q`
+  - Expected status before Task 3: likely pass for existing tests, but it will not catch the `VAULT_DIR` bug until a readonly MCP handler test is added.
+- REST auth/policy regression: `INBOX_TEST_MODE=1 uv run pytest tests/test_server.py -k "auth or preflight" -q`
+  - Expected status: pass for existing optional-auth/preflight behavior; should fail after adding fail-closed expectations until code is updated.
+- Lint: `uv run ruff check .`
+  - Expected status: unknown in this audit; docs list it as standard validation but it was not run because the queue validation command is `git status --short`.
+- Type check: `uv run pyright`
+  - Expected status: unknown in this audit; repo uses basic type checking.
+
+## Non-Goals
+
+- No product code changes.
+- No secret/token inspection beyond confirming live secret files were not present in the worktree.
+- No live Gmail, Calendar, Drive, Docs, Sheets, Tasks, Reminders, iMessage, WhatsApp, audio, notification, or GitHub operations.
+- No local server startup, Caddy/LaunchAgent changes, deploy changes, pushes, PR creation, or tracker updates.
+- No attempt to resolve product decisions such as which Google scopes should be permanently removed.
+
+## Unknowns
+
+- Whether the daily-driver environment currently sets `INBOX_SERVER_TOKEN`, `INBOX_MCP_TOKEN`, and `INBOX_DEFAULT_GOOGLE_ACCOUNT`.
+- Whether any deployed Caddy/LaunchAgent setup differs from the checked-in examples.
+- Whether token files on the daily-driver host contain legacy broad scopes or recently reauthed scopes.
+- Whether users rely on direct REST scripts that would break if write confirmation became mandatory.
+- Whether any hidden local logs under `/tmp/inbox-*.log` contain account metadata or message snippets.
+- Whether the scheduler has pending real scheduled messages in the daily-driver `.inbox_scheduler.sqlite3`.
+
+## Handoff Notes
+
+- The highest-leverage fix is to make public/service auth fail closed and classify all REST writes centrally.
+- The lowest-risk starter fix is Task 3: repair `inbox_mcp_readonly.py:47` and add direct tests for readonly hand-written tools.
+- Morning review should inspect this report with `git show -- docs/overnight/inbox-sym-116-risk-register.md` and verify that only this file changed for the queue item.

--- a/docs/overnight/inbox-sym-116-validation-map.md
+++ b/docs/overnight/inbox-sym-116-validation-map.md
@@ -1,0 +1,449 @@
+# inbox-sym-116 validation-map audit
+
+Queue item: `inbox-sym-116-validation-map`
+Repo: `inbox-sym-116`
+Worktree: `/Users/jwalinshah/projects/agent-stack/.agent-stack-worktrees/2026-05-07-overnight-marathon/inbox-sym-116-validation-map`
+Branch observed: `codex/goal-inbox-sym-116-validation-map`
+Base HEAD observed before report: `2805b8400519da188ca7d3f6e39b19a8ca42b05a`
+Focus area: validation-map
+
+## Scope decision
+
+This was a read-only validation audit. I did not change product code, generated data,
+secrets, deployment configuration, external services, trackers, remotes, or PR state.
+The only intended repo change is this report file.
+
+Because `docs/TESTING_FOR_AGENTS.md` says agent runs must be deterministic, local,
+and safe, I treated the documented agent-safe commands as the validation contract.
+I did not run the full unmarked test suite because the repo explicitly warns agents
+not to run local-data, live-write, or provider-specific integration tests without
+explicit opt-in.
+
+## Repo purpose
+
+`inbox-sym-116` is a local-first personal inbox/control-plane application. The core
+runtime is a Python FastAPI backend plus a Textual TUI that integrates iMessage,
+Gmail, Google Calendar, Google Sheets, Google Drive, Apple Notes, Apple Reminders,
+GitHub notifications, local ML/audio, and MCP-facing agent tools. The validation
+surface has to protect personal-data integrations while still giving agents a cheap
+proof loop.
+
+Local evidence:
+
+- `README.md` describes the product as a unified communication/productivity TUI and
+  lists `uv run ruff check --fix .`, `uv run pyright`, and `uv run pytest` as dev
+  commands.
+- `CLAUDE.md` documents worktree development on alternate ports and repeats the
+  same lint/type/test commands.
+- `docs/TESTING_FOR_AGENTS.md` is the only file found with explicit agent-safe
+  validation rules.
+- `pyproject.toml` declares Python `>=3.12,<3.15`, runtime dependencies including
+  FastAPI, Google APIs, MLX, Textual, PyObjC, Rich, MCP, and dev dependencies
+  including pytest, pytest-cov, ruff, pyright, bandit, and pre-commit.
+- `tests/conftest.py` stubs heavy ML/hardware modules (`mlx_lm`, `mlx_whisper`,
+  `sounddevice`, `Quartz`, `outlines`) but does not stub general runtime
+  dependencies such as `google_auth_oauthlib`, `textual`, `loguru`, or `trio`.
+- `inbox_test_mode.py` defines `INBOX_TEST_MODE`, `INBOX_TEST_DATA_DIR`,
+  `INBOX_TEST_NOW`, and `assert_live_writes_allowed`.
+- `services.py` calls `_assert_live_write_allowed(...)` across many mutation
+  surfaces, including Google auth, iMessage, Gmail, Calendar, WhatsApp, Reminders,
+  Drive, Sheets, Docs, and notifications.
+- `tests/test_inbox_test_mode.py` and `tests/test_mcp_gateway.py` are the only test
+  files currently marked `safe`.
+- `scripts/run_inbox_backend.sh`, `scripts/run_inbox_mcp_http.sh`, and
+  `scripts/run_inbox_mcp_http_readonly.sh` set `UV_CACHE_DIR` to `/tmp/uv-cache`
+  before invoking `uv run`, which is relevant for sandboxed agents.
+- `dev.sh` starts worktree copies on `INBOX_SERVER_PORT=9850` by default, avoiding
+  the primary daily-driver server on port 9849.
+
+## Validation surfaces found
+
+### Package and tool config
+
+`pyproject.toml` is the central validation config:
+
+- Ruff: `[tool.ruff]`, target `py312`, line length 100.
+- Ruff lint select: `E`, `F`, `I`, `UP`, `B`, `SIM`; ignores `E501`.
+- Pyright: Python 3.12, `typeCheckingMode = "basic"`, missing imports reported.
+- Pytest: `testpaths = ["tests"]`.
+- Pytest default addopts: `--cov=. --cov-report=term-missing`.
+- Pytest markers: `safe`, `integration`, `local_data`, `slow`, `live_write`.
+- Bandit configured with `exclude_dirs = [".venv", "tests"]` and skips for several
+  common subprocess/assert/import warnings.
+
+### Documented commands
+
+Agent-safe commands in `docs/TESTING_FOR_AGENTS.md`:
+
+```bash
+INBOX_TEST_MODE=1 uv run pytest -m safe
+uv run ruff check .
+uv run pyright
+```
+
+Focused safe command in `docs/TESTING_FOR_AGENTS.md`:
+
+```bash
+INBOX_TEST_MODE=1 uv run pytest tests/test_inbox_test_mode.py -q
+```
+
+General developer commands in `README.md`, `CLAUDE.md`, and `DOCS_INDEX.md`:
+
+```bash
+uv run ruff check --fix .
+uv run pyright
+uv run pytest
+```
+
+Additional historical command in `SHEETS_CHANGELOG.md`:
+
+```bash
+uv run pytest tests/ -q
+```
+
+### Test inventory
+
+Command observations:
+
+- `rg --files tests | wc -l` returned `31`.
+- `rg "^def test_|^class Test" tests | wc -l` returned `393`.
+- `rtk grep "@pytest.mark|pytestmark|mark.safe|mark.integration|mark.local_data|mark.live_write|mark.slow" tests`
+  returned only 4 marker matches across 2 files:
+  - `tests/test_inbox_test_mode.py`: `pytestmark = pytest.mark.safe`
+  - `tests/test_mcp_gateway.py`: `pytestmark = pytest.mark.safe`
+  - two `@pytest.mark.anyio` entries in `tests/test_mcp_gateway.py`
+
+This means `pytest -m safe` is currently a small marker set, not a broad suite
+classification. Most test files are unmarked.
+
+## Commands run and observed results
+
+Environment and repo state:
+
+```bash
+git branch --show-current
+# codex/goal-inbox-sym-116-validation-map
+
+git rev-parse HEAD
+# 2805b8400519da188ca7d3f6e39b19a8ca42b05a
+
+git status --short
+# clean before writing this report
+
+uv --version
+# uv 0.11.5 (Homebrew 2026-04-08 aarch64-apple-darwin)
+
+python3 --version
+# Python 3.12.8
+
+fd -H '^\.venv$' .
+# no .venv existed before the first uv attempt
+```
+
+Structure and config discovery:
+
+```bash
+llm-tldr tree .
+# observed flat Python app modules, docs, scripts, tests, pyproject.toml, uv.lock
+
+rtk read pyproject.toml
+# observed dependencies, pytest markers, pytest-cov addopts, ruff, pyright, bandit
+
+rtk read docs/TESTING_FOR_AGENTS.md
+# observed documented agent-safe validation commands and explicit opt-in warnings
+
+rtk grep "pytest|ruff|mypy|uv run|python -m|tox|coverage|lint|test" .
+# observed validation docs spread across README, CLAUDE, DOCS_INDEX, pyproject,
+# scripts, and tests
+```
+
+Safe validation attempts:
+
+```bash
+INBOX_TEST_MODE=1 uv run --frozen pytest -m safe -q
+```
+
+Result: BLOCKED before pytest. `uv` tried to initialize cache at
+`/Users/jwalinshah/.cache/uv` and failed with "Operation not permitted".
+
+```bash
+UV_CACHE_DIR=/private/tmp/inbox-sym-116-validation-map-uv-cache \
+  INBOX_TEST_MODE=1 uv run --frozen pytest -m safe -q
+```
+
+Result: BLOCKED by offline dependency hydration. `uv` created `.venv`, then failed
+to download `pyobjc-core==12.1`, included via `pyobjc-framework-quartz==12.1`,
+because DNS/network access was unavailable. `.venv` is gitignored.
+
+```bash
+INBOX_TEST_MODE=1 python3 -m pytest tests/test_inbox_test_mode.py -q
+```
+
+Result: BLOCKED by missing plugin under system Python. Pytest read
+`pyproject.toml` and rejected `--cov=. --cov-report=term-missing` because
+`pytest-cov` is not installed in the system environment.
+
+```bash
+INBOX_TEST_MODE=1 python3 -m pytest -o addopts='' -m safe -q
+```
+
+Result: FAIL during collection before marker filtering completed. The system
+environment lacks project dependencies such as `google_auth_oauthlib`, `textual`,
+and `loguru`, so unmarked test modules fail import even though only `safe` tests
+were requested.
+
+```bash
+INBOX_TEST_MODE=1 python3 -m pytest -o addopts='' \
+  tests/test_inbox_test_mode.py tests/test_mcp_gateway.py -q
+```
+
+Result: PARTIAL FAIL, 9 passed and 4 failed. Failures were environment/dependency
+failures:
+
+- `tests/test_inbox_test_mode.py::test_services_resolve_local_data_paths_under_test_dir`
+  failed importing `services.py` because `google_auth_oauthlib` is missing.
+- `tests/test_inbox_test_mode.py::test_google_auth_all_creates_missing_test_data_parent`
+  failed importing `services.py` because `google_auth_oauthlib` is missing.
+- `tests/test_mcp_gateway.py::test_health_handler_includes_backend_and_extra_payload[trio]`
+  failed because `trio` is missing.
+- `tests/test_mcp_gateway.py::test_health_handler_handles_backend_error[trio]`
+  failed because `trio` is missing.
+
+Narrow local proofs that do run under system Python:
+
+```bash
+INBOX_TEST_MODE=1 python3 -m pytest -o addopts='' \
+  tests/test_inbox_test_mode.py::test_test_mode_blocks_live_writes \
+  tests/test_inbox_test_mode.py::test_test_mode_uses_configured_test_data_dir \
+  tests/test_inbox_test_mode.py::test_agent_safe_pytest_markers_are_registered \
+  tests/test_inbox_test_mode.py::test_agent_testing_docs_define_safe_commands_and_opt_in_warnings \
+  -q
+# 4 passed in 0.03s
+```
+
+```bash
+python3 -m pytest -o addopts='' tests/test_mcp_gateway.py -k 'not trio' -q
+# 5 passed, 2 deselected in 0.17s
+```
+
+Syntax proof:
+
+```bash
+python3 -m compileall -q *.py tests
+# passed with exit code 0
+```
+
+Lint/type command observations under system Python:
+
+```bash
+python3 -m ruff check .
+# /usr/local/bin/python3: No module named ruff
+
+python3 -m pyright
+# /usr/local/bin/python3: No module named pyright
+```
+
+These do not prove lint/type failures in the repo; they prove the local
+non-`uv` tool environment is incomplete.
+
+## Current validation map
+
+| Command | Scope | Expected status in a hydrated dev env | Observed status here | Notes |
+|---|---|---:|---:|---|
+| `git status --short` | queue validation | PASS | PASS before report; expected to show only this report after write | Required by queue item. |
+| `INBOX_TEST_MODE=1 uv run pytest -m safe` | documented agent-safe tests | SHOULD PASS | BLOCKED | Needs uv cache path writable and dependencies available/cached. |
+| `INBOX_TEST_MODE=1 uv run pytest tests/test_inbox_test_mode.py -q` | focused test-mode safety | SHOULD PASS | BLOCKED through uv; partially runnable via system Python | Depends on project deps for `services.py` import cases. |
+| `uv run ruff check .` | lint | SHOULD PASS before merge | BLOCKED | Cannot hydrate uv env offline; system Python has no ruff. |
+| `uv run pyright` | type check | SHOULD PASS before merge | BLOCKED | Cannot hydrate uv env offline; system Python has no pyright. |
+| `uv run pytest` | full suite with coverage | UNKNOWN | NOT RUN | Not agent-safe by default; most tests are unmarked and repo warns against local/live/provider tests without opt-in. |
+| `uv run pytest tests/ -q` | historical full tests command | UNKNOWN | NOT RUN | Same opt-in concern; docs claim 736 pass but current grep saw 393 test defs/classes. |
+| `python3 -m compileall -q *.py tests` | syntax-only local proof | PASS | PASS | Useful fallback when dependency hydration is blocked. |
+| `python3 -m pytest -o addopts='' tests/test_mcp_gateway.py -k 'not trio' -q` | system-Python partial MCP safe proof | PASS | PASS | Avoids missing `trio` backend. |
+| selected `tests/test_inbox_test_mode.py` no-service tests | system-Python partial test-mode proof | PASS | PASS | Avoids missing Google runtime dependencies. |
+
+## Risks and stale assumptions
+
+1. Agent-safe validation depends on full dependency hydration.
+   `docs/TESTING_FOR_AGENTS.md` recommends `uv run pytest -m safe`, but in a
+   sandboxed/offline agent worktree this fails before pytest if the default uv
+   cache is outside the writable sandbox or dependencies are not already cached.
+   The scripts under `scripts/` already use `UV_CACHE_DIR=/tmp/uv-cache`, but the
+   testing docs do not mention this workaround.
+
+2. `pytest -m safe` is not guaranteed to avoid collection-time imports from
+   unmarked files. Under system Python with incomplete deps, the command still
+   hit collection errors in unmarked tests before producing a useful safe-only
+   result. This is a validation ergonomics risk for agents trying to respect the
+   safety policy.
+
+3. The safe marker set is very small. Only `tests/test_inbox_test_mode.py` and
+   `tests/test_mcp_gateway.py` are marked `safe`, while the repo has 31 test files
+   and roughly 393 test/class definitions. The documented safe command may give a
+   false sense of coverage for changes outside test-mode and MCP gateway code.
+
+4. Docs contain stale or unverified test-count claims. `DOCS_INDEX.md` and
+   `SHEETS_CHANGELOG.md` claim "All 736 tests pass"; this checkout's local grep
+   saw 393 test/class definitions and validation could not reproduce the claim.
+   The number may be historical, but morning reviewers should not treat it as
+   current evidence.
+
+5. `pyproject.toml` always injects coverage options through pytest addopts. That
+   is reasonable in the managed `uv` env, but it makes system-Python fallback
+   pytest unusable unless `-o addopts=''` is added. This matters during sandboxed
+   audits where `uv` cannot hydrate.
+
+6. `tests/conftest.py` stubs ML/hardware dependencies but not baseline app
+   dependencies. Tests that are conceptually safe can still fail to import
+   `services.py`, `inbox.py`, or async backends when the full dependency set is
+   not present.
+
+7. The validation story mixes agent-safe commands and general developer commands.
+   `README.md` and `CLAUDE.md` advertise `uv run pytest`; `docs/TESTING_FOR_AGENTS.md`
+   narrows agents to `INBOX_TEST_MODE=1 uv run pytest -m safe`. This split is good,
+   but it should be the first thing a worker sees when asked to validate changes.
+
+## Next safe work
+
+### 1. Make sandboxed agent validation boot reliably
+
+Acceptance criteria:
+
+- `docs/TESTING_FOR_AGENTS.md` includes a sandbox-friendly variant using
+  `UV_CACHE_DIR=/tmp/uv-cache` or another writable temp path.
+- The same doc explains that the default `~/.cache/uv` path can be blocked in
+  restricted worktrees.
+- No product code changes.
+
+Validation command:
+
+```bash
+UV_CACHE_DIR=/tmp/uv-cache INBOX_TEST_MODE=1 uv run --frozen pytest -m safe -q
+```
+
+Expected status: PASS in a hydrated/cached environment; BLOCKED offline until
+`pyobjc-core` and the rest of the lockfile are available locally.
+
+### 2. Add a dependency-light safe smoke lane
+
+Acceptance criteria:
+
+- Add or document a command that runs only tests which do not import `services.py`,
+  `inbox.py`, Google clients, Textual, or optional anyio trio backend.
+- The command should be useful when `uv` dependency hydration is blocked.
+- The command should include `-o addopts=''` or otherwise avoid requiring
+  `pytest-cov` under system Python.
+
+Candidate validation command:
+
+```bash
+INBOX_TEST_MODE=1 python3 -m pytest -o addopts='' \
+  tests/test_inbox_test_mode.py::test_test_mode_blocks_live_writes \
+  tests/test_inbox_test_mode.py::test_test_mode_uses_configured_test_data_dir \
+  tests/test_inbox_test_mode.py::test_agent_safe_pytest_markers_are_registered \
+  tests/test_inbox_test_mode.py::test_agent_testing_docs_define_safe_commands_and_opt_in_warnings \
+  -q
+```
+
+Expected status: PASS; observed `4 passed in 0.03s`.
+
+### 3. Fix safe marker coverage and collection behavior
+
+Acceptance criteria:
+
+- Review all tests and mark deterministic, local, non-mutating tests as `safe`.
+- Add `integration`, `local_data`, `slow`, or `live_write` markers where tests
+  should not run by default.
+- Ensure `INBOX_TEST_MODE=1 uv run pytest -m safe -q` collects cleanly and gives
+  meaningful coverage of safe surfaces.
+
+Validation commands:
+
+```bash
+rtk grep "@pytest.mark|pytestmark" tests
+INBOX_TEST_MODE=1 uv run pytest -m safe -q
+```
+
+Expected status: first command shows broad marker coverage; second command PASS
+in a hydrated environment.
+
+### 4. Replace stale test-count claims with reproducible evidence
+
+Acceptance criteria:
+
+- `DOCS_INDEX.md` and `SHEETS_CHANGELOG.md` no longer state unqualified
+  "All 736 tests pass" unless a current command and commit are cited.
+- Docs distinguish historical release notes from current validation state.
+
+Validation command:
+
+```bash
+rtk grep "736 tests|All .* tests pass|uv run pytest" DOCS_INDEX.md SHEETS_CHANGELOG.md README.md CLAUDE.md
+```
+
+Expected status: PASS when stale claims are removed or clearly dated.
+
+### 5. Add a no-dependency syntax proof to the agent guide
+
+Acceptance criteria:
+
+- `docs/TESTING_FOR_AGENTS.md` lists `python3 -m compileall -q *.py tests` as a
+  fallback syntax-only proof when `uv` cannot hydrate.
+- The doc labels it as insufficient for merge readiness.
+
+Validation command:
+
+```bash
+python3 -m compileall -q *.py tests
+```
+
+Expected status: PASS; observed PASS in this worktree.
+
+## Non-goals
+
+- Do not broaden or refactor product code as part of this audit.
+- Do not run live-write, local-data, or provider integration tests without
+  explicit human opt-in.
+- Do not start the inbox server, MCP services, launchd jobs, Caddy, OAuth flows,
+  notification tests, audio capture, or UI automation.
+- Do not edit credentials, tokens, local personal-data stores, or generated state.
+- Do not push branches, open PRs, merge PRs, or mark external trackers done.
+- Do not treat the partial system-Python proofs as a substitute for hydrated
+  `uv` validation before merge.
+
+## Unknowns
+
+- Whether `uv run pytest -m safe`, `uv run ruff check .`, and `uv run pyright`
+  pass in the primary checkout or any already-hydrated developer environment.
+- Whether the historical "736 tests pass" claim corresponds to another branch,
+  an older suite layout, generated parametrization, or stale documentation.
+- Whether the full unmarked suite is entirely deterministic under
+  `INBOX_TEST_MODE=1`; this audit did not run it because the repo docs warn
+  against unapproved local/live/provider tests.
+- Whether CI exists for this repo and which validation subset it runs; no CI
+  metadata was inspected beyond local files.
+- Whether any ignored `.venv` created by `uv` during this audit is complete; the
+  observed `uv` attempt failed during dependency download.
+
+## Handoff notes
+
+Files changed:
+
+- `docs/overnight/inbox-sym-116-validation-map.md`
+
+Validation result for this audit:
+
+- Required queue validation command: `git status --short`
+- Status before report write: PASS, clean output.
+- Status after report write: PASS, output `?? docs/overnight/`.
+- `fd . docs/overnight` confirmed the directory contains exactly
+  `docs/overnight/inbox-sym-116-validation-map.md`.
+
+PR URL:
+
+- None. PR creation was explicitly out of scope for this Goal Pack.
+
+Blockers:
+
+- Hydrated `uv` validation could not run inside this sandbox because the default
+  uv cache path was not writable and the temp-cache retry needed network access
+  for `pyobjc-core==12.1`.

--- a/docs/overnight/inbox-sym-116-workflow-handoff.md
+++ b/docs/overnight/inbox-sym-116-workflow-handoff.md
@@ -1,0 +1,169 @@
+# inbox-sym-116 workflow-handoff audit
+
+Queue item: `inbox-sym-116-workflow-handoff`
+Branch: `codex/goal-inbox-sym-116-workflow-handoff`
+Audit date: 2026-05-07
+Scope: read-only audit plus this report. No product code, generated data, secrets, external services, deploys, pushes, or PR creation.
+
+## Executive summary
+
+`inbox-sym-116` is a local-first Python inbox assistant. The repo combines a Textual TUI, FastAPI backend, MCP gateway surfaces, local SQLite indexing, Google Workspace integrations, macOS data-source readers, AppleScript mutators, background audio/LLM features, and utility workflows.
+
+This is not a small repo: `git ls-files | wc -l` reports 196 tracked files, `rg --files | wc -l` reports 104 visible files, and `wc -l inbox.py inbox_server.py services.py message_sync.py message_index_store.py mcp_gateway.py mcp_backend.py mcp_server.py inbox_mcp_readonly.py tools_registry.py tests/test_server.py tests/test_message_sync.py tests/test_mcp_gateway.py` reports 20,736 lines across the main audited surfaces.
+
+The strongest handoff path is to turn the next work into narrow, independently grabbable tasks around validation reliability, read-only MCP correctness, and stale workflow docs. The current architecture already has better implementation evidence than the docs imply: index-backed views and `/index/*` endpoints exist, but some docs still claim upcoming work or old test counts.
+
+## Repo state
+
+- Current branch: `codex/goal-inbox-sym-116-workflow-handoff` from `git branch --show-current`.
+- Current HEAD: `2805b8400519da188ca7d3f6e39b19a8ca42b05a`.
+- Recent history: `git log --oneline -5` shows latest commit `2805b84 Merge pull request #34 from jwalin-shah/codex/SYM-9-indexed-defaults`, followed by `a821b5a Make indexed inbox views the default`.
+- Remote: `origin https://github.com/jwalin-shah/inbox.git` from `git remote -v`.
+- Initial tracked dirty state: `git status --short --branch` showed only `## codex/goal-inbox-sym-116-workflow-handoff`.
+- After attempting the safe pytest command, `git status --short` remained empty, while `git status --short --ignored=matching` showed ignored `.venv/` created by `uv run`.
+- This audit intentionally adds only `docs/overnight/inbox-sym-116-workflow-handoff.md`.
+
+## Evidence map
+
+- `CLAUDE.md` defines the product as a Python + Textual + Rich TUI backed by local FastAPI, with agents using the server API directly.
+- `README.md:32` says Python 3.10+ is required, while `pyproject.toml:5` requires `>=3.12,<3.15`; this is a clear stale setup claim.
+- `pyproject.toml:53-61` configures pytest to discover `tests/`, run coverage by default, and register `safe`, `integration`, `local_data`, `slow`, and `live_write` markers.
+- `docs/TESTING_FOR_AGENTS.md:9-18` documents the agent-safe loop as `INBOX_TEST_MODE=1 uv run pytest -m safe`, `uv run ruff check .`, and `uv run pyright`.
+- `rg --files tests | wc -l` reports 31 test files, but `rg "pytestmark = pytest.mark.safe" tests -n` finds safe marks only in `tests/test_inbox_test_mode.py:8` and `tests/test_mcp_gateway.py:18`.
+- `tests/conftest.py` stubs heavy ML and hardware modules such as `mlx_lm`, `mlx_whisper`, `sounddevice`, `outlines`, and `Quartz`, so the test suite is designed to run without full local hardware dependencies once Python deps are installed.
+- `inbox_test_mode.py` provides `INBOX_TEST_MODE`, `INBOX_TEST_DATA_DIR`, `INBOX_TEST_NOW`, and `assert_live_writes_allowed`, giving future workers a concrete safety shim for live-write blockers.
+- `message_index_store.py` defines `.inbox_index.sqlite3`, `sync_state`, `items`, `threads`, and `sender_stats`; `list_threads()` supports actionable, recent, waiting-on, and priority sorting behavior.
+- `message_sync.py` implements Gmail bootstrap and incremental sync, Gmail history/timestamp cursors, iMessage rowid sync, changed-scope thread rebuilds, and a CLI with `bootstrap`, `incremental`, `rebuild`, and `summary`.
+- `inbox_server.py:565-632` defines index-oriented response models with `read_model="index"` and `raw_provider_fetch=False`; `inbox_server.py:3805-3853` exposes `/index/threads`, `/index/status`, `/index/health`, `/index/views/{view_name}`, and sync endpoints.
+- `inbox_client.py:86-131` has first-class client helpers for `index_threads`, `index_status`, `index_health`, `index_view`, `indexed_recent_threads`, `indexed_actionable_threads`, `indexed_waiting_on_me_threads`, and `indexed_waiting_on_others_threads`.
+- `inbox.py:1702-1723` renders the TUI `all`, `actionable`, and `waiting` filters from indexed thread lists, which conflicts with older docs saying indexed views are not yet the default TUI experience.
+- `tools_registry.py` is the central MCP registry. `rg "Tool\\(" tools_registry.py -c` found 60 registry tools, `rg "readonly=True" tools_registry.py -c` found 29 read-only tools, and `rg "confirm=True" tools_registry.py -c` found 34 confirmation-gated tools.
+- `tests/test_tools_registry.py` verifies all mutating registry tools require confirmation, read-only registration excludes write tools, path parameters are URL encoded, and body params are not URL encoded.
+- `mcp_gateway.py` implements `INBOX_MCP_TOKEN` bearer auth for public MCP requests and leaves `/health` unauthenticated for health checks.
+- `mcp_server.py` and `inbox_mcp_readonly.py` share `make_mcp_app()` and the central tool registry, but still define hand-written ambient/memory tools outside the registry.
+- `inbox_mcp_readonly.py:47` references `ambient_notes.VAULT_DIR`; `ambient_notes.py` defines `VAULT_PATH`, `DAILY_DIR`, and `AMBIENT_DIR`, not `VAULT_DIR`. `rg "VAULT_DIR" -n .` finds only that broken reference.
+- `.gitignore` excludes local credentials and generated state: `credentials.json`, `token.json`, `tokens/`, `github_token.txt`, `google_maps_key.txt`, `gemini_api_key.txt`, `config/inbox.env`, `.inbox_memory.sqlite3`, `.inbox_scheduler.sqlite3`, `.inbox_index.sqlite3`, batch state, and logs.
+- `MCP_SETUP.md` documents a safer topology: private `inbox_server.py` on loopback, public MCP gateways protected by separate `INBOX_MCP_TOKEN`, and a read-only MCP surface for cloud or lower-trust clients.
+- `deploy/Caddyfile.example` exposes only `/health` and `/mcp*` for both full and read-only MCP virtual hosts.
+- `dev.sh` defaults dev worktrees to `INBOX_SERVER_PORT=9850` and derives `INBOX_SERVER_URL`; `.mcp.json` and `.cursor/mcp.json` still point both full and read-only local MCP servers at primary `127.0.0.1:9849`.
+- `batch/batch-runner.sh` is a mutation workflow for Gmail archiving; it supports `--dry-run`, state files, logs, and optional parallelism, but writes state and logs under `batch/`.
+- `DOCS_INDEX.md:140` claims "All 736 tests pass" and "production-ready"; local validation could not substantiate this because dependency installation is blocked by network restrictions.
+
+## Architecture handoff
+
+The codebase has three major workflow layers:
+
+1. Human UI path: `inbox.py` uses `inbox_client.py`, renders source tabs plus indexed `Now`/actionable/waiting-like views, and can auto-start `inbox_server.py`.
+2. Backend path: `inbox_server.py` owns app state, auth middleware, provider service routing, index endpoints, write endpoints, ambient/dictation state, scheduler hooks, and cross-source APIs. `services.py` remains the large source-adapter module.
+3. Agent/MCP path: `mcp_server.py`, `inbox_mcp_readonly.py`, stdio wrappers, `mcp_gateway.py`, `mcp_backend.py`, and `tools_registry.py` expose a curated tool surface over the private HTTP backend.
+
+The current repo direction is consistent: `PLAN.md` wants indexed operational inbox views, `CONNECTOR_ROADMAP.md` wants normalized intent-level tools and coded account policy, and current code has already moved meaningful pieces in that direction. The handoff risk is that docs, config snippets, and validation affordances lag the code.
+
+## Risks and stale assumptions
+
+1. Stale runtime requirement: `README.md` says Python 3.10+, but `pyproject.toml` requires Python 3.12+. New workers using the README can start from the wrong interpreter.
+2. Unsupported validation claim: `DOCS_INDEX.md` and `SHEETS_CHANGELOG.md` claim 736 tests pass, but this worker could not install dependencies or run tests in the sandbox. The claim should be replaced with dated, reproducible validation evidence or removed.
+3. Safe test loop is undercovered: only two of 31 test files are marked `safe`, so `pytest -m safe` is likely too narrow to prove most agent-safe backend, registry, client, and index behavior even after dependencies install.
+4. Read-only MCP bug: `inbox_mcp_readonly.py` likely raises `AttributeError` for dated daily-note reads because it references nonexistent `ambient_notes.VAULT_DIR`.
+5. Primary/dev routing confusion remains plausible: docs warn about it, `dev.sh` defaults to port 9850, but committed `.mcp.json` and `.cursor/mcp.json` point to primary port 9849. Worktree testing can silently hit the daily-driver backend unless clients are explicitly reconfigured.
+6. MCP implementation drift risk: `tools_registry.py` now owns the HTTP-backed MCP surface, while `mcp_backend.py` still carries many older hand-written async wrapper methods. Future edits can update one path while tests only cover the other.
+7. Batch archiving needs stronger input safety before broader use: `batch/batch-runner.sh` reads thread IDs from TSV, uses them in log filenames and JSON payloads, and mutates Gmail labels unless `--dry-run` is set. It is not a default safe agent workflow.
+8. `main.py` still prints "Hello from inbox!", which is harmless but stale for a package named `inbox`; it can mislead tooling or new contributors looking for the app entrypoint.
+
+## Next safe work
+
+### Task 1: Make agent validation reproducible offline
+
+Acceptance criteria:
+- Update docs so the default agent validation command includes `UV_CACHE_DIR=/tmp/uv-cache` or another repo-approved writable cache path.
+- Remove or qualify unverified "736 tests pass" claims with the date, command, environment, and source of truth.
+- Add a short troubleshooting note for sandboxed workers where `uv` cannot write `~/.cache/uv` or cannot reach PyPI.
+- Do not change product behavior.
+
+Validation command candidates:
+- `git status --short` should show only docs touched for this task.
+- `UV_CACHE_DIR=/tmp/uv-cache INBOX_TEST_MODE=1 uv run pytest -m safe -q` should pass when dependencies are already cached; in this sandbox it currently fails before tests because `sentencepiece==0.2.1` cannot be downloaded.
+- `uv run ruff check docs/TESTING_FOR_AGENTS.md DOCS_INDEX.md SHEETS_CHANGELOG.md` is not a valid lint target for Markdown; use `git diff --check` instead for whitespace.
+
+### Task 2: Fix and test read-only MCP daily note reads
+
+Acceptance criteria:
+- Replace the `ambient_notes.VAULT_DIR` reference in `inbox_mcp_readonly.py` with the existing daily-note API or `ambient_notes.DAILY_DIR`.
+- Add a focused test that imports the read-only MCP module or the handler safely, monkeypatches ambient note paths to a temp dir, and proves both today's note and a dated note can be read without touching the real vault.
+- Keep the change read-only; no writes to real Obsidian paths in tests.
+
+Validation command candidates:
+- `UV_CACHE_DIR=/tmp/uv-cache INBOX_TEST_MODE=1 uv run pytest tests/test_mcp_gateway.py -q` should pass when deps are installed.
+- If a new focused test file is added, run that file directly with `INBOX_TEST_MODE=1`.
+- `rg "VAULT_DIR" -n .` should return no matches after the fix.
+
+### Task 3: Expand the safe test marker surface deliberately
+
+Acceptance criteria:
+- Audit existing tests for deterministic, local-only behavior and mark a first batch as `safe`, starting with `tests/test_tools_registry.py`, `tests/test_client.py`, `tests/test_message_index_store.py`, and pure index/sync tests that use fakes and temp SQLite only.
+- Do not mark tests safe if they touch real macOS data stores, OAuth, external APIs, microphone/audio hardware, AppleScript writes, or live provider mutation.
+- Update `docs/TESTING_FOR_AGENTS.md` to name what `pytest -m safe` is expected to cover and what remains opt-in.
+
+Validation command candidates:
+- `UV_CACHE_DIR=/tmp/uv-cache INBOX_TEST_MODE=1 uv run pytest -m safe -q` should run a materially larger set than the current two marked files.
+- `UV_CACHE_DIR=/tmp/uv-cache INBOX_TEST_MODE=1 uv run pytest tests/test_inbox_test_mode.py tests/test_tools_registry.py tests/test_client.py tests/test_message_index_store.py -q` should pass when dependencies are installed.
+- `git diff --check` should pass.
+
+### Task 4: Add a dev-routing self-check for MCP clients
+
+Acceptance criteria:
+- Add a small local-only command or docs-backed health procedure that reports `cwd`, `INBOX_SERVER_URL`, backend `/health`, MCP mode, and whether the client is pointed at primary 9849 or a dev port.
+- Update `MCP_SETUP.md` and `CLAUDE.md` with the command and expected output shape.
+- Do not expose secrets; redact `INBOX_SERVER_TOKEN` and `INBOX_MCP_TOKEN`.
+
+Validation command candidates:
+- `INBOX_SERVER_URL=http://127.0.0.1:9850 <new-command>` should show dev routing without printing tokens.
+- `git diff --check` should pass.
+- A focused unit test should prove token redaction and primary/dev classification without starting a live server.
+
+## Validation notes from this audit
+
+Commands run:
+- `llm-tldr tree .` succeeded and mapped the repo structure.
+- `git status --short --branch` succeeded and showed the branch with no tracked changes at audit start.
+- `git log --oneline -5`, `git remote -v`, `git rev-parse HEAD`, and `git branch --show-current` succeeded.
+- `rtk read` and `rg`/`nl`/`wc` commands succeeded for docs, scripts, entrypoints, tests, and key modules.
+- `INBOX_TEST_MODE=1 uv run pytest -m safe -q` failed before test collection because `uv` could not initialize `/Users/jwalinshah/.cache/uv` in this sandbox.
+- `UV_CACHE_DIR=/tmp/uv-cache INBOX_TEST_MODE=1 uv run pytest -m safe -q` advanced past the cache issue, created ignored `.venv/`, then failed before test collection because network access is restricted and `sentencepiece==0.2.1` could not be downloaded.
+
+Required queue validation:
+- Command: `git status --short`
+- Result: exit 0.
+- Output: `?? docs/overnight/`.
+- Detail command: `git status --short --untracked-files=all` shows `?? docs/overnight/inbox-sym-116-workflow-handoff.md`.
+
+## Non-goals
+
+- No product-code changes.
+- No fixes to tests, docs outside this report, scripts, or MCP code.
+- No credentials, tokens, OAuth flows, local inbox server startup, live provider reads, or live provider writes.
+- No deploy, public endpoint, push, PR, merge, or tracker state update.
+- No sibling repo comparison; this repo is substantial enough to justify the full audit locally.
+
+## Unknowns
+
+- Whether the full test suite currently passes outside this sandbox with dependencies already cached.
+- Whether the daily-driver inbox server on port 9849 is currently healthy; this audit did not curl it to avoid touching live personal data paths.
+- Whether committed `.mcp.json` primary routing is intentional for all local clients or should become worktree-aware.
+- Whether `batch/archive-input.tsv` is intentionally tracked as an empty template or should be documented as input-only with stronger sanitization.
+- Whether the "736 tests pass" claim came from a real historical run, generated text, or an old branch state.
+
+## Handoff
+
+Changed files:
+- `docs/overnight/inbox-sym-116-workflow-handoff.md`
+
+Commit SHA:
+- Current HEAD before this report: `2805b8400519da188ca7d3f6e39b19a8ca42b05a`
+
+PR URL:
+- None. Pushes and PR creation are out of scope for this Goal Pack item.
+
+Blockers:
+- Dependency-backed pytest validation cannot run in this sandbox without either an existing dependency cache or network access to fetch `sentencepiece`.
+- Live server and provider checks were intentionally not run.

--- a/docs/overnight/inbox-sym-117-docs-claims.md
+++ b/docs/overnight/inbox-sym-117-docs-claims.md
@@ -1,0 +1,210 @@
+# Overnight Docs-Claims Audit: inbox-sym-117
+
+Queue item: `inbox-sym-117-docs-claims`
+Branch: `codex/goal-inbox-sym-117-docs-claims`
+Base HEAD observed before report: `2805b8400519da188ca7d3f6e39b19a8ca42b05a`
+Audit date: 2026-05-07
+
+## Scope
+
+This is a read-only docs-claims audit plus this single report. I did not edit product code, run live provider writes, push, deploy, create a PR, or touch external trackers.
+
+The repo is a local-first personal inbox/TUI/backend that joins macOS personal data stores, Google APIs, GitHub notifications, local ML/audio features, and MCP surfaces. The current docs are broad and mostly useful, but several claims have drifted from the code and validation reality.
+
+## Repo State
+
+- `git status --short --branch` initially returned only `## codex/goal-inbox-sym-117-docs-claims`, so no tracked or untracked dirty state was visible before this report.
+- `git rev-parse HEAD` returned `2805b8400519da188ca7d3f6e39b19a8ca42b05a`.
+- `llm-tldr tree .` showed a flat Python app with core modules (`inbox.py`, `inbox_server.py`, `services.py`, `inbox_client.py`), MCP modules, 31 test files under `tests/`, operational docs, config examples, deploy examples, and no existing `docs/overnight/` report directory.
+- Running `uv run pytest -m safe -q` created a local `.venv` and `.coverage`; both are ignored by `.gitignore` (`.gitignore:9-10`, `.gitignore:27-29`).
+- The exact documented safe command, `INBOX_TEST_MODE=1 uv run pytest -m safe -q`, failed in this sandbox because `uv` attempted to initialize `/Users/jwalinshah/.cache/uv`, outside the writable roots.
+- Workaround command `UV_CACHE_DIR=/tmp/uv-cache INBOX_TEST_MODE=1 uv run pytest -m safe -q` passed with `11 passed, 855 deselected` on CPython 3.12.12.
+- Required validation `git status --short` passed after writing the report and showed `?? docs/overnight/`.
+- Staging/commit was attempted but blocked by sandbox permissions: `git add docs/overnight/inbox-sym-117-docs-claims.md && git diff --cached --stat` failed because Git could not create `/Users/jwalinshah/projects/inbox/.git/worktrees/inbox-sym-117-docs-claims/index.lock`.
+
+## Documentation Inventory
+
+Relevant local docs and config evidence:
+
+- `README.md` is the public overview, quick start, API summary, keybindings, architecture, dev commands, and privacy statement.
+- `CLAUDE.md` is the broad project context with worktree workflow, a larger API list, data sources, integration details, testing notes, and session-start health check.
+- `DOCS_INDEX.md` is a docs navigation page with explicit test-count and production-ready claims.
+- `SHEETS.md`, `SHEETS_QUICKSTART.md`, and `SHEETS_CHANGELOG.md` are the highest-claim docs, especially around "full" Sheets access.
+- `MCP_SETUP.md` and `MCP_V1_PLAN.md` describe public/private MCP topology, token separation, and v1 tool intent.
+- `CONNECTOR_ROADMAP.md` is planning material, not shipped-state docs; it names target policies such as `INBOX_DEFAULT_GOOGLE_ACCOUNT`.
+- `docs/TESTING_FOR_AGENTS.md` defines the safe local validation loop and live-write opt-in policy.
+- `config/inbox.env.example`, `config/codex.inbox.example.toml`, `deploy/Caddyfile.example`, and launch/service examples support the MCP setup docs.
+
+## Supported Claims
+
+These claims are well supported by local code:
+
+- Client/server architecture is real. `README.md:23-25` and `CLAUDE.md:78-85` map to `inbox_server.py` FastAPI construction at `inbox_server.py:1288-1310`, HTTP client defaults at `inbox_client.py:16-25`, and TUI client startup at `inbox_client.py:49-77`.
+- Default server port and worktree override are supported. `CLAUDE.md:13`, `CLAUDE.md:31-45`, `dev.sh:7-11`, and `inbox_client.py:16-17` all agree on `9849` default and `9850` dev override patterns.
+- Optional REST auth via `INBOX_SERVER_TOKEN` is implemented. `README.md:50` and `CLAUDE.md:115-116` map to `inbox_server.py:1313-1340`, which accepts bearer tokens and `x-api-key`.
+- Google service construction covers Gmail, Calendar, Drive, Sheets, Docs, and Tasks. `services.py:88-98` lists scopes, and `services.py:330-416` returns six service maps.
+- Sheets REST endpoints broadly match the detailed Sheets docs. `SHEETS_CHANGELOG.md:25-29`, `SHEETS.md:63-100`, and `inbox_server.py:2596-2761` align on list/create/get/delete, value get/update/append/clear/batch, tab add/delete/rename/copy, and format.
+- Local SQLite reads use read-only URI mode. This supports the read-only data-source framing in `README.md:144-148`; implementation evidence is `services.py:220-230`.
+- MCP public auth and `/mcp`/`/health` routing are implemented. `MCP_SETUP.md:142-154` and `MCP_SETUP.md:281-290` map to `mcp_gateway.py:18-45` and `mcp_gateway.py:87-93`.
+- Read-only MCP registration is test-covered. `inbox_mcp_readonly.py:77-80` registers only readonly tools, and `tests/test_tools_registry.py:46-53` checks write tools are absent from readonly registration.
+- Test docs correctly warn that personal-data integrations need explicit opt-in. `docs/TESTING_FOR_AGENTS.md:21-43` aligns with `inbox_test_mode.py` checks in `tests/test_inbox_test_mode.py:11-80` and write-guard tests in `tests/test_services.py:934-951`.
+
+## Stale Or Unsupported Claims
+
+1. Python version requirement is wrong in README.
+   - Claim: `README.md:31-34` says Python 3.10+.
+   - Evidence: `pyproject.toml:5` requires `>=3.12,<3.15`; `pyproject.toml:40-49` targets Python 3.12 in Ruff/Pyright.
+   - Risk: a new user on 3.10 or 3.11 will follow the README and hit install or syntax/runtime failures.
+
+2. The "736 tests pass" claim is stale.
+   - Claim: `DOCS_INDEX.md:40-45`, `DOCS_INDEX.md:134-140`, `SHEETS_CHANGELOG.md:34-38`, and `SHEETS_CHANGELOG.md:112-121` say all 736 tests pass.
+   - Evidence: `rg -n "^\s*def test_" tests | wc -l` returned `864`; safe pytest output reported `11 passed, 855 deselected`, implying 866 collected test cases in that run.
+   - Risk: morning reviewers may trust a dated count instead of running the current suite.
+
+3. The documented agent-safe test command is incomplete for sandboxed agent runs.
+   - Claim: `docs/TESTING_FOR_AGENTS.md:7-13` recommends `INBOX_TEST_MODE=1 uv run pytest -m safe`.
+   - Evidence: exact command failed here with `failed to open file /Users/jwalinshah/.cache/uv/... Operation not permitted`; adding `UV_CACHE_DIR=/tmp/uv-cache` made it pass.
+   - Risk: local isolated workers can falsely report validation blocked even though the test itself is healthy.
+
+4. `safe` marker coverage is much narrower than the test suite.
+   - Claim context: `docs/TESTING_FOR_AGENTS.md:7-18` presents `pytest -m safe` as the default verification loop.
+   - Evidence: only `tests/test_inbox_test_mode.py:8` and `tests/test_mcp_gateway.py:18` set `pytestmark = pytest.mark.safe`; safe run selected 11 tests and deselected 855.
+   - Risk: docs may imply a broader proof than the marker currently provides.
+
+5. README keybinding for ambient listening is stale.
+   - Claim: `README.md:120-122` and `CLAUDE.md:193-199` say `Ctrl+6` toggles ambient listening.
+   - Evidence: `inbox.py:1179-1194` binds `ctrl+6` to Reminders and `ctrl+shift+6` to Ambient; `tests/test_inbox_app.py:706-718` asserts `Ctrl+6` opens Reminders.
+   - Risk: users following docs will switch tabs instead of toggling ambient capture.
+
+6. MCP transport descriptions conflict.
+   - Claim: `CLAUDE.md:83-85` and `CLAUDE.md:274-278` call `mcp_server.py` stdio-based.
+   - Evidence: `mcp_server.py:34-38` creates a stateless HTTP `FastMCP`, `mcp_server.py:145-151` serves it through uvicorn on port 8000, and `inbox_mcp_stdio.py:13-17` is the stdio wrapper.
+   - Counter-evidence: `MCP_SETUP.md:19-36` correctly distinguishes HTTP and stdio surfaces.
+   - Risk: agent/client setup can point at the wrong transport.
+
+7. "No cloud dependencies" for LLM/ASR is overstated.
+   - Claim: `README.md:23-25` says local-first ML has "no cloud dependencies"; `README.md:165` says no API calls for ASR or LLM.
+   - Evidence: `pyproject.toml:10` includes `google-generativeai`; `CLAUDE.md:294` documents optional Gemini; `services.py:3249-3473` implements Gemini summarization, replies, categorization, digest, and action extraction; `inbox_server.py:2197-2262` exposes Gemini endpoints.
+   - Risk: privacy docs under-disclose optional cloud LLM paths.
+
+8. README privacy credential list is incomplete.
+   - Claim: `README.md:171-174` lists `credentials.json`, `tokens/`, and `github_token.txt`.
+   - Evidence: `.gitignore:13-20` and `services.py:84-86` also include `google_maps_key.txt`, `gemini_api_key.txt`, and `config/inbox.env`; `CLAUDE.md:294-297` documents Gemini and Maps keys.
+   - Risk: a user doing a secret sweep from README alone can miss sensitive local files.
+
+9. "Full Google Sheets API access" and "any Sheets operation" are too broad.
+   - Claim: `SHEETS_QUICKSTART.md:1-3`, `SHEETS_CHANGELOG.md:102-110`, and `CLAUDE.md:222-230` say full/any Sheets operation access.
+   - Evidence: REST code implements a useful but finite subset at `inbox_server.py:2596-2761`; MCP exposes only `list_sheets`, `read_sheet_values`, `create_sheet`, and `append_sheet_rows` for Sheets in `tools_registry.py:176-237`.
+   - Risk: agents may assume capabilities such as protected ranges, named ranges, charts, pivot tables, or permissions exist as first-class operations when they do not.
+
+10. Sheets multi-account body examples are partly wrong.
+   - Claim: `SHEETS.md:181-193` says write operations can specify `account` in the request body.
+   - Evidence: `SheetValuesUpdateRequest` has only `values` and `value_input` (`inbox_server.py:504-507`), while update/append/batch endpoints take `account` as a query parameter (`inbox_server.py:2650-2670`, `inbox_server.py:2698-2705`). Body `account` only exists for create/add/format request models (`inbox_server.py:498-523`).
+   - Risk: a multi-account write can silently default to the first available account if the caller puts account in the wrong place.
+
+11. Live-write guard coverage is incomplete for some Sheets writes.
+   - Claim: `docs/TESTING_FOR_AGENTS.md:25-29` says live writes are blocked through `assert_live_writes_allowed`.
+   - Evidence: `sheets_values_update`, `sheets_values_append`, `sheets_values_clear`, `sheets_add_sheet`, and delete paths call `_assert_live_write_allowed` (`services.py:4161-4244`, `services.py:4255-4303`), but `sheets_rename_sheet`, `sheets_format`, and `sheets_copy_to` do not (`services.py:4315-4388`).
+   - Risk: test-mode and agent-safe guarantees are weaker than documented for those Sheets mutations.
+
+12. `SHEETS_CHANGELOG.md` contains a stale tuple migration claim.
+   - Claim: `SHEETS_CHANGELOG.md:11-15`, `SHEETS_CHANGELOG.md:30-36`, and `SHEETS_CHANGELOG.md:124-129` describe a move to a 4-tuple and "only addition: sheets service + endpoints".
+   - Evidence: current `google_auth_all()` returns six maps (`services.py:330-416`) and includes Docs and Tasks scopes/services (`services.py:88-98`, `services.py:404-416`).
+   - Risk: implementers updating fixtures or auth code from the changelog will miss Docs/Tasks.
+
+13. `MCP_V1_PLAN.md` is useful as plan history but no longer describes the full MCP surface.
+   - Claim: `MCP_V1_PLAN.md:28-62` lists a narrow v1 tool set.
+   - Evidence: `tools_registry.py:129-848` contains many more Gmail, Sheets, Tasks, Calendar, WhatsApp, scheduled/followup, Drive, Docs, and GitHub tools.
+   - Risk: treating the plan as current API reference will under-document available tools and policy coverage.
+
+## Explicit Non-Claims
+
+- `PLAN.md` and `CONNECTOR_ROADMAP.md` are forward-looking. For example, `PLAN.md:74-80` explicitly lists incomplete areas, and `CONNECTOR_ROADMAP.md:32-45` describes desired account-default policy rather than current enforcement.
+- `MCP_V1_PLAN.md` should be read as historical planning unless promoted or replaced by a current MCP API reference.
+- The audit did not verify live Gmail, Calendar, Drive, Sheets, Docs, Tasks, iMessage, Notes, Reminders, GitHub, Maps, Gemini, microphone, or accessibility behavior.
+- The report does not claim the app is unsafe to run; it only identifies places where docs overstate or misroute current behavior.
+
+## Risks And Stale Assumptions
+
+1. Multi-account write safety risk: stale account-location docs plus first-account fallback can route Sheets writes to the wrong Google account.
+2. Validation trust risk: "736 tests pass" and a narrow `safe` marker can create false confidence in morning review.
+3. Privacy/compliance risk: README's local/no-cloud phrasing under-discloses optional Gemini and Maps integrations plus extra key files.
+4. Agent setup risk: conflicting MCP transport docs can make clients use HTTP vs stdio incorrectly or hit the wrong backend.
+5. Live-write test-mode risk: several Sheets mutations lack `_assert_live_write_allowed`, so the docs' safety guarantee is not universal.
+6. User workflow risk: stale `Ctrl+6` documentation can accidentally switch to Reminders instead of toggling ambient listening.
+
+## Next Safe Work
+
+1. Update README/DOCS_INDEX/CLAUDE runtime and keybinding claims.
+   - Acceptance: README says Python 3.12+, `Ctrl+6` is Reminders, `Ctrl+Shift+6` is Ambient, and test-count wording avoids fixed stale totals.
+   - Validation: `rg -n "Python 3.10|736 tests|Ctrl\\+6.*Ambient|stdio-based MCP server" README.md DOCS_INDEX.md CLAUDE.md` returns no stale matches except historical notes explicitly marked as historical.
+
+2. Fix agent-safe validation docs for sandboxed workers.
+   - Acceptance: `docs/TESTING_FOR_AGENTS.md` documents `UV_CACHE_DIR=/tmp/uv-cache INBOX_TEST_MODE=1 uv run pytest -m safe`, explains that `safe` currently covers 11 tests, and points broader validation to explicit commands.
+   - Validation: `UV_CACHE_DIR=/tmp/uv-cache INBOX_TEST_MODE=1 uv run pytest -m safe -q` passes.
+
+3. Tighten Sheets multi-account and "full API" language.
+   - Acceptance: `SHEETS.md`, `SHEETS_QUICKSTART.md`, and `SHEETS_CHANGELOG.md` say "supported Sheets operations" instead of "any operation"; account placement is documented per endpoint as query vs body.
+   - Validation: `rg -n "full Google Sheets API|any Sheets operation|account.*body" SHEETS.md SHEETS_QUICKSTART.md SHEETS_CHANGELOG.md CLAUDE.md` has no unsupported broad claim.
+
+4. Add test-mode guards for uncovered Sheets mutations.
+   - Acceptance: `sheets_rename_sheet`, `sheets_format`, and `sheets_copy_to` call `_assert_live_write_allowed`; tests cover all three under `INBOX_TEST_MODE=1`.
+   - Validation: `INBOX_TEST_MODE=1 uv run pytest tests/test_services.py -q` passes, with `UV_CACHE_DIR=/tmp/uv-cache` in sandboxed workers.
+
+5. Split current MCP API docs from historical MCP plans.
+   - Acceptance: a current MCP surface doc is generated from `tools_registry.TOOLS`, and `MCP_V1_PLAN.md` is labeled historical or archived.
+   - Validation: `uv run pytest tests/test_tools_registry.py tests/test_mcp_gateway.py -q` passes; a docs check confirms every tool name appears in the current MCP reference.
+
+6. Update README privacy section to include optional cloud and key files.
+   - Acceptance: README lists `google_maps_key.txt`, `gemini_api_key.txt`, `config/inbox.env`, and explains optional Gemini/Maps network behavior.
+   - Validation: `rg -n "gemini_api_key|google_maps_key|config/inbox.env|Gemini API|Google Maps" README.md` returns expected lines.
+
+## Validation Candidates
+
+| Command | Expected status | Notes |
+|---|---:|---|
+| `git status --short` | Pass | Required queue validation; should show only this report before commit or clean after commit. |
+| `INBOX_TEST_MODE=1 uv run pytest -m safe -q` | Fail in this sandbox | Fails on default uv cache path under `/Users/jwalinshah/.cache/uv`; docs do not mention cache override. |
+| `UV_CACHE_DIR=/tmp/uv-cache INBOX_TEST_MODE=1 uv run pytest -m safe -q` | Pass | Observed `11 passed, 855 deselected`; good cheap proof for docs-only edits touching test guidance. |
+| `uv run ruff check .` | Unknown/not run | Candidate for code/doc-adjacent changes; may need `UV_CACHE_DIR=/tmp/uv-cache` in sandbox. |
+| `uv run pyright` | Unknown/not run | Candidate for code changes; not necessary for this report-only audit. |
+| `uv run pytest tests/ -q` | Unknown/not run | Current docs claim stale 736 total; full suite should be run before any "all tests pass" claim is restored. |
+
+## Commands Run
+
+- `llm-tldr tree .`
+- `git status --short --branch`
+- `git rev-parse --show-toplevel && git rev-parse --abbrev-ref HEAD && git rev-parse HEAD`
+- `rg --files -g 'README*' -g 'AGENTS.md' -g 'CLAUDE.md' -g 'docs/**' -g '*.md'`
+- `rtk read README.md`
+- `rtk read DOCS_INDEX.md`
+- `rtk read pyproject.toml`
+- `rtk read CLAUDE.md`
+- `rtk read MCP_SETUP.md`
+- `rtk read docs/TESTING_FOR_AGENTS.md`
+- `rg` searches over docs, routes, services, tests, MCP, keybindings, privacy, and Sheets claims
+- `sed`/`nl -ba` targeted line reads for docs and implementation evidence
+- `uv run pytest -m safe -q`
+- `INBOX_TEST_MODE=1 uv run pytest -m safe -q`
+- `UV_CACHE_DIR=/tmp/uv-cache INBOX_TEST_MODE=1 uv run pytest -m safe -q`
+- `rg -n "^\s*def test_" tests | wc -l`
+- `rg --files tests | wc -l`
+- `git ls-files docs/overnight docs || true`
+- `git status --short`
+- `git add docs/overnight/inbox-sym-117-docs-claims.md && git diff --cached --stat` (blocked by sandbox permissions)
+
+## Unknowns
+
+- Whether the full suite currently passes; this audit did not run `uv run pytest tests/ -q`.
+- Whether live provider endpoints work with current local credentials; live credentials and external writes were out of scope.
+- Whether the current primary checkout differs from this isolated worktree in runtime config, tokens, or generated state.
+- Whether the fixed test count after full pytest collection is exactly 866; the safe run reported 855 deselected plus 11 passed, while a simple `def test_` grep returned 864 definitions.
+- Whether all MCP tools are intentionally exposed; the registry has grown beyond `MCP_V1_PLAN.md`.
+
+## Handoff
+
+Changed file: `docs/overnight/inbox-sym-117-docs-claims.md`
+Commit SHA: no new commit created; current HEAD remains `2805b8400519da188ca7d3f6e39b19a8ca42b05a`.
+PR URL: none; PR creation is out of scope for this queue item.
+Validation result: `git status --short` exited 0 and showed `?? docs/overnight/`.
+Blockers: none for writing the report. Local staging/commit is blocked by sandbox permissions on the parent repo worktree index lock. Exact documented safe-test command is blocked in this sandbox without `UV_CACHE_DIR=/tmp/uv-cache`.

--- a/docs/overnight/inbox-sym-117-risk-register.md
+++ b/docs/overnight/inbox-sym-117-risk-register.md
@@ -1,0 +1,574 @@
+# inbox-sym-117 risk-register audit
+
+Queue item: `inbox-sym-117-risk-register`
+Repo: `inbox-sym-117`
+Branch: `codex/goal-inbox-sym-117-risk-register`
+Focus area: risk-register
+Audit date: 2026-05-07
+
+## Executive summary
+
+`inbox-sym-117` is a local-first Python inbox/control-plane application. It exposes a FastAPI backend, a Textual TUI, local and HTTP MCP gateways, scheduler workflows, Google/Gmail/Calendar/Drive/Sheets/Docs/Tasks integrations, macOS Messages/Notes/Reminders/Accessibility integrations, GitHub notification tooling, local ML, optional Gemini AI calls, and audio/dictation workflows.
+
+The largest risk is not a single secret in the checkout. It is the combination of:
+
+- broad local and cloud write authority,
+- optional bearer-token auth,
+- many REST write endpoints,
+- MCP confirmation gates that do not cover direct REST/TUI paths,
+- service-level `INBOX_TEST_MODE` write guards that are present but not exhaustive,
+- privacy docs that still describe the AI path as local-only while Gemini endpoints can send inbox content to Google when a Gemini key is configured.
+
+No product code was changed during this audit. The only intended change is this report.
+
+## Repo purpose and state
+
+Purpose from local docs:
+
+- [README.md](../../README.md) describes a privacy-first terminal UI consolidating iMessage, Gmail, Calendar, Sheets, Notes, Reminders, GitHub, and Drive.
+- [CLAUDE.md](../../CLAUDE.md) describes the client-server split: `services.py` for data access, `inbox_server.py` for the FastAPI backend, `inbox_client.py` for HTTP clients, MCP entrypoints, scheduler, local SQLite stores, and token files.
+- [MCP_SETUP.md](../../MCP_SETUP.md) describes a private backend on `127.0.0.1:9849`, a full MCP HTTP gateway, and a read-only MCP HTTP gateway.
+
+Observed git state:
+
+- `git status --short --branch` before writing this report: `## codex/goal-inbox-sym-117-risk-register`; no tracked or untracked changes were present.
+- `git rev-parse HEAD`: `2805b8400519da188ca7d3f6e39b19a8ca42b05a`.
+- `git log --oneline -5` shows HEAD as `2805b84 Merge pull request #34 from jwalin-shah/codex/SYM-9-indexed-defaults`.
+- `git remote -v` points to `https://github.com/jwalin-shah/inbox.git`.
+- `rtk read items/inbox-sym-117-risk-register/ISSUE.md` failed with `No such file or directory`; the queue item text in the prompt was used as the local work contract.
+- `fd -H 'ISSUE\.md$|inbox-sym-117-risk-register' .` found no local issue file.
+
+## Local evidence map
+
+Repo shape and hidden/local state:
+
+- `llm-tldr tree .` shows a flat Python app with `services.py`, `inbox_server.py`, `inbox.py`, MCP entrypoints, `tests/`, `deploy/`, `scripts/`, `modes/`, and docs.
+- `fd -H -t f` shows hidden operational artifacts under `.factory/`, repo-local `.mcp.json`, `.cursor/mcp.json`, `.env.mcp.example`, `.pre-commit-config.yaml`, and `.tldrignore`.
+- `fd -H '^(credentials\.json|token\.json|tokens|github_token\.txt|google_maps_key\.txt|gemini_api_key\.txt|inbox\.env|\.env)$' .` produced no output, so the obvious secret/token files were not present in this worktree.
+- `fd -t f . docs/overnight` failed because `docs/overnight` did not exist before this report.
+
+Credentials and auth:
+
+- [.gitignore](../../.gitignore) ignores `credentials.json`, `token.json`, `tokens/`, `github_token.txt`, `google_maps_key.txt`, `gemini_api_key.txt`, `config/inbox.env`, `.env`, `.env.local`, `*.key`, and `*.secret`.
+- [config/inbox.env.example](../../config/inbox.env.example) defines `INBOX_SERVER_TOKEN`, `INBOX_MCP_TOKEN`, and optional `INBOX_MEMORY_DB`.
+- [.env.mcp.example](../../.env.mcp.example) leaves `INBOX_SERVER_TOKEN=` blank and sets a placeholder `INBOX_MCP_TOKEN`.
+- [.mcp.json](../../.mcp.json) and [.cursor/mcp.json](../../.cursor/mcp.json) both point local MCP clients at `http://127.0.0.1:9849` and pass `${INBOX_SERVER_TOKEN}`.
+- [inbox_server.py](../../inbox_server.py) has `AUTH_TOKEN_ENV = "INBOX_SERVER_TOKEN"` and `_is_authorized()` returns `True` when the token env var is unset.
+- [mcp_gateway.py](../../mcp_gateway.py) has `MCP_TOKEN_ENV = "INBOX_MCP_TOKEN"` and `_is_publicly_authorized()` returns `True` when the public MCP token env var is unset.
+- [tests/test_server.py](../../tests/test_server.py) verifies backend auth is not required when `INBOX_SERVER_TOKEN` is unset and is required when set.
+- [tests/test_mcp_gateway.py](../../tests/test_mcp_gateway.py) verifies MCP token rejection only when `INBOX_MCP_TOKEN` is set; health remains public.
+
+Write surfaces:
+
+- `rg -n "^@app\.(post|put|patch|delete)" inbox_server.py` found many mutating routes: messages, Gmail archive/delete/unsubscribe/read state, calendar CRUD, reminders, tasks, scheduled messages, followups, Drive, Sheets, Docs, ambient/dictation, accounts, notifications, workflow creation, index sync, and memory extraction.
+- [services.py](../../services.py) defines `_assert_live_write_allowed()` and calls it on many mutators.
+- `rg -n "_assert_live_write_allowed" services.py` shows guards for representative Gmail, iMessage, Calendar, Reminders, Tasks, Drive folder/delete, Sheets create/value/tab add/delete, Docs create/delete, GitHub notification mutation, desktop notifications, WhatsApp, and attendee changes.
+- [tests/test_services.py](../../tests/test_services.py) contains representative `INBOX_TEST_MODE` tests, but the tested set is not exhaustive.
+- [tools_registry.py](../../tools_registry.py) confirms all registered mutating MCP tools require `confirm=True`, and [tests/test_tools_registry.py](../../tests/test_tools_registry.py) asserts all non-readonly MCP registry tools are confirmation-gated.
+
+External services and local data:
+
+- [services.py](../../services.py) reads local macOS personal-data SQLite stores for iMessage, Notes, Reminders, and AddressBook.
+- [services.py](../../services.py) uses broad Google scopes: Gmail read/modify/send/settings, Calendar, Drive, Sheets, Docs, and Tasks.
+- [services.py](../../services.py) reads `github_token.txt` or `gh auth token`, then calls `https://api.github.com`.
+- [services.py](../../services.py) reads `google_maps_key.txt` or map-related env vars for location/travel APIs.
+- [services.py](../../services.py) reads `gemini_api_key.txt` or `GEMINI_API_KEY`, then uses `google.generativeai`.
+- [ambient_notes.py](../../ambient_notes.py) writes raw ambient transcripts into `~/vault/daily/YYYY-MM-DD.md`.
+- [inbox_server.py](../../inbox_server.py) can start ambient listening and dictation via REST endpoints.
+- [inbox_server.py](../../inbox_server.py) can auto-start ambient listening on server startup if voice config enables `ambient_autostart`.
+
+Deployment and operations:
+
+- [inbox_server.py](../../inbox_server.py), [mcp_server.py](../../mcp_server.py), and [inbox_mcp_readonly.py](../../inbox_mcp_readonly.py) bind uvicorn to `127.0.0.1`.
+- [deploy/Caddyfile.example](../../deploy/Caddyfile.example) exposes only `/health` and `/mcp` for full and readonly MCP hostnames.
+- [deploy/inbox-backend.service.example](../../deploy/inbox-backend.service.example), [deploy/inbox-mcp.service.example](../../deploy/inbox-mcp.service.example), and [deploy/inbox-mcp-readonly.service.example](../../deploy/inbox-mcp-readonly.service.example) hardcode `/Users/jwalinshah/projects/inbox` and `config/inbox.env`.
+- [deploy/com.inbox.backend.plist.example](../../deploy/com.inbox.backend.plist.example), [deploy/com.inbox.mcp.plist.example](../../deploy/com.inbox.mcp.plist.example), and [deploy/com.inbox.mcp-readonly.plist.example](../../deploy/com.inbox.mcp-readonly.plist.example) source `config/inbox.env` through `bash -lc` and write logs under `/tmp`.
+- [scripts/setup_inbox_mcp.sh](../../scripts/setup_inbox_mcp.sh) creates `config/inbox.env` with `chmod 600`, copies launch agents, unloads and loads them, and reports `/tmp` log paths.
+
+Validation surface:
+
+- [docs/TESTING_FOR_AGENTS.md](../TESTING_FOR_AGENTS.md) says safe agent commands are `INBOX_TEST_MODE=1 uv run pytest -m safe`, `uv run ruff check .`, and `uv run pyright`.
+- [pyproject.toml](../../pyproject.toml) defines pytest markers `safe`, `integration`, `local_data`, `slow`, and `live_write`; default pytest includes coverage.
+- [.pre-commit-config.yaml](../../.pre-commit-config.yaml) has ruff, ruff-format, trailing whitespace, end-of-file fixer, check-yaml, check-added-large-files, detect-private-key, and bandit.
+- [pyproject.toml](../../pyproject.toml) configures bandit but skips several rules, including subprocess-related `B404`, `B603`, and `B607`.
+
+## Risk register
+
+### R1. Some external write paths bypass `INBOX_TEST_MODE` service guards
+
+Severity: high
+Likelihood: medium
+Blast radius: Google Drive, Gmail labels, Sheets tabs/format/copy, Google Docs text.
+
+Evidence:
+
+- [services.py](../../services.py) has a clear guard pattern: `_assert_live_write_allowed(action)` delegates to `inbox_test_mode.assert_live_writes_allowed`.
+- `rg -n "_assert_live_write_allowed" services.py` did not include `drive_upload`, `gmail_label_create`, `sheets_rename_sheet`, `sheets_format`, `sheets_copy_to`, or `docs_insert_text`.
+- [services.py](../../services.py) `drive_upload()` calls `drive_service.files().create(...).execute()` without `_assert_live_write_allowed`.
+- [inbox_server.py](../../inbox_server.py) `/drive/upload` reads uploaded content to a temp file and calls `drive_upload`.
+- [services.py](../../services.py) `gmail_label_create()` calls `service.users().labels().create(...)` without `_assert_live_write_allowed`.
+- [inbox_server.py](../../inbox_server.py) `/gmail/labels` calls `gmail_label_create`.
+- [services.py](../../services.py) `sheets_rename_sheet()`, `sheets_format()`, and `sheets_copy_to()` call Google Sheets `batchUpdate` or `copyTo` without `_assert_live_write_allowed`.
+- [inbox_server.py](../../inbox_server.py) exposes `/sheets/{spreadsheet_id}/tabs/{sheet_id}`, `/sheets/{spreadsheet_id}/tabs/{sheet_id}/copy`, and `/sheets/{spreadsheet_id}/format`.
+- [services.py](../../services.py) `docs_insert_text()` calls Google Docs `documents().batchUpdate(...)` without `_assert_live_write_allowed`.
+- [inbox_server.py](../../inbox_server.py) `/docs/{document_id}/text` calls `docs_insert_text`.
+- [tests/test_services.py](../../tests/test_services.py) only checks representative write guards: `gmail_send`, `calendar_create_event`, `reminder_complete`, `task_create`, `drive_create_folder`, `sheets_values_update`, `docs_create`, `github_mark_read`, `send_notification`, and `whatsapp_send`.
+
+Decision note:
+
+This is not necessarily an auth bypass. It is a safety-mode bypass. A local safe test or agent-safe backend run can still touch live external services through these paths if a mocked test accidentally uses a real service, or if an agent calls the REST path directly while `INBOX_TEST_MODE=1` is expected to prevent writes.
+
+Next safe work:
+
+1. Add `_assert_live_write_allowed()` to every service function that writes to an external API or local personal store.
+2. Add a table-driven test that enumerates all service mutators and proves each raises `LiveWriteBlocked` before touching a fake service in `INBOX_TEST_MODE=1`.
+3. Add endpoint-level tests for the currently missed paths using service patches or sentinel objects.
+
+Validation candidates:
+
+- Expected fail before fix: `INBOX_TEST_MODE=1 uv run pytest tests/test_services.py -q -k live_write`
+- Expected fail before fix if new coverage is added first: `INBOX_TEST_MODE=1 uv run pytest tests/test_drive.py tests/test_server_endpoints.py -q -k "upload or label or sheet or doc"`
+- Expected pass after fix: `INBOX_TEST_MODE=1 uv run pytest -m safe`
+
+### R2. Auth is fail-open when token env vars are unset
+
+Severity: high if a service is exposed beyond loopback, medium for local-only use
+Likelihood: medium
+Blast radius: every backend or MCP operation on the exposed surface.
+
+Evidence:
+
+- [inbox_server.py](../../inbox_server.py) `_is_authorized()` returns `True` when `INBOX_SERVER_TOKEN` is unset.
+- [mcp_gateway.py](../../mcp_gateway.py) `_is_publicly_authorized()` returns `True` when `INBOX_MCP_TOKEN` is unset.
+- [README.md](../../README.md) describes token auth as optional for all endpoints at `localhost:9849`.
+- [mcp_server.py](../../mcp_server.py) documents `INBOX_MCP_TOKEN` as optional.
+- [.env.mcp.example](../../.env.mcp.example) leaves `INBOX_SERVER_TOKEN=` blank.
+- [tests/test_server.py](../../tests/test_server.py) explicitly validates that auth is not required when token is unset.
+- [tests/test_mcp_gateway.py](../../tests/test_mcp_gateway.py) explicitly validates MCP auth behavior only when `INBOX_MCP_TOKEN` is set.
+- [MCP_SETUP.md](../../MCP_SETUP.md) says to require `INBOX_MCP_TOKEN` when exposing the MCP gateway and keep `INBOX_SERVER_TOKEN` private.
+
+Decision note:
+
+Loopback binding lowers risk for ordinary local runs. The risk grows sharply in the documented remote/cloud-agent path because a missing env var silently turns off public MCP auth.
+
+Next safe work:
+
+1. Add a startup warning or fail-closed mode for HTTP MCP when `INBOX_MCP_TOKEN` is unset outside explicit local/dev mode.
+2. Split examples into `local-stdio`, `local-http-dev`, and `public-http` configs so public examples never show blank auth.
+3. Add tests for a `INBOX_REQUIRE_AUTH=1` or similar mode that refuses to start when required tokens are missing.
+
+Validation candidates:
+
+- Expected pass today: `uv run pytest tests/test_server.py::TestServerAuth tests/test_mcp_gateway.py -q`
+- Expected fail before hardening: a new test that sets public mode with no `INBOX_MCP_TOKEN` and expects startup/request rejection.
+
+### R3. Privacy docs claim local-only AI, but Gemini endpoints can send inbox content to Google
+
+Severity: high for sensitive inbox content
+Likelihood: medium when `GEMINI_API_KEY` or `gemini_api_key.txt` exists
+Blast radius: Gmail/iMessage/calendar/task snippets and message bodies sent to external Gemini API.
+
+Evidence:
+
+- [README.md](../../README.md) says local ML has "no cloud dependencies" and privacy says all data processing happens on-device with no cloud syncing.
+- [pyproject.toml](../../pyproject.toml) includes `google-generativeai`.
+- [CLAUDE.md](../../CLAUDE.md) documents an optional Gemini API backend via `gemini_api_key.txt`.
+- [services.py](../../services.py) `_get_gemini_model()` reads `GEMINI_API_KEY` or `gemini_api_key.txt`, configures `google.generativeai`, and creates `gemini-2.5-flash`.
+- [services.py](../../services.py) `gemini_summarize()` builds a prompt from the last 20 messages, including sender and body snippets, and calls `model.generate_content(...)`.
+- [services.py](../../services.py) `gemini_smart_reply()` and `gemini_categorize()` also send message or email snippets through `generate_content`.
+- [inbox_server.py](../../inbox_server.py) exposes `/ai/gemini-summarize`, `/ai/smart-reply`, `/ai/categorize`, `/ai/digest`, and `/ai/action-items`.
+
+Decision note:
+
+The code supports both local and cloud AI paths. The docs should not describe the system as categorically local-only unless cloud endpoints are removed or gated behind explicit opt-in with visible warnings.
+
+Next safe work:
+
+1. Add a `INBOX_ENABLE_CLOUD_AI=1` gate around Gemini endpoints and Gemini model initialization.
+2. Update README/CLAUDE privacy sections to distinguish local ML from optional cloud Gemini.
+3. Add a safe test proving Gemini endpoints return an explicit disabled response when cloud AI is not enabled.
+
+Validation candidates:
+
+- Expected fail before hardening: new test with `GEMINI_API_KEY` set but `INBOX_ENABLE_CLOUD_AI` unset expecting no `generate_content` call.
+- Expected pass after hardening: `INBOX_TEST_MODE=1 uv run pytest tests/test_ai_layer.py tests/test_server.py -q -k "gemini or ai"`
+
+### R4. Broad OAuth scopes and file-based token storage increase local compromise blast radius
+
+Severity: high
+Likelihood: medium
+Blast radius: Gmail, Calendar, Drive, Sheets, Docs, Tasks across all authorized accounts.
+
+Evidence:
+
+- [services.py](../../services.py) requests `gmail.readonly`, `gmail.modify`, `gmail.send`, `gmail.settings.basic`, `calendar`, `drive`, `spreadsheets`, `documents`, and `tasks`.
+- [services.py](../../services.py) stores `TOKEN_FILE` and `TOKENS_DIR` in the repo root by default, with test-mode overrides.
+- [services.py](../../services.py) `_write_text_with_lock()` writes token JSON atomically with a lock but does not set file mode.
+- [.gitignore](../../.gitignore) excludes token files, but ignore rules do not protect local file permissions or backups.
+- [scripts/setup_inbox_mcp.sh](../../scripts/setup_inbox_mcp.sh) applies `chmod 600` to `config/inbox.env`, but there is no equivalent visible guard for token JSON files.
+- `fd -H '^(credentials\.json|token\.json|tokens|github_token\.txt|google_maps_key\.txt|gemini_api_key\.txt|inbox\.env|\.env)$' .` found no obvious local secret files in this worktree.
+
+Decision note:
+
+File-based OAuth tokens are pragmatic for a personal local app. The risk is acceptable only if the repo directory is treated as sensitive and token files are permission-checked.
+
+Next safe work:
+
+1. Update `_write_text_with_lock()` or token-specific writers to set `0600` permissions.
+2. Add a `health` or `doctor` check that warns when token/env files are group/world readable.
+3. Document token restore/copy risks for multi-worktree development.
+
+Validation candidates:
+
+- Expected fail before fix: new test that writes a token through `_write_text_with_lock()` and asserts mode `0600`.
+- Expected pass after fix: `INBOX_TEST_MODE=1 uv run pytest tests/test_inbox_test_mode.py tests/test_services.py -q -k "token or test_mode"`
+
+### R5. Account routing still defaults silently for many writes
+
+Severity: medium-high
+Likelihood: medium
+Blast radius: writes landing in the wrong Google account.
+
+Evidence:
+
+- [google_account_resolution.py](../../google_account_resolution.py) `default_google_account()` chooses `INBOX_DEFAULT_GOOGLE_ACCOUNT` if present, otherwise the first service key.
+- [google_account_resolution.py](../../google_account_resolution.py) Gmail message/thread routing is more conservative: it checks explicit account, cache, then live message/thread existence, then falls back.
+- [CLAUDE.md](../../CLAUDE.md) says account routing uses helpers with fallback logic when account is not specified.
+- [inbox_server.py](../../inbox_server.py) workflow endpoints create calendar events, Drive folders, Docs, and Sheets using account defaulting.
+- [inbox_server.py](../../inbox_server.py) has `/preflight/google-write`, and [tests/test_server.py](../../tests/test_server.py) covers several preflight outcomes, but write endpoints do not require preflight tokens or an explicit resolved-account acknowledgement.
+
+Decision note:
+
+Defaulting is useful for a personal app, but high-authority writes need either an explicit account or a recent preflight acknowledgement once multiple accounts are authorized.
+
+Next safe work:
+
+1. Add an optional strict mode that requires `account` for Google writes when more than one account is authorized.
+2. Return `resolved_account` on all write responses, not just some of them.
+3. Connect preflight results to workflow writes with a small acceptance token or required client-side acknowledgement.
+
+Validation candidates:
+
+- Expected pass today for existing behavior: `uv run pytest tests/test_server.py -q -k "default_account or preflight"`
+- Expected fail before strict mode: new test with two accounts and no `account` expecting a 400 for a high-risk write.
+
+### R6. Scheduler can send messages or create tasks in the background after startup
+
+Severity: medium-high
+Likelihood: low-medium
+Blast radius: scheduled Gmail/iMessage sends, Google Tasks, Apple Reminders.
+
+Evidence:
+
+- [inbox_server.py](../../inbox_server.py) `_process_scheduled_messages()` sends due Gmail messages via `gmail_compose_send()` and iMessages via `imsg_send()`.
+- [inbox_server.py](../../inbox_server.py) `_process_followup_reminders()` creates Google Tasks or Apple Reminders for followups.
+- [inbox_server.py](../../inbox_server.py) `_process_departure_alerts()` can create "leave now" tasks based on calendar/location.
+- [inbox_server.py](../../inbox_server.py) `_scheduler_loop()` checks scheduled messages, followups, and departure alerts every 30 seconds.
+- [scheduler.py](../../scheduler.py) stores persistent state in `.inbox_scheduler.sqlite3`, which is gitignored.
+
+Decision note:
+
+The service-level write guards should block these in `INBOX_TEST_MODE`, but a normal server start can process old queued work. This is an operational risk when switching between primary and dev worktrees or restoring scheduler DBs.
+
+Next safe work:
+
+1. Add a startup banner/health field showing pending scheduled sends and followups before background processing starts.
+2. Add a `INBOX_DISABLE_SCHEDULER=1` dev/agent mode and document it alongside `INBOX_TEST_MODE=1`.
+3. Add tests that scheduler loops respect disabled/test mode without touching service functions.
+
+Validation candidates:
+
+- Expected pass today for unit-level scheduler store: `INBOX_TEST_MODE=1 uv run pytest tests/test_server.py tests/test_services.py -q -k "scheduled or followup or scheduler"`
+- Expected fail before new guard: test with `INBOX_DISABLE_SCHEDULER=1` expecting no scheduled send processing.
+
+### R7. Deployment examples can leak operational details and PII into `/tmp` logs
+
+Severity: medium
+Likelihood: medium for launchd service users
+Blast radius: account emails, contact names, message recipients, ambient previews, failures.
+
+Evidence:
+
+- [deploy/com.inbox.backend.plist.example](../../deploy/com.inbox.backend.plist.example), [deploy/com.inbox.mcp.plist.example](../../deploy/com.inbox.mcp.plist.example), and [deploy/com.inbox.mcp-readonly.plist.example](../../deploy/com.inbox.mcp-readonly.plist.example) write stdout/stderr to `/tmp/inbox-*.log`.
+- [scripts/setup_inbox_mcp.sh](../../scripts/setup_inbox_mcp.sh) reports those `/tmp` log paths as the service logs.
+- [inbox_server.py](../../inbox_server.py) startup prints loaded contact count and lists of Gmail/Calendar/Drive/Sheets/Docs/Tasks account emails.
+- [inbox_server.py](../../inbox_server.py) scheduler logs sent Gmail recipients and iMessage contact names.
+- [ambient_notes.py](../../ambient_notes.py) logs and prints ambient capture previews.
+- [services.py](../../services.py) `_format_log_context()` truncates long strings but does not classify or redact context values by key.
+
+Decision note:
+
+Local logs are useful for a personal service, but `/tmp` is a poor default for logs that can include account identifiers and content previews.
+
+Next safe work:
+
+1. Move launchd logs to a user-private app log directory such as `~/Library/Logs/inbox/`.
+2. Redact account emails, recipients, contact names, file paths, and content previews in default logs.
+3. Add tests for log redaction helpers, especially around `INBOX_SERVER_TOKEN`, account emails, and message snippets.
+
+Validation candidates:
+
+- Expected fail before hardening: new unit tests for redacting account emails and message recipients from scheduler log messages.
+- Expected pass after hardening: `INBOX_TEST_MODE=1 uv run pytest tests/test_services.py tests/test_server.py -q -k "log or scheduler"`
+
+### R8. Ambient audio and dictation are powerful local capabilities exposed through the backend
+
+Severity: medium-high
+Likelihood: low by default, higher with autostart enabled or missing auth
+Blast radius: microphone capture, raw transcripts in Obsidian vault, keyboard injection.
+
+Evidence:
+
+- [ambient_daemon.py](../../ambient_daemon.py) continuously listens and saves extracted notes.
+- [ambient_notes.py](../../ambient_notes.py) saves raw transcript text under `~/vault/daily`.
+- [services.py](../../services.py) voice config defaults include `ambient_autostart: False` and `vault_dir`.
+- [inbox_server.py](../../inbox_server.py) can start/stop ambient listening through `/ambient/start` and `/ambient/stop`.
+- [inbox_server.py](../../inbox_server.py) can start/stop dictation through `/dictation/start` and `/dictation/stop`.
+- [inbox_server.py](../../inbox_server.py) startup can auto-start ambient listening when `ambient_autostart` is true and `INBOX_DISABLE_AMBIENT` is not set.
+- [services.py](../../services.py) WhatsApp and dictation-related code uses Accessibility/CGEvent style capabilities.
+
+Decision note:
+
+The default is safer than the capability surface because ambient autostart is off. The main risk is an unauthenticated local or accidentally exposed backend starting capture or dictation.
+
+Next safe work:
+
+1. Treat ambient/dictation start endpoints as high-risk operations in docs and tests.
+2. Add a separate local-only or explicit-confirmation guard for microphone/keyboard operations.
+3. Add `INBOX_DISABLE_VOICE=1` for agent/dev sessions and make docs recommend it.
+
+Validation candidates:
+
+- Expected pass today: `INBOX_TEST_MODE=1 uv run pytest tests/test_voice_pipeline.py -q`
+- Expected fail before hardening: new tests that require voice start endpoints to reject when a disable env var is set.
+
+### R9. Read-only MCP daily-note tool appears stale
+
+Severity: medium
+Likelihood: high when using read-only MCP note reads
+Blast radius: readonly MCP reliability; possible path-safety risk if fixed casually.
+
+Evidence:
+
+- [ambient_notes.py](../../ambient_notes.py) defines `VAULT_PATH`, `DAILY_DIR`, and `AMBIENT_DIR`.
+- [inbox_mcp_readonly.py](../../inbox_mcp_readonly.py) `read_daily_note()` references `ambient_notes.VAULT_DIR`, which is not defined.
+- `rg -n "read_daily_note|inbox_mcp_readonly|VAULT_DIR|VAULT_PATH" .` found no tests covering `inbox_mcp_readonly.read_daily_note`.
+
+Decision note:
+
+This is likely a stale name from an older implementation. Fixing it should also validate date input as `YYYY-MM-DD`, not just switch to a different path constant.
+
+Next safe work:
+
+1. Fix `read_daily_note()` to use `ambient_notes.read_daily_note(date)` or `DAILY_DIR`.
+2. Validate the `date` parameter strictly and reject path separators.
+3. Add tests for today's note, explicit date, missing date, and invalid date.
+
+Validation candidates:
+
+- Expected fail today if added: `uv run pytest tests/test_mcp_gateway.py -q -k "read_daily_note"`
+- Expected pass after fix: `INBOX_TEST_MODE=1 uv run pytest tests/test_mcp_gateway.py tests/test_ambient_notes.py -q`
+
+### R10. Drive upload reads whole files into memory and has no apparent size limit
+
+Severity: medium
+Likelihood: medium
+Blast radius: local memory/disk pressure and external Drive writes.
+
+Evidence:
+
+- [inbox_server.py](../../inbox_server.py) `/drive/upload` reads `content = await file.read()` before writing to a temp file.
+- [inbox_server.py](../../inbox_server.py) uses `NamedTemporaryFile(delete=False, suffix=f"_{file.filename}")`, so client filenames influence temp file suffixes.
+- [inbox_server.py](../../inbox_server.py) deletes the temp file in a `finally` block.
+- [services.py](../../services.py) `drive_upload()` calls `MediaFileUpload(..., resumable=True)` after the temp file is created.
+- [tests/test_drive.py](../../tests/test_drive.py) covers direct `drive_upload()` success/failure but not the FastAPI upload endpoint's size, temp-file naming, or `INBOX_TEST_MODE` behavior.
+
+Decision note:
+
+The `finally` cleanup is good. The risk is that the endpoint can allocate all uploaded bytes before size checks and then perform an external write that lacks the current live-write guard.
+
+Next safe work:
+
+1. Stream uploads to a temp file with a maximum byte limit.
+2. Sanitize temp suffix/file display names.
+3. Add `INBOX_TEST_MODE` guard to `drive_upload()` before any external API call.
+
+Validation candidates:
+
+- Expected fail before hardening: endpoint test uploading over a configured limit expects 413.
+- Expected pass after hardening: `INBOX_TEST_MODE=1 uv run pytest tests/test_drive.py tests/test_server_endpoints.py -q -k "upload"`
+
+### R11. Unsubscribe automation performs external HTTP/mail actions and archives regardless of method success
+
+Severity: medium
+Likelihood: low-medium
+Blast radius: external unsubscribe requests, Gmail archive state.
+
+Evidence:
+
+- [services.py](../../services.py) `gmail_unsubscribe()` reads `List-Unsubscribe`, performs `requests.post()` or `requests.get()` for URL unsubscribes, may send an unsubscribe email for `mailto`, then calls `gmail_archive(service, msg_id)`.
+- [inbox_server.py](../../inbox_server.py) exposes single and bulk unsubscribe endpoints.
+- [unsubscribe_bulk.py](../../unsubscribe_bulk.py) and [unsubscribe_all_newsletters.py](../../unsubscribe_all_newsletters.py) have interactive confirmations, but REST endpoints depend on backend auth and service guard, not a per-call confirmation.
+
+Decision note:
+
+The service-level guard covers agent safe mode. The behavior still deserves a high-friction confirmation path because it can notify external parties and change mailbox state.
+
+Next safe work:
+
+1. Split "inspect unsubscribe method" from "execute unsubscribe and archive".
+2. Require explicit confirmation metadata for bulk unsubscribe calls.
+3. Add a dry-run response showing method, target domain/email, and archive effect.
+
+Validation candidates:
+
+- Expected pass today: `INBOX_TEST_MODE=1 uv run pytest tests/test_gmail_actions.py -q -k unsubscribe`
+- Expected fail before hardening: new endpoint test requiring dry-run/confirm for bulk unsubscribe.
+
+## Stale assumptions and unsupported claims
+
+1. README privacy/local-only claim is stale relative to Gemini support. Evidence: [README.md](../../README.md) says local ML has no cloud dependencies and all data processing happens on-device, while [services.py](../../services.py) and [inbox_server.py](../../inbox_server.py) expose Gemini prompt calls.
+2. "Read-only MCP" is not fully validated. It excludes registry write tools, but its handwritten daily-note read tool references a missing constant.
+3. "All mutations are confirmation-gated" is true for `tools_registry.py` MCP tools, but not true for direct REST/TUI paths. Direct backend auth is optional and REST mutators do not carry `confirm=True`.
+4. Preflight exists for Google writes, but it is advisory. It does not appear to gate the actual write endpoints.
+5. Token safety is mostly gitignore-based. Config env files get `chmod 600` in setup, but OAuth token JSON writers do not visibly enforce private permissions.
+6. Launchd/systemd examples assume one fixed path and one primary checkout, while `CLAUDE.md` encourages multiple worktrees and alternate ports. That creates handoff risk if services are bootstrapped from the wrong checkout.
+
+## Independently grabbable next tasks
+
+### Task 1: Exhaustive live-write guard coverage
+
+Acceptance criteria:
+
+- Every external-service or personal-data mutator in `services.py` calls `_assert_live_write_allowed()` before touching service clients, subprocesses, or local personal stores.
+- Newly covered functions include `drive_upload`, `gmail_label_create`, `sheets_rename_sheet`, `sheets_format`, `sheets_copy_to`, and `docs_insert_text`.
+- A table-driven test proves each covered function raises `LiveWriteBlocked` before touching a sentinel fake service in `INBOX_TEST_MODE=1`.
+
+Validation:
+
+- `INBOX_TEST_MODE=1 uv run pytest tests/test_services.py tests/test_drive.py -q -k "live_write or upload or label or sheet or doc"`
+- `INBOX_TEST_MODE=1 uv run pytest -m safe`
+
+### Task 2: Cloud AI privacy gate and documentation correction
+
+Acceptance criteria:
+
+- Gemini model initialization and Gemini REST endpoints require explicit cloud-AI opt-in, for example `INBOX_ENABLE_CLOUD_AI=1`.
+- When disabled, Gemini endpoints return a clear disabled response without calling `generate_content`.
+- README and CLAUDE privacy sections distinguish local ML from optional Gemini cloud processing.
+
+Validation:
+
+- `INBOX_TEST_MODE=1 uv run pytest tests/test_ai_layer.py tests/test_server.py -q -k "gemini or cloud_ai or privacy"`
+- `uv run ruff check README.md CLAUDE.md services.py inbox_server.py tests`
+
+### Task 3: Public MCP fail-closed mode
+
+Acceptance criteria:
+
+- Public HTTP MCP can be configured to require `INBOX_MCP_TOKEN`.
+- In required mode, missing token rejects startup or all non-health routes.
+- Docs and examples for public HTTP MCP never show a blank token.
+- Local stdio remains ergonomic and does not require public MCP token.
+
+Validation:
+
+- `uv run pytest tests/test_mcp_gateway.py -q`
+- `uv run ruff check mcp_gateway.py mcp_server.py inbox_mcp_readonly.py tests/test_mcp_gateway.py`
+
+### Task 4: Account-routing strict mode for high-risk Google writes
+
+Acceptance criteria:
+
+- When more than one account exists and strict mode is enabled, high-risk Google writes require an explicit `account`.
+- Write responses consistently include `account` or `resolved_account`.
+- Existing default-account behavior remains available in normal local mode.
+
+Validation:
+
+- `INBOX_TEST_MODE=1 uv run pytest tests/test_server.py tests/test_gmail_actions.py -q -k "account or preflight or workflow"`
+
+### Task 5: Private log and token-file permission hardening
+
+Acceptance criteria:
+
+- Token JSON writes set private file permissions.
+- Launchd log defaults move from `/tmp` to a user-private app log directory.
+- Log redaction tests cover tokens, account emails, recipients, and content previews.
+
+Validation:
+
+- `INBOX_TEST_MODE=1 uv run pytest tests/test_services.py tests/test_server.py -q -k "token or log or redaction"`
+- `pre-commit run detect-private-key --all-files`
+
+### Task 6: Read-only MCP daily-note repair
+
+Acceptance criteria:
+
+- `inbox_mcp_readonly.read_daily_note()` no longer references `ambient_notes.VAULT_DIR`.
+- Date inputs are restricted to `YYYY-MM-DD` or empty for today.
+- Tests cover existing note, missing note, and invalid/path-like date.
+
+Validation:
+
+- `INBOX_TEST_MODE=1 uv run pytest tests/test_ambient_notes.py tests/test_mcp_gateway.py -q -k "daily_note or readonly"`
+
+## Validation command candidates
+
+Required queue validation:
+
+- Command: `git status --short`
+- Expected status after report write, before any commit: one untracked or modified report path under `docs/overnight/`.
+- Expected status after an optional local commit: clean output.
+
+Agent-safe validation:
+
+- Command: `INBOX_TEST_MODE=1 uv run pytest -m safe`
+- Expected status now: should pass if dependencies are installed and the repo's safe-test contract is current. This audit did not run it because the queue item's explicit validation command is `git status --short` and the task is read-only documentation.
+
+Lint/type validation:
+
+- Command: `uv run ruff check .`
+- Expected status now: should pass or surface existing lint unrelated to this report.
+- Command: `uv run pyright`
+- Expected status now: should pass or surface existing type debt unrelated to this report.
+
+Risk-focused future validation:
+
+- Command: `pre-commit run detect-private-key --all-files`
+- Expected status now: should pass based on `.gitignore` and absence of obvious secret files in this worktree.
+- Command: `uv run bandit -c pyproject.toml -r .`
+- Expected status now: may pass while missing subprocess risks because `pyproject.toml` skips subprocess-related bandit rules.
+
+## Non-goals
+
+- No product code changes.
+- No test rewrites.
+- No generated data changes.
+- No local server starts.
+- No external service calls.
+- No deploys.
+- No pushes or PR creation.
+- No Linear/GitHub tracker state changes.
+- No attempts to read real personal token files or local personal databases.
+- No migration of hidden `.factory/` artifacts.
+
+## Unknowns and blockers
+
+- The local queue issue file `items/inbox-sym-117-risk-register/ISSUE.md` is missing from this worktree.
+- I did not run the safe pytest suite; only the required queue validation command is intended for this worker.
+- I did not verify runtime behavior against live Gmail/Calendar/Drive/Sheets/Docs/Tasks, iMessage, Notes, Reminders, GitHub, Gemini, Google Maps, or audio hardware because external services and personal data access are out of scope.
+- I did not inspect actual ignored token files because none were present in this worktree and secret discovery beyond gitignored placeholders is out of scope.
+- I did not compare sibling repos from `repos.json` because this repo is not small and the queue item is scoped to one repo/worktree.
+
+## Handoff notes
+
+Changed files:
+
+- `docs/overnight/inbox-sym-117-risk-register.md`
+
+Suggested owner handoff:
+
+- Start with R1 before any new live-write-capable feature work.
+- Treat R3 as a documentation and product-policy decision: either Gemini is an explicit cloud feature or it should be disabled by default.
+- Treat R2 as deployment hardening: local stdio can stay easy, public HTTP MCP should fail closed.

--- a/docs/overnight/inbox-sym-117-validation-map.md
+++ b/docs/overnight/inbox-sym-117-validation-map.md
@@ -1,0 +1,165 @@
+# inbox-sym-117 validation-map audit
+
+Queue item: `inbox-sym-117-validation-map`
+Date: 2026-05-07
+Focus area: validation-map
+
+## Repo purpose and starting state
+
+`inbox-sym-117` is a Python local-first personal inbox system: a FastAPI backend, Textual TUI, MCP gateway, and service layer for iMessage, Gmail, Google Calendar, Sheets, Docs, Drive, Apple Notes, Reminders, GitHub notifications, audio/ASR, and local/optional LLM workflows. The most validation-sensitive boundary is that many modules touch live personal data or local credentials unless `INBOX_TEST_MODE=1` and mocked services are used.
+
+Starting branch and state:
+
+- `git status --short --branch` returned only `## codex/goal-inbox-sym-117-validation-map`; the worktree started with no tracked modifications.
+- `git log --oneline -5` showed starting HEAD `2805b84` (`Merge pull request #34 from jwalin-shah/codex/SYM-9-indexed-defaults`).
+- `git ls-files | wc -l` reported 196 tracked files.
+- `rg --files tests | wc -l` reported 31 test files.
+- `git diff --stat` was empty before this report was written.
+
+## Validation inventory
+
+Declared validation surfaces:
+
+- `pyproject.toml` declares Python `>=3.12,<3.15`, runtime dependencies including FastAPI, Google API clients, Textual, MLX, Outlines, MCP, sounddevice, and PyObjC, plus dev dependencies `pytest`, `pytest-cov`, `ruff`, `pyright`, `bandit`, `hypothesis`, and `pre-commit`.
+- `pyproject.toml` configures pytest with `testpaths = ["tests"]` and `addopts = "--cov=. --cov-report=term-missing"`. Any direct `pytest` fallback needs `pytest-cov` or `-o addopts=`.
+- `pyproject.toml` registers markers `safe`, `integration`, `local_data`, `slow`, and `live_write`, but marker search found only two module-level safe declarations: `tests/test_inbox_test_mode.py:8` and `tests/test_mcp_gateway.py:18`.
+- `docs/TESTING_FOR_AGENTS.md` names the intended agent-safe loop: `INBOX_TEST_MODE=1 uv run pytest -m safe`, `uv run ruff check .`, and `uv run pyright`. It also explicitly forbids live-write tests unless requested.
+- `.factory/services.yaml` defines a second validation contract: `uv run pytest --ignore=tests/test_audio.py --ignore=tests/test_llm.py -x -q`, `uv run pytest -x -q`, `uv run pyright`, and `uv run ruff check .`.
+- `.pre-commit-config.yaml` configures Ruff, Ruff format, common pre-commit hooks, and Bandit with `bandit[toml]`. Fresh pre-commit runs may need network to fetch hook repos.
+- `README.md` and `CLAUDE.md` both list `uv run ruff`, `uv run pyright`, and `uv run pytest` as development commands.
+- `scripts/run_inbox_backend.sh` and MCP launch scripts set `UV_CACHE_DIR="${UV_CACHE_DIR:-/tmp/uv-cache}"`, but `dev.sh`, `README.md`, `CLAUDE.md`, and `docs/TESTING_FOR_AGENTS.md` do not include a writable cache override.
+
+Runtime/test safety surfaces:
+
+- `inbox_test_mode.py` defines `INBOX_TEST_MODE`, `INBOX_TEST_DATA_DIR`, `INBOX_TEST_NOW`, and `assert_live_writes_allowed`.
+- `services.py` routes `TOKEN_FILE`, `TOKENS_DIR`, `IMSG_DB`, `NOTES_DB`, and `REMINDERS_DIR` under `test_data_dir()` when `INBOX_TEST_MODE=1`.
+- `services.py` imports `assert_live_writes_allowed` via `_assert_live_write_allowed`, but importing `services.py` still requires Google/logging dependencies before many test-mode assertions can run.
+- `tests/conftest.py` stubs heavy ML/hardware modules (`mlx_lm`, `mlx_whisper`, `sounddevice`, `outlines`, `Quartz`) but does not stub `google_auth_oauthlib`, `loguru`, `textual`, or `trio`.
+- `tests/test_mcp_gateway.py` uses `@pytest.mark.anyio`; without a project environment, AnyIO parameterizes Trio cases and fails if Trio is missing.
+- `inbox_server.py` exposes `PORT = 9849` and reads `INBOX_SERVER_PORT` at process start; `dev.sh` defaults worktrees to port 9850.
+
+## Commands run and observed status
+
+| Command | Result | Evidence |
+| --- | --- | --- |
+| `llm-tldr tree .` | Pass | Mapped Python app structure, `tests/`, `docs/`, launch scripts, and config files. |
+| `git status --short --branch` | Pass | Started clean on `codex/goal-inbox-sym-117-validation-map`. |
+| `rg --files tests | wc -l` | Pass | 31 test files. |
+| `rg -n "pytestmark = pytest.mark.safe\|@pytest.mark..." tests` | Pass | Only `tests/test_inbox_test_mode.py` and `tests/test_mcp_gateway.py` are marked safe. |
+| `INBOX_TEST_MODE=1 uv run pytest -m safe -q` | Fail, environment | uv could not initialize `/Users/jwalinshah/.cache/uv` in this sandbox (`Operation not permitted`). |
+| `UV_CACHE_DIR=/private/tmp/uv-cache-inbox-sym-117 INBOX_TEST_MODE=1 uv run pytest -m safe -q` | Fail, environment | uv created `.venv/`, then failed to download `google-ai-generativelanguage` because network/DNS is unavailable. |
+| `INBOX_TEST_MODE=1 python -m pytest -m safe -q` | Fail, environment | `python` command not found; host command is `python3`. |
+| `INBOX_TEST_MODE=1 python3 -m pytest -m safe -q` | Fail, environment | Host pytest lacks `pytest-cov`, so configured `--cov` addopts are unrecognized. |
+| `INBOX_TEST_MODE=1 python3 -m pytest -m safe -q -o addopts=` | Fail, collection/deps | Marker selection still collected tests that import missing `google_auth_oauthlib`, `textual`, and `loguru`; 11 collection errors. |
+| `INBOX_TEST_MODE=1 python3 -m pytest tests/test_inbox_test_mode.py tests/test_mcp_gateway.py -q -o addopts=` | Mixed | 9 passed, 4 failed: missing `google_auth_oauthlib` for service-import tests and missing `trio` for AnyIO Trio parametrizations. |
+| `INBOX_TEST_MODE=1 python3 -m pytest tests/test_mcp_gateway.py -q -o addopts= -k 'not trio'` | Pass | 5 passed, 2 deselected in 0.17s. |
+| `INBOX_TEST_MODE=1 python3 -m pytest tests/test_inbox_test_mode.py -q -o addopts= -k 'not services and not google_auth_all'` | Pass | 4 passed, 2 deselected in 0.03s. |
+| `UV_CACHE_DIR=/private/tmp/uv-cache-inbox-sym-117 uv run ruff check .` | Fail, environment | uv tried to resolve full dependencies and failed to download `numba` via `mlx-whisper`. |
+| `UV_CACHE_DIR=/private/tmp/uv-cache-inbox-sym-117 uv run pyright` | Fail, environment | uv tried to resolve full dependencies and failed to download `google-api-python-client`. |
+| `ruff check .` | Pass | Direct host Ruff 0.15.8 returned `All checks passed!`. |
+| `pyright` | Fail | Direct host Pyright 1.1.408 returned 116 errors, including missing `textual`, `loguru`, Google OAuth, PyObjC/Quartz, MLX/Outlines, `gemma4_hackathon`, and real type issues. |
+| `bandit -q -r . -c pyproject.toml` | Pass with warnings | Exit 0; warnings were about `nosec` comment parsing and suppressed findings. |
+| `git status --short --ignored .pytest_cache .ruff_cache .venv` | Pass observation | `.pytest_cache/`, `.ruff_cache/`, and `.venv/` are ignored artifacts from validation attempts. Removing `.venv/` was blocked by sandbox policy. |
+
+## Current validation map
+
+Best command when a full uv environment is already provisioned:
+
+```bash
+UV_CACHE_DIR=/tmp/uv-cache INBOX_TEST_MODE=1 uv run pytest -m safe
+UV_CACHE_DIR=/tmp/uv-cache uv run ruff check .
+UV_CACHE_DIR=/tmp/uv-cache uv run pyright
+```
+
+Expected current status in this fresh restricted worktree: pytest/ruff/pyright via uv fail before executing validation because dependency downloads are blocked. This is an environment/bootstrap failure, not a test assertion failure.
+
+Best host-only cheap checks observed here:
+
+```bash
+ruff check .
+bandit -q -r . -c pyproject.toml
+INBOX_TEST_MODE=1 python3 -m pytest tests/test_mcp_gateway.py -q -o addopts= -k 'not trio'
+INBOX_TEST_MODE=1 python3 -m pytest tests/test_inbox_test_mode.py -q -o addopts= -k 'not services and not google_auth_all'
+```
+
+Expected current status: pass on this machine. These are useful smoke checks but not a substitute for the declared uv environment.
+
+Commands expected to fail until validation debt is addressed:
+
+```bash
+INBOX_TEST_MODE=1 python3 -m pytest -m safe -q -o addopts=
+pyright
+pre-commit run --all-files
+```
+
+Expected current status:
+
+- `python3 -m pytest -m safe ...` fails during collection without project dependencies, because unselected tests still import unavailable modules before marker filtering completes.
+- `pyright` fails with 116 errors in the host environment.
+- `pre-commit run --all-files` is expected to require network/cached hook repos unless hooks are already installed; it was not run because this audit avoided external fetches.
+
+Commands that should remain opt-in only:
+
+```bash
+uv run pytest
+uv run pytest -x -q
+uv run pytest --ignore=tests/test_audio.py --ignore=tests/test_llm.py -x -q
+curl -sf http://localhost:9849/health
+uv run python inbox_server.py
+uv run python inbox.py
+```
+
+Reason: these either require the full dependency environment, may touch the live primary inbox server, may read local personal data stores, or may start long-running/local-service processes. For this audit, I did not start the server or call live localhost endpoints.
+
+## Risks and stale assumptions
+
+1. Safe pytest is not actually bootstrap-safe in a dependency-cold environment. `pytest -m safe` still collects the whole `tests/` tree, and collection imports modules needing `google_auth_oauthlib`, `textual`, and `loguru`.
+2. The documented safe commands do not include `UV_CACHE_DIR`, while this sandbox cannot use `~/.cache/uv`. Some scripts know to set `/tmp/uv-cache`, but the agent docs and `dev.sh` do not.
+3. Safe marker coverage is shallow. Only 2 of 31 test files are marked `safe`, so the safe loop currently checks MCP gateway/test-mode scaffolding, not most deterministic server/client/service behavior.
+4. `pyproject.toml` requires `pytest-cov` globally through addopts. Host Python can have pytest installed but still fail before any test runs because `--cov` is unknown.
+5. AnyIO tests assume Trio availability by default. `tests/test_mcp_gateway.py` passes under asyncio but fails the Trio parametrization when Trio is not installed.
+6. Documentation claims are stale or inconsistent: `README.md` says Python 3.10+, while `pyproject.toml` requires Python 3.12+; `DOCS_INDEX.md` claims 736 passing tests and production-ready status, which was not reproducible here.
+7. Direct `pyright` is not green. Some errors are missing environment packages, but others are apparent code/type contract mismatches, so a provisioned venv may still reveal real type debt.
+8. Hidden `.factory/services.yaml` claims older broad test commands and a server start command pinned to `/Users/jwalinshah/projects/inbox`, which is risky for isolated worktrees because it can exercise the primary checkout instead of the current worktree.
+
+## Next safe work
+
+1. Make the agent validation bootstrap deterministic.
+   - Acceptance criteria: `docs/TESTING_FOR_AGENTS.md`, `CLAUDE.md`, and `.factory/services.yaml` agree on `UV_CACHE_DIR=/tmp/uv-cache` or another writable cache; a fresh sandbox failure records dependency/network bootstrap clearly instead of failing on `~/.cache/uv` permissions.
+   - Validation: `UV_CACHE_DIR=/tmp/uv-cache INBOX_TEST_MODE=1 uv run pytest -m safe -q` reaches test execution in a provisioned/cache-warm environment; in a network-cold sandbox, the failure is only a dependency download blocker.
+
+2. Make `pytest -m safe` collect only safe/import-light tests.
+   - Acceptance criteria: safe marker collection no longer imports modules that require live Google/Textual/loguru deps before deselection, or those imports are properly stubbed under tests; the command remains read-only under `INBOX_TEST_MODE=1`.
+   - Validation: `INBOX_TEST_MODE=1 python3 -m pytest -m safe -q -o addopts=` runs the selected safe tests without collection errors on a host Python that has pytest and Starlette/AnyIO installed.
+
+3. Pin AnyIO safe tests to asyncio unless Trio is intentionally supported.
+   - Acceptance criteria: `tests/test_mcp_gateway.py` defines an `anyio_backend` fixture or otherwise avoids implicit Trio parametrization; all MCP gateway safe tests pass without installing Trio.
+   - Validation: `INBOX_TEST_MODE=1 python3 -m pytest tests/test_mcp_gateway.py -q -o addopts=` returns all tests passing, not just `-k 'not trio'`.
+
+4. Reconcile validation claims in docs.
+   - Acceptance criteria: `README.md` Python requirement matches `pyproject.toml`; `DOCS_INDEX.md` removes or dates the "736 tests pass" and "production-ready" claims unless a fresh command proves them.
+   - Validation: `rg -n "Python 3.10|736 pass|production-ready" README.md DOCS_INDEX.md CLAUDE.md` has no unsupported current validation claims.
+
+5. Split typecheck health into environment vs code debt.
+   - Acceptance criteria: missing optional/platform imports are either resolved by the uv environment or intentionally configured, and remaining Pyright errors are tracked as concrete code issues.
+   - Validation: `UV_CACHE_DIR=/tmp/uv-cache uv run pyright` runs in a provisioned environment and produces either 0 errors or a stable, triaged error list with owner tasks.
+
+## Non-goals
+
+- No product code was changed.
+- No live personal data stores, OAuth tokens, Gmail/Calendar/Drive/Docs/Sheets/Tasks APIs, iMessage, Notes, Reminders, GitHub APIs, microphone/audio paths, or notification mutations were exercised.
+- No server was started, no localhost health check was run against the primary inbox, and no external services were contacted intentionally.
+- No tracked generated data, credentials, deployment config, pushes, PRs, or external tracker state were created or modified. Ignored validation artifacts are listed in the command observations.
+- No attempt was made to fix the validation failures in this audit slice.
+
+## Unknowns
+
+- Whether the primary checkout or a CI runner has a warm uv cache that makes the declared uv commands pass.
+- Whether `uv run pyright` still reports the non-import type errors after all project dependencies are installed.
+- Whether the historical `.factory/validation/*` pass records correspond to this exact branch state.
+- Whether all deterministic tests can be safely marked `safe`, or whether some unmarked tests read local personal stores without writes.
+- Whether the runner expects ignored `.venv/`, `.pytest_cache/`, and `.ruff_cache/` artifacts to be cleaned; normal git status ignores them, and the sandbox blocked removing `.venv/`.
+
+## Handoff blocker
+
+The report is intentionally the only tracked file change, but this sandbox cannot stage or commit it: `git add docs/overnight/inbox-sym-117-validation-map.md` failed because Git tried to create `/Users/jwalinshah/projects/inbox/.git/worktrees/inbox-sym-117-validation-map/index.lock`, which is outside the writable roots.

--- a/docs/overnight/inbox-sym-118-architecture-map.md
+++ b/docs/overnight/inbox-sym-118-architecture-map.md
@@ -1,0 +1,278 @@
+# inbox-sym-118 architecture-map audit
+
+Date: 2026-05-07
+
+Queue item: `inbox-sym-118-architecture-map`
+
+Scope: read-only architecture audit for the local `inbox-sym-118` worktree. The only intended repository change is this report.
+
+## Summary
+
+Inbox is a local-first personal communication control plane with three major runtime surfaces:
+
+- a Textual TUI in `inbox.py`,
+- a local FastAPI backend in `inbox_server.py`,
+- an MCP/agent surface built from `mcp_backend.py`, `mcp_server.py`, `inbox_mcp_readonly.py`, and `tools_registry.py`.
+
+The product direction is clear: raw providers feed a local operational index, the server owns auth/routing/policy, and UI/agent clients consume compact views. The codebase is partway through that transition. The strongest newer boundaries are `service_models.py`, `google_account_resolution.py`, `message_index_store.py`, `message_sync.py`, and `tools_registry.py`. The highest architectural risk is that `services.py` and `inbox_server.py` still hold too much cross-domain behavior, so small connector changes can touch data access, routing policy, API models, background jobs, and UI refresh assumptions at once.
+
+## Repo State
+
+- Branch observed with `git status --short --branch`: `codex/goal-inbox-sym-118-architecture-map`.
+- Initial dirty state observed with `git status --short`: clean, no output.
+- Starting HEAD from `git rev-parse HEAD`: `2805b8400519da188ca7d3f6e39b19a8ca42b05a`.
+- Recent history from `git log --oneline -5` shows the branch starts at merge `2805b84 Merge pull request #34 from jwalin-shah/codex/SYM-9-indexed-defaults`, which matches recent indexed-defaults architecture work.
+- `llm-tldr tree .` shows a flat Python application with top-level runtime modules, `tests/`, `config/`, `deploy/`, `scripts/`, `modes/`, and only one pre-existing file under `docs/`.
+- `fd . docs -t f` initially returned only `docs/TESTING_FOR_AGENTS.md`; `docs/overnight/` did not exist before this report.
+- `rg --files -g '*.py' | xargs wc -l` reported 36,403 Python lines. Largest modules: `services.py` 6,467 lines, `inbox.py` 4,279 lines, `inbox_server.py` 3,940 lines, `tests/test_inbox_app.py` 3,636 lines, `tests/test_server.py` 2,289 lines.
+- `rg -c '^@app\\.' inbox_server.py` reported 160 FastAPI route decorators.
+- `rg -c 'Tool\\(' tools_registry.py` reported 60 MCP registry entries.
+- `rg -c '^    def |^    async def ' inbox_client.py mcp_backend.py` reported 103 synchronous client methods in `inbox_client.py` and 46 async backend methods in `mcp_backend.py`.
+
+## Purpose And Product Shape
+
+The README positions Inbox as a privacy-first TUI that consolidates iMessage, Gmail, Calendar, Sheets, Notes, Reminders, GitHub, and Drive (`README.md:1-15`). It also says the architecture is client-server, with FastAPI owning data access while the TUI and agents are thin HTTP clients (`README.md:23-27`).
+
+The product plan is narrower and more architectural than the README feature list. `PLAN.md` defines the current phase around Gmail, iMessage/SMS, calendar context, FastAPI, a local SQLite operational index, and Textual TUI, while explicitly deferring a general memory platform and other ingestions. It describes four layers: raw sources, operational index, inbox views, and interfaces (`PLAN.md:1-78`). This plan better matches the recent code than the README architecture block.
+
+The connector roadmap describes the intended long-term boundary: source adapters, normalization, policy, and intent tools (`CONNECTOR_ROADMAP.md:15-31`). It also calls out that account routing and write defaults should be code policy, not prompt convention (`CONNECTOR_ROADMAP.md:33-60`).
+
+## Architecture Map
+
+### Runtime Entrypoints
+
+1. `inbox.py` is the TUI entrypoint. `InboxApp` constructs an `InboxClient`, starts or connects to the backend, refreshes data, and then polls (`inbox.py:1147-1224`, `inbox.py:2082-2114`). It is not just presentation code; it owns boot recovery, status behavior, notifications, indexed-view refreshes, and many user workflows (`inbox.py:2140-2360`).
+
+2. `inbox_server.py` is the backend entrypoint. `make_lifespan()` initializes contacts, Google services, ambient audio, scheduler, and SQLite cleanup (`inbox_server.py:1198-1285`). `create_app()` creates the FastAPI app and copies existing routes into new runtime instances for tests (`inbox_server.py:1288-1310`). Authentication is optional unless `INBOX_SERVER_TOKEN` is set (`inbox_server.py:1313-1340`).
+
+3. `inbox_client.py` is the synchronous HTTP client used by the TUI. It derives `SERVER_URL` from `INBOX_SERVER_URL` or `INBOX_SERVER_PORT` (`inbox_client.py:16-18`), injects the bearer token if present (`inbox_client.py:21-25`), and can spawn `inbox_server.py` as a subprocess with logs in `server.log` (`inbox_client.py:48-77`).
+
+4. `mcp_backend.py` is the async HTTP client used by MCP tools. It defaults to `http://127.0.0.1:9849`, reads `INBOX_SERVER_URL` and `INBOX_SERVER_TOKEN`, and exposes `_request()` for registry-generated tools (`mcp_backend.py:9-56`).
+
+5. `mcp_server.py` and `inbox_mcp_readonly.py` expose FastMCP servers. Both delegate most HTTP-backed tool generation to `tools_registry.register_all()` (`tools_registry.py:1-12`, `tools_registry.py:110-119`).
+
+6. `message_sync.py` is the operational index sync entrypoint. Bootstrap sync reads Gmail and iMessage, records progress, and rebuilds changed thread rows (`message_sync.py:181-269`, `message_sync.py:602-626`).
+
+### Module Ownership Boundaries
+
+`services.py` owns provider access and local OS integration. It defines token paths, local data paths, Google scopes, SQLite helpers, OAuth, iMessage reads/writes, Gmail reads/writes, Calendar, Notes, WhatsApp Accessibility, Reminders, Tasks, Gemini, Maps, GitHub, Drive, Sheets, Docs, audio, LLM, global search, notifications, favorites, contacts, and AI helpers (`services.py:65-120`, `services.py:330-416`, `services.py:444-604`, `services.py:786-1464`, `services.py:1475-1820`, `services.py:1872-2024`, `services.py:2077-2580`, `services.py:2620-3239`, `services.py:3249-4519`, `services.py:4546-6425`). This is the primary monolith.
+
+`service_models.py` is a cleaner shared model boundary. It defines stable dataclasses such as `Contact`, `Msg`, `CalendarEvent`, `DriveFile`, `Spreadsheet`, `Document`, and `ThreadSummary` (`service_models.py:1-153`). This file is a good extraction target and should stay pure.
+
+`inbox_server.py` owns HTTP models, route orchestration, background server state, and conversion from service dataclasses to API response models. `ServerState` holds all Google service dictionaries, conversation cache, ambient service, dictation service, scheduler, index store, and source adapters (`inbox_server.py:802-817`). This centralizes state but also creates hidden coupling among routes.
+
+`google_account_resolution.py` is the main account-routing policy boundary. It defines a protocol for multi-account state, honors `INBOX_DEFAULT_GOOGLE_ACCOUNT`, routes Gmail by cached conversation or message/thread lookup, and resolves services for Gmail, Sheets, Drive, Tasks, Docs, and Calendar (`google_account_resolution.py:14-33`, `google_account_resolution.py:36-157`). It also owns preflight payload construction for Google writes (`google_account_resolution.py:160-220`).
+
+`message_index_store.py` owns the local operational read model. Its schema has `sync_state`, `items`, `threads`, and `sender_stats` tables (`message_index_store.py:69-170`). It rebuilds thread rows from normalized items and stores derived fields such as `human_score`, `noise_class`, `topic`, `urgency`, `actionability`, `needs_reply`, `summary`, and `open_loop` (`message_index_store.py:407-563`). It also owns query filtering for actionable/recent/waiting-style views (`message_index_store.py:565-612`).
+
+`message_sync.py` owns source-to-index ingestion. Gmail bootstrap stores page progress and later switches to Gmail history cursor when available (`message_sync.py:181-269`). Top-level `bootstrap()` and `incremental()` sync Gmail and iMessage, then rebuild changed thread scopes (`message_sync.py:602-626`).
+
+`thread_classifier.py` and `gmail_triage.py` own derived thread/workflow intelligence. `message_index_store.py` calls `classify_thread()` during rebuild (`message_index_store.py:448-500`), while `inbox_server.py` imports Gmail triage helpers for summaries, workflow display, thread briefs, and needs-action routing (`inbox_server.py:23-54`).
+
+`scheduler.py` owns local durable workflow state for scheduled messages, follow-up reminders, and task-message links in `.inbox_scheduler.sqlite3` (`scheduler.py:1-16`, `scheduler.py:59-114`). `inbox_server.py` starts the scheduler loop at server lifespan time and exposes scheduler endpoints (`inbox_server.py:979-1192`, `inbox_server.py:2061-2183`).
+
+`memory_store.py` owns local durable memory entries in `.inbox_memory.sqlite3`; `mcp_server.py`, `inbox_mcp_readonly.py`, and `/memory/extract` expose memory reads/writes. This is adjacent to the main inbox plan but not part of the narrow Phase 1 core.
+
+`tools_registry.py` is the strongest agent-surface boundary. It defines `Tool` metadata, parameter placement, generated function signatures, readonly filtering, and confirm-gating (`tools_registry.py:26-119`). The registry keeps full and readonly MCP servers from drifting, but it is still a second API map separate from `inbox_client.py`.
+
+### Data Flow
+
+1. Local/macOS and cloud providers enter through `services.py`.
+2. The FastAPI lifespan initializes provider services and stores them in global `state` (`inbox_server.py:1198-1229`).
+3. Raw source endpoints either fetch live data through `services.py` or use `state.conv_cache` to recover conversation metadata (`inbox_server.py:1396-1450`).
+4. Index sync writes normalized source items into `message_index_store.py` through `message_sync.py`.
+5. Indexed read endpoints serve compact thread views through `/index/*` and `/inbox/needs-action` (`inbox_server.py:3739-3853`).
+6. The TUI fetches both raw provider tabs and indexed views. `_collect_auxiliary_data()` fetches calendar, notes, reminders, GitHub, and indexed recent/actionable/waiting views on each refresh/poll (`inbox.py:2295-2360`).
+7. MCP tools call `mcp_backend.InboxBackend._request()` directly, using registry metadata from `tools_registry.py`.
+
+## Stale Assumptions And Risks
+
+1. README runtime requirement is stale. `README.md:31-34` says Python 3.10+, but `pyproject.toml:1-5` requires `>=3.12,<3.15`.
+
+2. The README architecture list is incomplete. It lists `services.py`, `inbox_server.py`, `inbox_client.py`, `inbox.py`, `contacts.py`, `ambient_notes.py`, and `ambient_daemon.py` (`README.md:132-142`), but omits current architecture-critical modules: `message_index_store.py`, `message_sync.py`, `thread_classifier.py`, `gmail_triage.py`, `google_account_resolution.py`, `scheduler.py`, `memory_store.py`, `mcp_backend.py`, and `tools_registry.py`.
+
+3. "Thin HTTP clients" is only partly true. `inbox_client.py` and `mcp_backend.py` are transport clients, but `inbox.py` is a 4,279-line UI/control-plane module with server boot, error recovery, polling, notifications, indexed-view state, compose flows, Gmail actions, Drive actions, account auth actions, and AI actions (`inbox.py:2082-2360`, `inbox.py:2771-4277`).
+
+4. `services.py` has too many ownership domains. Provider IO, OAuth, OS scripting, local DB reads, cloud writes, ML loading, Gemini, maps, search, notifications, and favorites all live in one 6,467-line module. Any extraction should avoid a rewrite and start from pure helpers or one provider at a time.
+
+5. `inbox_server.py` has route sprawl and hidden global state coupling. It has 160 route decorators and a mutable global `state`. `create_app()` copies already-registered routes into a new app for tests (`inbox_server.py:1288-1310`), which is pragmatic but makes import order and app construction semantics important.
+
+6. Several routes depend on `state.conv_cache` for correctness. `/messages/{source}/{conv_id}` picks the Gmail service from cached conversation metadata and falls back to the first/default Gmail service when missing (`inbox_server.py:1413-1427`). `/messages/send` refuses to send unless `/conversations` populated the cache first (`inbox_server.py:1434-1450`). That is an architectural coupling between read navigation and write routing.
+
+7. Account ownership vocabulary is inconsistent. `Contact` has `gmail_account` (`service_models.py:11-25`), Google Drive/Sheets/Docs dataclasses have `account` (`service_models.py:102-139`), and `ThreadSummary` has `owning_account` (`service_models.py:142-153`). `CONNECTOR_ROADMAP.md` wants `owning_account` everywhere. Future agents should normalize with compatibility shims rather than renaming fields in one sweep.
+
+8. REST writes rely on server auth and test-mode guards, while MCP writes add confirm gates. `tools_registry.py` confirm-gates mutating MCP tools (`tools_registry.py:52-78`), and `services.py` has `_assert_live_write_allowed()` for test mode (`services.py:114-120`), but REST endpoints such as `/messages/send`, `/calendar/events`, `/drive/upload`, `/sheets`, and `/docs` execute writes once authorized. This is acceptable for a local app but risky if deployment files expose it beyond localhost.
+
+9. Optional token auth means "safe by default" depends on deployment context. If `INBOX_SERVER_TOKEN` is unset, `_is_authorized()` returns true (`inbox_server.py:1317-1329`). The server binds to `127.0.0.1` in `__main__`, but deploy examples and Caddy/system service files should be reviewed before any remote exposure.
+
+10. Validation claims are likely stale. `DOCS_INDEX.md` claims "Tests (736 pass)" and "All 736 tests pass", but the current test suite has many more test/class definitions by `rg -c 'def test_|class Test' tests/*.py`, and I did not run the full suite during this read-only queue item.
+
+11. Cross-silo query support introduces an undeclared optional dependency. `/query` imports `gemma4_hackathon` dynamically and returns 503 if not installed (`inbox_server.py:3896-3932`), but this is not present in `pyproject.toml`. This endpoint is an architecture exception and should stay explicitly optional.
+
+12. Local generated state is intentionally gitignored, but it is architecturally important. `.gitignore:12-20` ignores credentials and tokens; `.gitignore:34-43` ignores logs, `.claude/`, `.inbox_memory.sqlite3`, and `.inbox_scheduler.sqlite3`; `.gitignore:56-58` ignores `.inbox_index.sqlite3`. Agents must not assume a fresh worktree has accounts, index state, scheduler state, or memory state.
+
+## Decisions For Future Work
+
+- Treat `PLAN.md` and `CONNECTOR_ROADMAP.md` as the current architecture direction. Treat `README.md` as user-facing overview that needs refresh.
+- Do not start by "cleaning up" `services.py` globally. Extract one source adapter or one pure policy boundary at a time, with route-contract tests.
+- Keep `service_models.py`, `google_account_resolution.py`, `message_index_store.py`, and `tools_registry.py` small and explicit. These are the current leverage points for making the repo more navigable.
+- Preserve old response fields while adding normalized fields. The product has both human TUI and agent/MCP clients, so field renames need compatibility periods.
+- Prefer indexed views for "what needs attention"; use raw provider reads only for drill-down and explicit refresh.
+
+## Validation Map
+
+Required validation for this queue item:
+
+- `git status --short`
+- Actual result after writing this report: command exited 0 and printed `?? docs/overnight/`.
+- Local docs-only commit was attempted after validation, but `git add docs/overnight/inbox-sym-118-architecture-map.md` failed because the sandbox could not create the linked worktree Git index lock under `/Users/jwalinshah/projects/inbox/.git/worktrees/inbox-sym-118-architecture-map/index.lock`.
+- Expected status if a human or runner stages/commits from an unrestricted shell: pass with no output.
+
+Agent-safe validation candidates from local docs:
+
+- `INBOX_TEST_MODE=1 uv run pytest tests/test_inbox_test_mode.py -q`
+  - Expected: pass.
+  - Evidence: documented as the smallest focused safe test in `docs/TESTING_FOR_AGENTS.md:15-19`.
+  - Not run during this audit because the queue validation command is `git status --short`.
+
+- `INBOX_TEST_MODE=1 uv run pytest -m safe`
+  - Expected: pass if current branch health matches docs.
+  - Evidence: default safe loop in `docs/TESTING_FOR_AGENTS.md:5-13`; safe marker registered in `pyproject.toml:53-62`.
+  - Not run during this audit.
+
+- `uv run ruff check .`
+  - Expected: pass on a healthy branch.
+  - Evidence: documented in `docs/TESTING_FOR_AGENTS.md:9-13`; ruff config in `pyproject.toml:40-46`.
+  - Not run during this audit.
+
+- `uv run pyright`
+  - Expected: pass on a healthy branch, but sensitive to local environment and installed dependencies.
+  - Evidence: documented in `docs/TESTING_FOR_AGENTS.md:9-13`; pyright config in `pyproject.toml:48-51`.
+  - Not run during this audit.
+
+Architecture-change validation candidates:
+
+- For route extraction: `INBOX_TEST_MODE=1 uv run pytest tests/test_api_contract.py tests/test_server.py::TestHealth -q`
+  - Expected: pass if route path/method contracts and app construction are preserved.
+
+- For MCP registry changes: `INBOX_TEST_MODE=1 uv run pytest tests/test_tools_registry.py tests/test_mcp_gateway.py -q`
+  - Expected: pass if registry signatures, readonly filtering, confirm gates, and gateway auth still match.
+
+- For account-routing changes: `INBOX_TEST_MODE=1 uv run pytest tests/test_gmail_actions.py tests/test_api_contract.py -q`
+  - Expected: pass if Gmail reply ownership and API contracts are preserved.
+
+- For index changes: `INBOX_TEST_MODE=1 uv run pytest tests/test_message_index_store.py tests/test_message_sync.py tests/test_thread_classifier.py -q`
+  - Expected: pass if schema, sync checkpoints, thread rebuild, and classification behavior stay compatible.
+
+## Next Safe Work
+
+### Task 1: Refresh Architecture Docs To Match Current Runtime
+
+Acceptance criteria:
+
+- Update `README.md` architecture block to include the operational index, account routing, scheduler, MCP registry, and current Python requirement.
+- Add a short "Current Architecture" section that distinguishes raw sources, operational index, API, TUI, and MCP.
+- Do not claim full test counts unless generated during the change.
+
+Suggested validation:
+
+- `git diff -- README.md DOCS_INDEX.md`
+- `uv run ruff check .` if only Markdown links are unchanged, this may be optional.
+
+Files likely owned:
+
+- `README.md`
+- `DOCS_INDEX.md`
+
+### Task 2: Route Surface Inventory And Router Extraction Plan
+
+Acceptance criteria:
+
+- Produce a route inventory grouped by source area: health/auth, conversations, Gmail, calendar, reminders/tasks, scheduler, Drive/Sheets/Docs, index, AI/audio, contacts, MCP-adjacent.
+- Identify one first router extraction that preserves all path/method pairs.
+- If code is changed, route-contract tests must prove `create_app()` exposes the same paths before and after extraction.
+
+Suggested validation:
+
+- `INBOX_TEST_MODE=1 uv run pytest tests/test_api_contract.py tests/test_server.py::TestHealth -q`
+- `python - <<'PY'` route inventory script, if a future worker adds one as a checked-in helper or one-off local command.
+
+Files likely owned:
+
+- `inbox_server.py`
+- possibly a new `api/` package if implementation follows the plan
+- `tests/test_api_contract.py`
+
+### Task 3: Cache-Free Gmail Routing Work Pack
+
+Acceptance criteria:
+
+- Document or implement a path where Gmail message fetch/reply routing does not require a previous `/conversations` call.
+- Preserve current cached fast path but use `google_account_resolution.get_gmail_service_for_message()` for cache misses.
+- Add tests for message/thread lookup across two fake Gmail accounts.
+
+Suggested validation:
+
+- `INBOX_TEST_MODE=1 uv run pytest tests/test_gmail_actions.py tests/test_server.py::TestMessages -q`
+
+Files likely owned:
+
+- `inbox_server.py`
+- `google_account_resolution.py`
+- `tests/test_gmail_actions.py`
+- `tests/test_server.py`
+
+### Task 4: Normalize Account Ownership Fields With Compatibility
+
+Acceptance criteria:
+
+- Define a repository-wide rule for `account` vs `gmail_account` vs `owning_account`.
+- Add `owning_account` to Google response models where missing while retaining existing fields for compatibility.
+- Update tests to assert both old and normalized fields during the transition.
+
+Suggested validation:
+
+- `INBOX_TEST_MODE=1 uv run pytest tests/test_api_contract.py tests/test_drive.py tests/test_gmail_actions.py -q`
+
+Files likely owned:
+
+- `service_models.py`
+- `inbox_server.py`
+- `gmail_triage.py`
+- focused tests around API output shapes
+
+### Task 5: Provider Boundary Extraction For One Low-Risk Source
+
+Acceptance criteria:
+
+- Choose one small provider boundary, likely GitHub or Drive metadata, and move only cohesive functions out of `services.py`.
+- Keep public function names re-exported or update imports in one narrow pass.
+- Prove no endpoint behavior changes with focused tests.
+
+Suggested validation:
+
+- For GitHub: `INBOX_TEST_MODE=1 uv run pytest tests/test_github.py tests/test_server.py::TestGitHub -q`
+- For Drive: `INBOX_TEST_MODE=1 uv run pytest tests/test_drive.py tests/test_server_endpoints.py::TestDriveEndpoints -q`
+
+Files likely owned:
+
+- `services.py`
+- new provider module if introduced
+- matching focused tests
+
+## Non-Goals
+
+- No product code edits in this queue item.
+- No credential, token, local data, deploy, external service, or generated data mutation.
+- No live Gmail, Calendar, Drive, Docs, Sheets, Tasks, Reminders, iMessage, WhatsApp, GitHub, Gemini, Maps, microphone, or notification calls.
+- No Linear/GitHub tracker updates.
+- No PR creation or push.
+- No attempt to run broad live integration tests.
+
+## Unknowns
+
+- Which Google account is actually intended for default writes in this worktree depends on local `INBOX_DEFAULT_GOOGLE_ACCOUNT` and available token files; neither was inspected beyond code/docs.
+- Whether the primary daily-driver server on port 9849 is running was not tested, because this audit did not need live personal data access.
+- Current full-suite health is unknown; only command candidates were mapped.
+- The `.factory/` validation history appears to contain useful historical review evidence, but this audit did not verify whether those generated validation artifacts are authoritative for the current branch.
+- Whether external `gemma4_hackathon` is installed locally is unknown and not needed for this queue item.

--- a/docs/overnight/inbox-sym-118-dependency-surface.md
+++ b/docs/overnight/inbox-sym-118-dependency-surface.md
@@ -1,0 +1,227 @@
+# inbox-sym-118 dependency-surface audit
+
+Queue item: `inbox-sym-118-dependency-surface`
+Branch: `codex/goal-inbox-sym-118-dependency-surface`
+Audit date: 2026-05-07
+Focus area: dependencies, scripts, environment variables, generated artifacts, caches, and local-only state.
+
+## Summary
+
+`inbox-sym-118` is a local-first Python inbox/TUI project with a large integration surface: FastAPI server, Textual TUI, MCP HTTP/stdio gateways, Google OAuth integrations, macOS SQLite data readers, AppleScript/Quartz write paths, local ML/audio, local SQLite stores, and deployment templates for launchd/systemd/Caddy. The dependency surface is not just `pyproject.toml`; successful operation also depends on macOS permissions, local token files, per-checkout generated SQLite databases, port routing, and several path-pinned helper scripts.
+
+The repo was clean before writing this report. No ignored local credential/state files were present in this isolated worktree during the audit, but `.gitignore` shows many are expected in a real checkout.
+
+## Repo State
+
+- Purpose: README describes a privacy-first terminal UI for iMessage, Gmail, Calendar, Sheets, Notes, Reminders, GitHub, Drive, ambient audio, dictation, and local ML. Evidence: `README.md`, `CLAUDE.md`, `services.py`, `inbox_server.py`, `inbox.py`, `mcp_server.py`.
+- Current branch: `codex/goal-inbox-sym-118-dependency-surface`.
+- Starting HEAD: `2805b8400519da188ca7d3f6e39b19a8ca42b05a`.
+- Starting dirty state: `git status --short --branch` printed only `## codex/goal-inbox-sym-118-dependency-surface`; `git status --porcelain=v1` printed nothing.
+- Remote: `origin https://github.com/jwalin-shah/inbox.git`.
+- Upstream: `git rev-parse --abbrev-ref --symbolic-full-name @{u}` printed nothing, so this branch has no configured upstream.
+- Recent HEAD observation: `git log --oneline --decorate -5` shows HEAD at merge commit `2805b84` from `origin/main` and many goal branches pointing at the same commit.
+
+## Commands Run
+
+- `llm-tldr tree .` to map visible top-level structure.
+- `git status --short --branch` and `git status --porcelain=v1` for dirty state.
+- `git rev-parse --show-toplevel`, `git rev-parse --abbrev-ref HEAD`, and `git rev-parse HEAD` for repo/branch/commit identity.
+- `rtk read pyproject.toml`, `README.md`, `CLAUDE.md`, `docs/TESTING_FOR_AGENTS.md`, `.gitignore`, config examples, scripts, deploy examples, and selected code files.
+- `llm-tldr search "os.environ|os.getenv|environ.get|getenv|dotenv|INBOX_|TOKEN|credentials.json|token.json|tokens/|github_token|gemini_api_key|google_maps_key|sqlite|.sqlite|Path.home|expanduser|Library/|vault|UV_CACHE_DIR" .` for env/local-state discovery.
+- `rg -n "os\.environ|os\.getenv|environ\.get|getenv|load_dotenv|INBOX_|TOKEN|credentials\.json|token\.json|tokens/|github_token|gemini_api_key|google_maps_key|\.sqlite|Path\.home|expanduser|Library/|vault|UV_CACHE_DIR" -g '!uv.lock' -g '!docs/overnight/**' .` for exact code/doc hits.
+- `rg --files -uu -g '!.git/**'` showed 197 files visible including hidden tracked `.factory`, `.cursor`, `.mcp.json`, `.env.mcp.example`, `.pre-commit-config.yaml`, `.python-version`, and `.tldrignore`.
+- `git ls-files --others --ignored --exclude-standard | sed 's#/.*##' | sort | uniq -c` printed no ignored local files in this worktree.
+- `wc -l uv.lock pyproject.toml` found `uv.lock` at 2847 lines and `pyproject.toml` at 66 lines.
+- `rg '^name = ' uv.lock | ...` found 148 locked package names.
+- `rg -o "INBOX_[A-Z0-9_]+|GOOGLE_[A-Z0-9_]+|GEMINI_[A-Z0-9_]+|UV_CACHE_DIR" ...` found the env var inventory listed below.
+- `rg -n "Tool\(" tools_registry.py | wc -l` found 60 registered MCP tool definitions.
+- `rg -n "pytestmark = pytest.mark.safe|@pytest.mark.safe" tests -g '*.py'` found only two safe-marked test modules.
+- `du -sh . .factory uv.lock tests scripts config deploy docs` found the repo at 2.4M, `.factory` at 424K, `uv.lock` at 432K, and tests at 568K.
+
+## Package Surface
+
+Primary package metadata is in `pyproject.toml`:
+
+- Python: `requires-python = ">=3.12,<3.15"` in `pyproject.toml`; `.python-version` pins `3.12`; `uv.lock` repeats `requires-python = ">=3.12, <3.15"` and has resolution markers for Python 3.12, 3.13, and 3.14.
+- Runtime dependencies: FastAPI, Google API/OAuth/Gemini clients, httpx, loguru, `mcp[cli]`, MLX LLM/Whisper, numpy, outlines, pydantic, PyObjC ApplicationServices/Quartz, python-multipart, rich, sounddevice, Textual, uvicorn.
+- Dev dependencies: bandit, hypothesis, pre-commit, pyright, pytest, pytest-cov, python-dotenv, ruff.
+- Tool configs: Ruff targets `py312`; Pyright targets Python 3.12 with basic checking; pytest default addopts include coverage; Bandit excludes `.venv` and `tests` and skips several subprocess/assert-related checks.
+- Lockfile: `uv.lock` has 148 package names, all observed package sources are PyPI registry entries, and the lock includes heavy transitive packages from ML/Outlines/Torch, including CUDA/NVIDIA/Triton packages marked for Linux and MLX/Metal packages marked for Darwin.
+
+Stale assumption: `README.md` says requirements are Python 3.10+, but `pyproject.toml`, `.python-version`, and actual generic function syntax in `services.py` require Python 3.12.
+
+## Runtime Dependency Clusters
+
+- Server/API: `inbox_server.py` imports FastAPI, Pydantic, loguru, and wraps `services.py`; it binds to `127.0.0.1` and `INBOX_SERVER_PORT` with default port 9849.
+- TUI/client: `inbox.py` imports Textual/Rich/httpx and uses `InboxClient`; `inbox_client.py` can auto-start `inbox_server.py` through `subprocess.Popen`.
+- MCP: `mcp_server.py`, `inbox_mcp_stdio.py`, `inbox_mcp_readonly.py`, `inbox_mcp_readonly_stdio.py`, `mcp_gateway.py`, `mcp_backend.py`, and `tools_registry.py` provide HTTP and stdio MCP entrypoints.
+- Google APIs: `services.py` declares broad `GOOGLE_SCOPES` for Gmail read/modify/send/settings, Calendar, Drive, Sheets, Docs, and Tasks. Tokens are per-account JSON files under `tokens/`.
+- macOS local data: `services.py` and `contacts.py` read iMessage, Notes, Reminders, and AddressBook SQLite files under `~/Library/...`.
+- macOS write paths: `services.py` uses AppleScript for iMessage, Notes, Reminders, and notifications; Quartz CGEvent for WhatsApp/dictation keyboard injection; `open -a WhatsApp`; and CoreLocation for location fallback.
+- ML/audio: `services.py` uses MLX model ids, `mlx_lm`, `mlx_whisper`, `sounddevice`, and a hardcoded `/opt/homebrew/bin/whisper-stream` dictation binary.
+- Local persistent stores: `memory_store.py`, `message_index_store.py`, and `scheduler.py` create repo-local SQLite files by default.
+
+## Environment Variables
+
+Observed env vars from code, docs, config examples, and scripts:
+
+- `INBOX_SERVER_URL`: client/MCP backend URL, defaulting to localhost port 9849.
+- `INBOX_SERVER_PORT`: server/client port selection, default 9849; `dev.sh` defaults this to 9850.
+- `INBOX_SERVER_TOKEN`: optional private backend bearer token. If unset, server auth allows requests.
+- `INBOX_MCP_TOKEN`: optional public MCP gateway bearer token. If unset, MCP gateway allows non-health requests.
+- `INBOX_MCP_READONLY_PORT`: read-only MCP HTTP port, default 8001.
+- `INBOX_MEMORY_DB`: optional MCP memory-store SQLite path override.
+- `INBOX_TEST_MODE`: blocks representative live writes and redirects some local data paths.
+- `INBOX_TEST_DATA_DIR`: test-local token, SQLite, and config root.
+- `INBOX_TEST_NOW`: date/time override used by tests.
+- `INBOX_DEFAULT_GOOGLE_ACCOUNT`: write-routing hint for Google account selection.
+- `INBOX_PRE_WARM_CONVERSATIONS`: startup cache warmup flag.
+- `INBOX_DISABLE_AMBIENT`: disables ambient autostart.
+- `INBOX_HOME_ADDRESS`: fallback origin for location/departure calculations.
+- `INBOX_LLM_LARGE`: large MLX model id override.
+- `INBOX_POLL_INTERVAL`: TUI polling interval.
+- `GOOGLE_CLOUD_API_KEY` and `GOOGLE_MAPS_API_KEY`: Maps/cloud API key fallbacks.
+- `GEMINI_API_KEY`: Gemini fallback/specific-task API key.
+- `UV_CACHE_DIR`: wrapper scripts default this to `/tmp/uv-cache`.
+
+## Local Files, State, Caches, and Artifacts
+
+Tracked examples and ignore rules show the intended local-only state:
+
+- Secrets/tokens ignored by `.gitignore`: `credentials.json`, `token.json`, `token.json.lock`, `tokens/`, `github_token.txt`, `google_maps_key.txt`, `gemini_api_key.txt`, `config/inbox.env`, `.env`, `.env.local`, `.envrc`, `*.key`, `*.secret`.
+- Repo-local SQLite ignored by `.gitignore`: `.inbox_memory.sqlite3`, `.inbox_scheduler.sqlite3`, `.inbox_index.sqlite3`.
+- User config/state outside repo: `~/.config/inbox/notifications.json`, `~/.config/inbox/favorites.json`, `~/.config/inbox/voice.json`, `~/vault/daily`, and `~/vault/ambient`.
+- Local personal data read surfaces: `~/Library/Messages/chat.db`, `~/Library/Group Containers/group.com.apple.notes/NoteStore.sqlite`, `~/Library/Group Containers/group.com.apple.reminders/Container_v1/Stores/Data-*.sqlite`, and `~/Library/Application Support/AddressBook/...`.
+- Generated/test/cache ignores: `__pycache__/`, `.coverage`, `htmlcov/`, `.tldr/`, `.claude/`, `batch/triage-output.tsv`, `batch/archive-state.tsv`, `batch/logs/`, `batch/.batch-state.lock`, `CLAUDE.md.new`.
+- Tracked generated/planning artifacts: `.factory` is tracked and contains 85 files, including validation synthesis JSON files. This is repo context, not local cache.
+- Current isolated worktree observation: no ignored files were present according to `git ls-files --others --ignored --exclude-standard`.
+
+## Entrypoints and Scripts
+
+- `README.md` and `CLAUDE.md`: `uv run python inbox.py` starts server plus TUI; `uv run python inbox_server.py` starts server only.
+- `dev.sh`: sets `INBOX_SERVER_PORT=9850` and derives `INBOX_SERVER_URL` unless overridden, then runs `uv run python "${1:-inbox.py}"`.
+- `scripts/run_inbox_backend.sh`: sets `UV_CACHE_DIR=/tmp/uv-cache` if unset and runs `uv run python inbox_server.py`.
+- `scripts/run_inbox_mcp_http.sh`: runs `uv run python mcp_server.py`.
+- `scripts/run_inbox_mcp_http_readonly.sh`: runs `uv run python inbox_mcp_readonly.py`.
+- `scripts/run_inbox_mcp_stdio.sh`: runs `uv run python inbox_mcp_stdio.py`.
+- `scripts/run_inbox_mcp_stdio_readonly.sh`: runs `uv run python inbox_mcp_readonly_stdio.py`.
+- `scripts/setup_inbox_mcp.sh`: copies `config/inbox.env.example` to `config/inbox.env`, chmods it 600, installs launchd plists to `~/Library/LaunchAgents`, and loads backend/full/read-only services.
+- `deploy/*.plist.example` and `deploy/*.service.example`: path-pin `/Users/jwalinshah/projects/inbox`, use `config/inbox.env`, and write logs to `/tmp`.
+- `.factory/init.sh` and `.factory/services.yaml`: also path-pin `/Users/jwalinshah/projects/inbox`; `.factory/init.sh` can kill anything listening on port 9849.
+- `batch/batch-runner.sh`: defaults to live archive mode, writes ignored state/logs, and calls `/gmail/batch-modify`.
+- `unsubscribe_*.py` scripts call the live localhost server and can unsubscribe/archive Gmail after prompts or batches.
+- `oci_retry.sh`: launches an OCI compute instance in a loop using hardcoded OCIDs, hardcoded SSH key path, and log path under `/Users/jwalinshah/projects/inbox/oci_retry.log`.
+
+## Concrete Risks and Stale Assumptions
+
+1. Python version claim is stale. `README.md` says Python 3.10+, while `pyproject.toml`, `.python-version`, `uv.lock`, and syntax in `services.py` require Python 3.12. A user following README on 3.10 will fail before app behavior is tested.
+
+2. Some direct runtime imports rely on transitive or undeclared optional packages. `services.py` imports `requests` inside unsubscribe logic while `requests` is not a direct dependency in `pyproject.toml`; `mcp_gateway.py` imports Starlette directly while Starlette is transitive through FastAPI/MCP; `services.py` dynamically imports `CoreLocation`, `objc`, and `UserNotifications` but only ApplicationServices/Quartz PyObjC packages are directly declared. Optional fallback behavior hides this until a feature path runs.
+
+3. Auth defaults are permissive. `inbox_server.py` permits all requests when `INBOX_SERVER_TOKEN` is unset; `mcp_gateway.py` permits all non-health MCP routes when `INBOX_MCP_TOKEN` is unset. This is fine for private localhost, but dangerous if Caddy or service templates are copied without token setup.
+
+4. Google scope surface is very broad. `GOOGLE_SCOPES` includes Gmail modify/send/settings, full Calendar, Drive, Sheets, Docs, and Tasks. Tokens are local per-checkout files; copying tokens between primary and dev worktrees is documented, but that raises account-routing and accidental-write risk.
+
+5. Service and factory templates path-pin the primary checkout. launchd/systemd examples and `.factory` commands use `/Users/jwalinshah/projects/inbox`, while the current work happens in an isolated worktree. Running those templates from a worktree can hit the daily-driver checkout or kill the primary port 9849 service.
+
+6. The read-only MCP daily-note tool appears broken and untested. `inbox_mcp_readonly.py` refers to `ambient_notes.VAULT_DIR`, but `ambient_notes.py` defines `VAULT_PATH`, `DAILY_DIR`, and `AMBIENT_DIR`; `rg` found no direct test for this read-only tool path.
+
+7. The documented safe test command has narrow coverage. `docs/TESTING_FOR_AGENTS.md` recommends `INBOX_TEST_MODE=1 uv run pytest -m safe`, but only `tests/test_inbox_test_mode.py` and `tests/test_mcp_gateway.py` are safe-marked. Most deterministic tests are unmarked and will be skipped by that command.
+
+8. Local ML/audio is both large and platform-sensitive. `uv.lock` includes MLX, MLX Metal, Torch/Transformers/Outlines transitive packages, plus Linux CUDA/NVIDIA/Triton packages behind markers. Runtime also depends on microphone access, Accessibility permissions, and `/opt/homebrew/bin/whisper-stream`, none of which are proven by dependency install alone.
+
+9. Live helper scripts are easy to run against real data. `batch/batch-runner.sh` defaults to non-dry-run archive processing once input exists; `unsubscribe_all_newsletters.py` and related tools call live server endpoints; `organize-inbox-helper.sh` can start the primary port 9849 server and then modify Gmail labels.
+
+10. `oci_retry.sh` is a destructive/external compute surface in the repo. It is not part of inbox runtime, contains cloud resource identifiers and a personal SSH key path, writes outside the worktree, and would launch a VM if run in an authenticated environment.
+
+## Validation Map Notes
+
+Required queue validation:
+
+- `git status --short`
+- Expected final status if the report is committed: command exits 0 and prints nothing.
+- Expected status before commit: command exits 0 and shows only the new report path.
+
+Useful dependency-surface validation candidates:
+
+- `uv lock --check`
+  - Expected: pass if `pyproject.toml` and `uv.lock` are synchronized.
+  - Risk: may depend on current `uv` behavior/version, but should not touch live personal data.
+
+- `INBOX_TEST_MODE=1 uv run pytest tests/test_inbox_test_mode.py -q`
+  - Expected: pass; proves test-mode data redirection and live-write guard.
+  - Risk: may create temp test data only.
+
+- `INBOX_TEST_MODE=1 uv run pytest -m safe -q`
+  - Expected: pass, but currently covers only two safe-marked modules.
+  - Risk: low; coverage is narrower than docs imply.
+
+- `uv run ruff check .`
+  - Expected: should pass for a clean implementation branch.
+  - Risk: purely static, but may flag existing style in generated/planning files if scope is not configured.
+
+- `uv run pyright`
+  - Expected: should pass or expose missing imports from optional/transitive packages.
+  - Risk: higher signal for dependency surface, but may be noisy due dynamic APIs and mocks.
+
+- `bash -n dev.sh scripts/*.sh batch/batch-runner.sh organize-inbox-helper.sh oci_retry.sh`
+  - Expected: pass syntax checks without running live operations.
+  - Risk: only shell syntax, not safety.
+
+- `INBOX_TEST_MODE=1 uv run pytest tests/test_mcp_gateway.py -q`
+  - Expected: pass; validates MCP auth defaults and memory DB override behavior.
+  - Risk: low; uses local test client and temp DB.
+
+## Next Safe Work
+
+1. Align Python/runtime dependency claims.
+   - Acceptance criteria: `README.md`, `CLAUDE.md`, `.python-version`, `pyproject.toml`, and `uv.lock` all agree on Python 3.12+; README no longer says Python 3.10+; direct feature requirements mention macOS-only surfaces.
+   - Validation: `uv lock --check`; `INBOX_TEST_MODE=1 uv run pytest tests/test_inbox_test_mode.py -q`.
+
+2. Create a dependency/environment manifest.
+   - Acceptance criteria: add a docs page listing required Python deps, optional feature deps, env vars, local files, macOS permissions, external CLIs/binaries, and live-write commands; link it from `DOCS_INDEX.md` or README.
+   - Validation: `uv run ruff check .`; `bash -n dev.sh scripts/*.sh batch/batch-runner.sh organize-inbox-helper.sh oci_retry.sh`.
+
+3. Make optional/direct dependencies explicit.
+   - Acceptance criteria: either declare direct imports (`requests`, Starlette if intentionally direct, relevant PyObjC framework packages) or refactor to avoid relying on transitive packages; document `whisper-stream` as an external binary rather than a Python dependency.
+   - Validation: `uv lock --check`; `uv run pyright`; focused tests for unsubscribe, MCP gateway, notification, and location fallback paths.
+
+4. Harden worktree-safe service templates.
+   - Acceptance criteria: deploy examples and `.factory` commands avoid hardcoded primary checkout paths or clearly mark them primary-only; worktree examples require explicit `INBOX_SERVER_PORT` and `INBOX_SERVER_URL`; no template kills port 9849 without an explicit primary-service action.
+   - Validation: `bash -n scripts/*.sh dev.sh`; manual review of `deploy/*.example`, `.factory/init.sh`, `.factory/services.yaml`.
+
+5. Expand safe test markers.
+   - Acceptance criteria: deterministic tests that use mocks/temp DBs are marked `safe`; `INBOX_TEST_MODE=1 uv run pytest -m safe -q` covers more than just test-mode and MCP gateway smoke tests; docs state what remains excluded.
+   - Validation: `INBOX_TEST_MODE=1 uv run pytest -m safe -q`; `rg -n "pytestmark = pytest.mark.safe|@pytest.mark.safe" tests -g '*.py'`.
+
+6. Fix and test read-only MCP daily-note path.
+   - Acceptance criteria: `inbox_mcp_readonly.py` uses existing `ambient_notes` path constants or public helpers; date-specific daily note reads work; a safe unit test covers missing and present notes.
+   - Validation: `INBOX_TEST_MODE=1 uv run pytest tests/test_mcp_gateway.py tests/test_ambient_notes.py -q` plus a new focused read-only MCP test.
+
+7. Decide whether `oci_retry.sh` belongs in this repo.
+   - Acceptance criteria: either remove/move it to a private ops location, or gate it behind explicit docs and safe defaults; no hardcoded tenancy/subnet/image IDs or personal SSH key path remain in the inbox product repo.
+   - Validation: `git grep -n "ocid1\\|oci compute instance launch\\|/Users/jwalinshah/.ssh"`.
+
+## Non-Goals
+
+- No product code was changed for this audit.
+- No secrets, tokens, local SQLite databases, or user data files were opened.
+- No tests, servers, MCP services, deploys, OAuth flows, external APIs, cloud jobs, or live-write helper scripts were run.
+- No external tracker state was changed.
+- No PR was created or merged.
+
+## Handoff Notes
+
+- Changed file: `docs/overnight/inbox-sym-118-dependency-surface.md`.
+- Required validation run after report creation: `git status --short` exited 0 and printed `?? docs/overnight/`.
+- Commit status: attempted to stage the report with `git add docs/overnight/inbox-sym-118-dependency-surface.md`, but Git could not create `/Users/jwalinshah/projects/inbox/.git/worktrees/inbox-sym-118-dependency-surface/index.lock` due sandbox write permissions. The worktree content is inside the writable root, but the linked Git metadata is outside it.
+- Commit SHA: no new commit was created. Current HEAD remains `2805b8400519da188ca7d3f6e39b19a8ca42b05a`.
+- PR URL: none created.
+
+## Unknowns
+
+- Whether the primary checkout currently has real `tokens/`, `credentials.json`, `github_token.txt`, or local SQLite stores; this worktree had none.
+- Whether the installed local machine has `/opt/homebrew/bin/whisper-stream`, MLX models cached, microphone permission, Accessibility permission, Full Disk Access, and Location Services permission.
+- Whether launchd/systemd/Caddy templates are actually used in production or are historical examples.
+- Whether `.factory` is an active workflow contract or historical generated context.
+- Whether the broad Google OAuth scope set is intentional for all accounts or should be split by feature.

--- a/docs/overnight/inbox-sym-118-risk-register.md
+++ b/docs/overnight/inbox-sym-118-risk-register.md
@@ -1,0 +1,562 @@
+# inbox-sym-118 risk register audit
+
+Queue item: `inbox-sym-118-risk-register`
+Repo: `inbox-sym-118`
+Worktree: `/Users/jwalinshah/projects/agent-stack/.agent-stack-worktrees/2026-05-07-overnight-marathon/inbox-sym-118-risk-register`
+Branch: `codex/goal-inbox-sym-118-risk-register`
+Base HEAD before this report: `2805b8400519da188ca7d3f6e39b19a8ca42b05a`
+Audit date: 2026-05-07
+
+## Scope and method
+
+This was a read-only risk-register audit. I did not call live Inbox, Gmail,
+Calendar, Drive, GitHub, WhatsApp, macOS automation, cloud deployment, or MCP
+services. The only write intended by this queue item is this report.
+
+Evidence came from compact structure/search commands plus targeted file reads.
+One validation-discovery probe attempted to build the test environment with
+`uv`; it failed before tests ran because this sandbox has no network access. The
+temporary `.venv` created by that probe was removed.
+
+## Repo purpose and current state
+
+`README.md` describes Inbox as a privacy-first terminal UI that consolidates
+iMessage, Gmail, Google Calendar, Google Sheets, Apple Notes, Apple Reminders,
+GitHub notifications, Google Drive, ambient audio, dictation, and local ML into
+one keyboard-driven interface. The runtime is a local FastAPI backend
+(`inbox_server.py`) with thin clients (`inbox.py`, `inbox_client.py`) and MCP
+surfaces (`mcp_server.py`, `inbox_mcp_readonly.py`, `mcp_backend.py`).
+
+Observed repo state:
+
+- `pwd` returned this assigned worktree path.
+- `git status --short --branch` initially returned only
+  `## codex/goal-inbox-sym-118-risk-register`; no pre-existing dirty state was
+  observed.
+- `git log --oneline -5` showed HEAD at merge commit `2805b84` with recent
+  indexed inbox/default sync work.
+- `llm-tldr tree .` showed the important risk surfaces: `config/`, `deploy/`,
+  `scripts/`, `batch/`, `tests/`, `inbox_server.py`, `services.py`,
+  `tools_registry.py`, MCP entrypoints, local stores, and unsubscribe utilities.
+- `docs/` initially contained only `docs/TESTING_FOR_AGENTS.md`; this report
+  creates `docs/overnight/`.
+
+## Local evidence inventory
+
+These are the highest-signal local observations used for the register.
+
+- `README.md:48-83` documents many REST write endpoints, including message send,
+  Gmail unsubscribe, calendar create/update/delete, reminder completion, GitHub
+  notification mutation, Sheets writes, and Drive delete.
+- `README.md:146-156` says auth is optional through `INBOX_SERVER_TOKEN`, and
+  `README.md:158-164` names local credential files: `credentials.json`,
+  `tokens/`, and `github_token.txt`.
+- `inbox_server.py:1313-1340` implements optional API-token auth; if
+  `INBOX_SERVER_TOKEN` is unset, `_is_authorized` returns true for every
+  request.
+- `inbox_server.py:1346-1357` returns health metadata including configured
+  Gmail, calendar, Drive, and Sheets accounts plus GitHub-token presence.
+- `mcp_gateway.py:48-58` explicitly lets `/health` bypass public MCP auth, while
+  `mcp_gateway.py:67-79` includes backend health, memory DB path, and auth
+  status in the health payload.
+- `deploy/Caddyfile.example:4-11` and `deploy/Caddyfile.example:21-28` expose
+  `/health` and `/mcp` for full and read-only MCP hostnames.
+- `tools_registry.py:110-119` filters read-only MCP registration by
+  `tool.readonly`, and `tools_registry.py:73-79` enforces MCP `confirm=True` for
+  registry tools marked confirm-gated.
+- `tools_registry.py:41-42`, `tools_registry.py:126-851`, and
+  `tests/test_tools_registry.py:41-53` show that registry-exposed mutating MCP
+  tools are expected to be confirmation-gated and excluded from read-only MCP.
+- `inbox_mcp_readonly.py:44-50` still exposes `read_daily_note`; it reads from
+  the local Obsidian vault path computed in `ambient_notes.py`.
+- `services.py:88-98` requests broad Google OAuth scopes: Gmail read/modify/send
+  and settings, Calendar, Drive, Sheets, Docs, and Tasks.
+- `.gitignore:12-20` ignores credential/token files, and `.gitignore:40-48`
+  ignores local memory, scheduler, index, and batch state files.
+- `git ls-files | rg ...` found only `config/inbox.env.example` and
+  `oci_retry.sh` tracked among the searched credential/cloud-state patterns.
+- `services.py:198-212` writes token payloads through a lock/temp-file/replace
+  helper, but the helper does not set restrictive file permissions itself.
+- `services.py:215-232` opens Apple SQLite sources with `mode=ro`, a good
+  mitigation for iMessage/Notes/AddressBook-style reads.
+- `services.py:114-120` defines the test-mode live-write guard, and
+  `rg -n "_assert_live_write_allowed" services.py` found 43 guarded call sites.
+- `docs/TESTING_FOR_AGENTS.md:8-18` defines the safe test loop and
+  `INBOX_TEST_MODE=1`; `docs/TESTING_FOR_AGENTS.md:23-43` forbids live-write,
+  local-data, and provider-specific integration tests unless explicitly opted in.
+- `tests/test_services.py:909-951` verifies representative live-write blocking,
+  but it does not enumerate every mutating helper.
+- `rg -n "@app\\.(post|put|patch|delete)" inbox_server.py` found 95 mutating
+  HTTP routes. Many are direct REST endpoints with no per-call `confirm`
+  parameter.
+- `services.py:3864-3890` uploads files to Drive without calling
+  `_assert_live_write_allowed`.
+- `services.py:4341-4372` applies raw Sheets formatting and copies sheets
+  without a live-write guard.
+- `services.py:4476-4492` inserts text into a Google Doc without a live-write
+  guard.
+- `services.py:6236-6249` RSVPs to a calendar event without a live-write guard.
+- `inbox_server.py:3047-3060` exposes ambient start/stop, and
+  `services.py:4635-4659` records microphone audio into a transcript buffer.
+- `services.py:4702-4714` injects typed text through Quartz events, and
+  `inbox_server.py:3098-3113` exposes dictation start/stop.
+- `ambient_notes.py:14-21` writes to `~/vault/daily` and `~/vault/ambient`;
+  `ambient_notes.py:28-39` appends daily-note content.
+- `message_index_store.py:100-117` persists indexed message subject, snippet,
+  body text, labels, and raw pointers in `.inbox_index.sqlite3`.
+- `scheduler.py:70-80` persists scheduled message text and account data in
+  `.inbox_scheduler.sqlite3`.
+- `memory_store.py:50-61` persists memory subjects/content/metadata in
+  `.inbox_memory.sqlite3`.
+- `google_account_resolution.py:24-33` picks
+  `INBOX_DEFAULT_GOOGLE_ACCOUNT` when present, otherwise the first service key.
+  `config/inbox.env.example:1-9` does not document that default account env var.
+- `CONNECTOR_ROADMAP.md:32-45` and `CONNECTOR_ROADMAP.md:216-229` state that
+  Google writes should default to `jshah1331@gmail.com` and that this should be
+  enforced, not only prompt-documented.
+- `batch/batch-runner.sh:61-80` builds raw curl calls for Gmail batch-modify,
+  with auth only if `INBOX_SERVER_TOKEN` is present.
+- `unsubscribe_bulk.py:10-58`,
+  `unsubscribe_all_newsletters.py:10-164`, and
+  `unsubscribe_interactive.py:10-67` call the local REST API directly and do not
+  add `INBOX_SERVER_TOKEN` headers.
+- `oci_retry.sh:7-13` tracks concrete OCI compartment, image, subnet, SSH-key,
+  and log paths; `oci_retry.sh:16-52` loops forever launching a public-IP
+  instance until success.
+- `pyproject.toml:55-61` configures safe/integration/local-data/slow/live-write
+  pytest markers and default coverage addopts.
+- `DOCS_INDEX.md:136-140` claims "All 736 tests pass"; this was not verifiable
+  in this sandbox.
+- `pytest --collect-only -q` failed in the bare environment because
+  `pytest-cov` options from `pyproject.toml` were not available.
+- `INBOX_TEST_MODE=1 uv run pytest -m safe --collect-only -q` first failed
+  because `uv` could not access `~/.cache/uv`; with
+  `UV_CACHE_DIR=/tmp/uv-cache`, dependency installation then failed on PyPI DNS
+  for `googleapis-common-protos`.
+
+## Existing mitigations
+
+- The private server binds to loopback by default:
+  `inbox_server.py:3936-3940` runs Uvicorn on `127.0.0.1`.
+- The full MCP and read-only MCP HTTP apps also bind to loopback by default:
+  `mcp_server.py:148-151` and `inbox_mcp_readonly.py:83-87`.
+- `MCP_SETUP.md:246-260` documents the intended topology: keep
+  `inbox_server.py` private, expose MCP rather than raw REST, prefer read-only
+  MCP remotely, and keep tokens in service env.
+- `.gitignore` covers the obvious local secrets and generated sqlite state.
+- MCP registry tools use a centralized `readonly` plus `confirm` table, and the
+  read-only MCP entrypoint uses `readonly_only=True`.
+- `INBOX_TEST_MODE=1` blocks many service-level live writes.
+- Apple SQLite reads use `mode=ro`, reducing risk to local Messages/Notes style
+  databases.
+- `dev.sh:7-8` defaults worktree dev servers to port 9850, which reduces
+  primary-vs-dev collisions when agents follow the documented workflow.
+
+## Risk register
+
+### R1. Private REST auth is optional while the REST write surface is broad
+
+Severity: High.
+
+If `INBOX_SERVER_TOKEN` is unset, every local request is accepted
+(`inbox_server.py:1317-1320`). The server exposes high-impact mutations:
+message send/delete/archive, Gmail filters/labels, calendar create/update/delete,
+reminders/tasks, Drive/Docs/Sheets writes, ambient/dictation controls, account
+reauth, notification config, memory/index writes, and workflow creates. The MCP
+layer adds confirmation, but direct REST endpoints do not.
+
+Why this matters: any local process or misconfigured agent pointed at port 9849
+can mutate personal inbox state without per-action confirmation when the token is
+unset. This also weakens the "read-only remote MCP first" story if a proxy or
+client ever reaches raw REST.
+
+Current mitigations: loopback bind, optional token auth, docs recommending token
+separation, MCP confirmation gates.
+
+Gap: token absence is treated as an allowed mode rather than an explicit unsafe
+mode. There is no server-level confirmation/preflight policy for direct REST.
+
+### R2. MCP `/health` is intentionally unauthenticated and can leak sensitive metadata
+
+Severity: Medium to High.
+
+`mcp_gateway.py:48-58` bypasses auth for `/health`, and the health payload
+includes backend health, memory DB path, auth status, and extra mode payload
+(`mcp_gateway.py:67-79`). The backend health response includes configured
+account emails and GitHub-token presence (`inbox_server.py:1346-1357`). The
+Caddy example exposes `/health` for both full and read-only MCP hostnames
+(`deploy/Caddyfile.example:4-11`, `deploy/Caddyfile.example:21-28`).
+
+Why this matters: a public read-only endpoint can disclose account inventory,
+local filesystem paths, and whether GitHub is configured. That is useful for
+debugging but not necessary for unauthenticated external observers.
+
+Current mitigations: only `/health` and `/mcp` are routed by Caddy; the private
+backend remains loopback in examples.
+
+Gap: no sanitized public health mode or auth requirement for health on exposed
+MCP hostnames.
+
+### R3. Live-write test guard coverage is incomplete
+
+Severity: High for agent safety, Medium for production.
+
+The repo has a useful live-write guard (`services.py:114-120`) and tests for
+representative writes (`tests/test_services.py:909-951`). However, several
+mutating helpers do not call the guard:
+
+- `drive_upload` creates Drive files (`services.py:3864-3890`).
+- `sheets_format` and `sheets_copy_to` mutate Sheets
+  (`services.py:4341-4372`).
+- `docs_insert_text` mutates Docs (`services.py:4476-4492`).
+- `calendar_rsvp_event` patches an event (`services.py:6236-6249`).
+- Local config/favorite writers (`services.py:5476`, `services.py:5579`,
+  `services.py:6114`) mutate local user state outside the guard.
+- Scheduler and memory store methods write local state directly
+  (`scheduler.py:118-157`, `scheduler.py:229-278`,
+  `memory_store.py:72-116`, `memory_store.py:173-198`).
+
+Why this matters: `INBOX_TEST_MODE=1` is the documented safety contract for
+agents, but it does not prove all write paths are blocked. Tests can accidentally
+exercise real providers if a missing guard is combined with live credentials and
+insufficient mocking.
+
+Current mitigations: most high-profile provider writes are guarded; safe test
+docs exist; many tests use mocks.
+
+Gap: no exhaustive test or static policy mapping all mutating services/routes to
+the live-write guard.
+
+### R4. MCP confirmation is not an end-to-end write policy
+
+Severity: High.
+
+The MCP registry properly confirm-gates mutating tools
+(`tools_registry.py:73-79`, `tests/test_tools_registry.py:41-53`), but raw REST
+and utility scripts bypass MCP. `batch/batch-runner.sh:74-80` posts directly to
+`/gmail/batch-modify`; unsubscribe scripts post to unsubscribe endpoints directly
+without auth headers (`unsubscribe_bulk.py:10-58`,
+`unsubscribe_all_newsletters.py:10-164`, `unsubscribe_interactive.py:10-67`).
+
+Why this matters: a user or agent can accidentally run a helper script against
+the primary daily-driver server and perform bulk mailbox changes. Scripts do ask
+for user confirmation in some cases, but not all of them enforce server token
+use or test mode.
+
+Current mitigations: some scripts prompt interactively; batch runner has
+`--dry-run`.
+
+Gap: no shared client wrapper enforcing token presence, target server display,
+dry-run preview, or primary-vs-dev warnings for write scripts.
+
+### R5. Credential and token blast radius is large
+
+Severity: High.
+
+`services.py:88-98` asks Google OAuth for broad scopes covering Gmail modify/send
+and settings, Calendar, Drive, Sheets, Docs, and Tasks. Token files live under
+the repo directory by default (`services.py:56-67`), and GitHub, Maps, and Gemini
+keys are read from repo-root text files (`services.py:84-86`). `.gitignore`
+protects these names (`.gitignore:12-20`), and `setup_inbox_mcp.sh:17-24`
+creates `config/inbox.env` with `chmod 600`.
+
+Why this matters: compromise of the host or checkout grants broad write access
+across personal communications and workspace data. The token write helper
+(`services.py:198-212`) does not itself set restrictive permissions on token
+files, so actual mode depends on umask or existing file state.
+
+Current mitigations: gitignore, local-first design, env-token docs, token
+separation advice in `MCP_SETUP.md`.
+
+Gap: no documented token file permission check, scope minimization matrix, or
+startup warning for over-broad production tokens.
+
+### R6. Cross-account write routing still depends on defaults and caller discipline
+
+Severity: Medium to High.
+
+`google_account_resolution.py:24-33` honors
+`INBOX_DEFAULT_GOOGLE_ACCOUNT` when present, otherwise uses the first service key.
+The roadmap says writes should default to `jshah1331@gmail.com` and be enforced
+in backend policy (`CONNECTOR_ROADMAP.md:32-45`,
+`CONNECTOR_ROADMAP.md:216-229`), but `config/inbox.env.example:1-9` does not
+document `INBOX_DEFAULT_GOOGLE_ACCOUNT`.
+
+Why this matters: Drive/Docs/Sheets/Tasks/Calendar writes can land in whichever
+account happens to be first when env is unset. For personal systems, wrong
+account is a data-placement and privacy bug.
+
+Current mitigations: shared account-resolution helper, tests for some routing
+cases, explicit `account` params on many endpoints.
+
+Gap: default-account policy is not surfaced in the default env template and is
+not enforced as a startup invariant for write-capable deployments.
+
+### R7. Ambient listening and dictation are high-privacy/high-impact controls
+
+Severity: High.
+
+Ambient capture can be started by REST (`inbox_server.py:3047-3060`), records
+microphone audio through `sounddevice` (`services.py:4635-4659`), and writes
+transcripts into Obsidian daily notes (`ambient_notes.py:28-39`,
+`ambient_notes.py:69-76`). Dictation can be started by REST
+(`inbox_server.py:3098-3113`) and injects keyboard events into the current UI
+(`services.py:4702-4714`, `services.py:4768-4811`).
+
+Why this matters: these are not ordinary data fetches. Ambient listening can
+capture sensitive room audio, and dictation can type into any focused
+application. The direct REST endpoints have no per-call confirmation or test-mode
+guard.
+
+Current mitigations: loopback bind, server token if configured, availability
+checks, local ML.
+
+Gap: no explicit confirmation/startup warning, session timeout, visible active
+indicator requirement, or audit trail tied to the REST calls.
+
+### R8. Local persistent stores contain sensitive personal data
+
+Severity: Medium.
+
+The index stores message body text, snippets, labels, senders, recipients, and
+raw pointers (`message_index_store.py:100-117`). Scheduler storage includes
+scheduled message text and account (`scheduler.py:70-80`). Memory storage keeps
+subjects, content, status, and metadata (`memory_store.py:50-61`). These files
+are gitignored, but the MCP health endpoint can expose memory DB paths and the
+REST index endpoints expose index DB paths and indexed thread data
+(`inbox_server.py:3805-3841`).
+
+Why this matters: local sqlite files become a second data lake for personal
+communications. Backups, file permissions, path disclosure, and retention policy
+matter even if the original providers are protected.
+
+Current mitigations: gitignore, local-only defaults.
+
+Gap: no retention/redaction story, no permission checks, and no clear boundary
+around which agents can read index/memory endpoints.
+
+### R9. Tracked cloud automation script can create public cloud resources
+
+Severity: High.
+
+`oci_retry.sh` is tracked and contains concrete OCI compartment, image, subnet,
+SSH key, log path, and display-name values (`oci_retry.sh:7-15`). It loops
+forever and launches a public-IP A1.Flex instance until success
+(`oci_retry.sh:16-52`).
+
+Why this matters: it is outside the core Inbox product, contains cloud resource
+identifiers, and can incur cloud activity/cost if run. It also undermines the
+repo's "personal connector" boundary by mixing cloud provisioning into the same
+checkout.
+
+Current mitigations: none observed beyond being a shell script that must be run
+manually.
+
+Gap: no quarantine, dry-run, confirmation, or separation into a private ops repo.
+
+### R10. Validation docs assume a synced environment that this sandbox did not have
+
+Severity: Medium.
+
+`docs/TESTING_FOR_AGENTS.md:8-18` gives a sensible safe loop. In this sandbox,
+bare `pytest --collect-only -q` failed because the configured coverage plugin
+was unavailable. `uv run` with the default cache failed due `~/.cache/uv`
+permission; retrying with `UV_CACHE_DIR=/tmp/uv-cache` then failed on PyPI DNS
+for `googleapis-common-protos`. `DOCS_INDEX.md:136-140` claims all 736 tests
+pass, but that claim could not be verified here.
+
+Why this matters: future overnight workers may misclassify validation failures
+as product failures when they are actually environment/cache/network failures.
+
+Current mitigations: scripts set `UV_CACHE_DIR=/tmp/uv-cache`; safe test docs
+exist.
+
+Gap: the agent-safe validation docs do not mention the uv cache override or a
+network-free dependency setup path.
+
+## Decisions made during this audit
+
+- Treat the raw REST API as the critical write boundary. MCP confirmation is a
+  helpful client policy, but it is not sufficient when scripts and direct clients
+  can hit REST.
+- Treat account routing as a risk even though helper code exists, because the
+  default-account env var is not documented in the env example and roadmap text
+  says enforcement is still a work item.
+- Treat local stores as sensitive data stores, not caches, because they contain
+  message body text, scheduled message text, and memory content.
+- Do not run live provider tests, local-data tests, macOS automation, server
+  startup, or MCP calls in this queue item.
+
+## Next safe work
+
+### Task 1: Exhaustive live-write guard coverage
+
+Acceptance criteria:
+
+- Add a test or static registry that enumerates every service-level provider
+  mutation and asserts it calls `_assert_live_write_allowed` before touching the
+  provider.
+- Add guards at minimum for `drive_upload`, `sheets_format`, `sheets_copy_to`,
+  `docs_insert_text`, and `calendar_rsvp_event`.
+- Decide whether local-only writes such as memory, scheduler, favorites,
+  notification config, and voice config should be blocked in `INBOX_TEST_MODE`
+  or explicitly exempted with tests.
+
+Validation command candidate:
+
+`UV_CACHE_DIR=/tmp/uv-cache INBOX_TEST_MODE=1 uv run pytest tests/test_services.py tests/test_drive.py tests/test_tools_registry.py -q`
+
+Expected status: pass once dependencies are available. In this sandbox, `uv run`
+cannot install missing dependencies because network is restricted.
+
+### Task 2: Harden auth and public health responses
+
+Acceptance criteria:
+
+- Require `INBOX_SERVER_TOKEN` for write-capable server startup unless an
+  explicit unsafe env var such as `INBOX_ALLOW_UNAUTH_LOCAL=1` is set.
+- Either auth-protect MCP `/health` or return a sanitized public payload that
+  does not include backend account emails or local DB paths.
+- Add tests for unauthenticated full/read-only MCP health behavior and private
+  server startup policy.
+
+Validation command candidate:
+
+`UV_CACHE_DIR=/tmp/uv-cache INBOX_TEST_MODE=1 uv run pytest tests/test_server.py tests/test_mcp_gateway.py -q`
+
+Expected status: pass after tests are updated.
+
+### Task 3: Move confirmation/preflight policy into REST for high-risk writes
+
+Acceptance criteria:
+
+- Add server-side confirmation or preflight requirements for high-risk REST
+  writes: sends, delete/archive/bulk Gmail operations, account reauth, Drive,
+  Docs, Sheets, Calendar mutations, ambient/dictation start, and notification
+  tests.
+- Keep MCP `confirm=True`, but make direct REST clients satisfy the same policy
+  or route through a shared safe client.
+- Update `batch/` and unsubscribe scripts to show target server, require token
+  when configured, support dry-run, and refuse obvious primary-vs-dev mistakes.
+
+Validation command candidate:
+
+`UV_CACHE_DIR=/tmp/uv-cache INBOX_TEST_MODE=1 uv run pytest tests/test_server_endpoints.py tests/test_gmail_actions.py tests/test_client.py -q`
+
+Expected status: initial failures until endpoint/client contracts are updated,
+then pass.
+
+### Task 4: Enforce source-of-truth Google writes
+
+Acceptance criteria:
+
+- Add `INBOX_DEFAULT_GOOGLE_ACCOUNT` to `config/inbox.env.example`,
+  `MCP_SETUP.md`, and startup/self-check output.
+- For Google writes, fail closed when no default account is configured and no
+  explicit account is provided, or make the chosen default visible in a required
+  preflight response.
+- Add tests proving Docs, Sheets, Drive, Calendar, and Tasks writes route to the
+  configured default and never the first dict key by accident.
+
+Validation command candidate:
+
+`UV_CACHE_DIR=/tmp/uv-cache INBOX_TEST_MODE=1 uv run pytest tests/test_server.py tests/test_calendar.py tests/test_drive.py -q`
+
+Expected status: pass after account-routing tests and docs are updated.
+
+### Task 5: Quarantine or remove tracked cloud automation
+
+Acceptance criteria:
+
+- Move `oci_retry.sh` out of the Inbox repo, replace it with a private ops note,
+  or make it a non-executable documented example with placeholders only.
+- Remove real compartment, subnet, image, SSH-key, and log path values from
+  tracked files.
+- Add a simple secret/resource-id grep check for OCI OCIDs and private absolute
+  paths.
+
+Validation command candidate:
+
+`git ls-files | xargs rg -n "ocid1\\.|/Users/jwalinshah/\\.ssh|assign-public-ip true" --`
+
+Expected status: fail today because `oci_retry.sh` matches; pass after cleanup
+or explicit allowlisting.
+
+### Task 6: Make validation reproducible for agents
+
+Acceptance criteria:
+
+- Update `docs/TESTING_FOR_AGENTS.md` to include
+  `UV_CACHE_DIR=/tmp/uv-cache` for sandboxed agents.
+- Document expected failure modes when dependencies are not synced and network is
+  unavailable.
+- Consider a `make`/script wrapper for the safe test loop that sets
+  `INBOX_TEST_MODE=1`, cache path, and no-live-test marker policy.
+
+Validation command candidate:
+
+`UV_CACHE_DIR=/tmp/uv-cache INBOX_TEST_MODE=1 uv run pytest -m safe --collect-only -q`
+
+Expected status: pass in a synced or network-enabled environment; failed in this
+sandbox due PyPI DNS after uv cache was moved to `/tmp/uv-cache`.
+
+## Validation candidates and observed status
+
+- Required queue validation: `git status --short`
+  - Expected after this report is committed: pass with no output.
+- Agent-safe unit loop: `INBOX_TEST_MODE=1 uv run pytest -m safe`
+  - Expected in a synced environment: pass.
+  - Observed here: not run to completion because dependency setup required
+    network.
+- Focused safety tests:
+  `UV_CACHE_DIR=/tmp/uv-cache INBOX_TEST_MODE=1 uv run pytest tests/test_inbox_test_mode.py tests/test_tools_registry.py tests/test_mcp_gateway.py -q`
+  - Expected in a synced environment: pass.
+  - Observed here: not run because broader uv dependency resolution failed first.
+- Bare pytest discovery: `pytest --collect-only -q`
+  - Observed here: failed because `pyproject.toml` adds `--cov` options but the
+    bare interpreter did not have `pytest-cov`.
+- Uv safe discovery with default cache:
+  `INBOX_TEST_MODE=1 uv run pytest -m safe --collect-only -q`
+  - Observed here: failed because sandbox could not open `~/.cache/uv`.
+- Uv safe discovery with sandbox cache:
+  `UV_CACHE_DIR=/tmp/uv-cache INBOX_TEST_MODE=1 uv run pytest -m safe --collect-only -q`
+  - Observed here: failed to download `googleapis-common-protos` due DNS/network
+    restriction.
+- Lint/type candidates from docs:
+  `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check .` and
+  `UV_CACHE_DIR=/tmp/uv-cache uv run pyright`
+  - Expected in a synced environment: pass according to project docs.
+  - Observed here: not run because uv dependency setup was blocked by network.
+
+## Non-goals
+
+- No product code changes.
+- No secret reads beyond file/path names present in tracked source.
+- No Gmail, Calendar, Drive, Docs, Sheets, Tasks, GitHub, WhatsApp, iMessage,
+  Notes, Reminders, microphone, dictation, desktop notification, or MCP calls.
+- No deploys, pushes, PRs, issue tracker changes, cloud jobs, or OCI operations.
+- No attempt to prove whether the user's primary daily-driver Inbox instance is
+  currently secured; this audit stayed inside the assigned worktree.
+
+## Unknowns
+
+- Whether the real daily-driver process has `INBOX_SERVER_TOKEN` and
+  `INBOX_MCP_TOKEN` set.
+- Whether full MCP or read-only MCP is publicly exposed anywhere today.
+- Actual OAuth token scopes and token file permissions on the primary checkout.
+- Whether `INBOX_DEFAULT_GOOGLE_ACCOUNT` is set in the user's shell or service
+  environment.
+- Whether `oci_retry.sh` is still intentionally used or only stale local ops
+  residue.
+- Whether generated sqlite stores are backed up, encrypted, rotated, or
+  routinely deleted.
+- Whether external agents ever receive raw REST access instead of only curated
+  MCP tools.
+
+## Handoff notes
+
+- File changed by this queue item: `docs/overnight/inbox-sym-118-risk-register.md`.
+- Product code was intentionally untouched.
+- PR creation is out of scope for this Goal Pack item.
+- Blocker for deeper automated validation: this sandbox cannot access PyPI, and
+  dependencies were not already synced for `uv run`.

--- a/docs/overnight/inbox-sym-119-architecture-map.md
+++ b/docs/overnight/inbox-sym-119-architecture-map.md
@@ -1,0 +1,817 @@
+# inbox-sym-119 Architecture Map Audit
+
+Queue item: `inbox-sym-119-architecture-map`
+
+Focus area: `architecture-map`
+
+Repo: `inbox-sym-119`
+
+Report path: `docs/overnight/inbox-sym-119-architecture-map.md`
+
+## 1. Scope
+
+This is a read-only architecture audit. The only repository mutation made for
+this queue item is this report file.
+
+In scope:
+
+- Module boundaries, entrypoints, ownership, and runtime state.
+- Stale architecture assumptions in local docs.
+- Local evidence from files and command observations.
+- Validation command candidates and next safe Work Pack or Linear-ready tasks.
+
+Out of scope:
+
+- Product code changes.
+- Generated data changes.
+- Credential reads beyond path/name inventory.
+- External services, deploys, pushes, PR creation, or tracker state changes.
+- Running live personal inbox flows, OAuth flows, AppleScript sends, or provider
+  write endpoints.
+
+## 2. Repo State
+
+- Current working directory observed with `pwd`:
+  `/Users/jwalinshah/projects/agent-stack/.agent-stack-worktrees/2026-05-07-overnight-marathon/inbox-sym-119-architecture-map`
+- Branch observed with `git status --short --branch`:
+  `codex/goal-inbox-sym-119-architecture-map`
+- Initial HEAD observed with `git rev-parse HEAD`:
+  `2805b8400519da188ca7d3f6e39b19a8ca42b05a`
+- Initial dirty state observed with `git status --short`: clean, no output.
+- `CONTEXT.md` and `docs/adr/` were not present in this worktree. The durable
+  architecture context is spread across `README.md`, `CLAUDE.md`, `PLAN.md`,
+  `CONNECTOR_ROADMAP.md`, `DOCS_INDEX.md`, `.factory/library/*.md`, source, and
+  tests.
+
+## 3. Commands Run And Local Observations
+
+Representative commands used during the audit:
+
+- `llm-tldr tree .`
+  - Observed a flat Python application with top-level modules including
+    `services.py`, `inbox_server.py`, `inbox_client.py`, `inbox.py`,
+    `message_index_store.py`, `message_sync.py`, `gmail_triage.py`,
+    `thread_classifier.py`, `mcp_backend.py`, `mcp_server.py`,
+    `tools_registry.py`, `scheduler.py`, and `memory_store.py`.
+- `git status --short --branch`
+  - Observed branch `codex/goal-inbox-sym-119-architecture-map`.
+- `git rev-parse HEAD`
+  - Observed initial SHA `2805b8400519da188ca7d3f6e39b19a8ca42b05a`.
+- `fd -a '^(CONTEXT.md|AGENTS.md|CLAUDE.md|README.md|DOCS_INDEX.md|PLAN.md|CONNECTOR_ROADMAP.md)$' .`
+  - Observed local docs and instruction files; no `CONTEXT.md`.
+- `fd -a 'adr|decision|architecture' .`
+  - Observed `.factory/library/architecture.md` and
+    `.factory/library/architecture-hardening.md`; no `docs/adr/`.
+- `wc -l *.py tests/*.py`
+  - Observed large owner modules: `services.py` 6467 lines, `inbox.py` 4279
+    lines, `inbox_server.py` 3940 lines, `inbox_client.py` 947 lines,
+    `tools_registry.py` 851 lines, `message_sync.py` 659 lines, and
+    `message_index_store.py` 616 lines.
+- `rg -c '^@app\.' inbox_server.py`
+  - Observed 160 FastAPI route decorators in `inbox_server.py`.
+- `rg -c '^    Tool\(' tools_registry.py`
+  - Observed 60 registry-defined MCP tools.
+- `rg -c '^(def|class) ' services.py`
+  - Observed 205 top-level functions/classes in `services.py`.
+- `rg -c '^    def ' inbox_client.py`
+  - Observed 103 `InboxClient` methods.
+- `llm-tldr context create_app --project .`
+  - Observed that app construction is coupled to lifespan setup, global route
+    copying, scheduler startup, ambient services, and runtime state injection.
+- `llm-tldr context _preflight_google_write --project .`
+  - Observed that Google write preflight reaches from server routing into
+    `google_account_resolution.py`, which then imports helpers from
+    `services.py`.
+- `llm-tldr context get_needs_action --project .`
+  - Observed a cross-source endpoint mixing indexed threads, live Google Tasks,
+    and live Calendar into one response with local exception swallowing.
+- `llm-tldr imports inbox_server.py`
+  - Observed broad imports from `services.py`, plus optional external
+    `gemma4_hackathon` imports near the query endpoint.
+- `llm-tldr imports services.py`
+  - Observed provider SDK, macOS, SQLite, audio, ML, auth, and OS automation
+    imports in one module.
+- `llm-tldr arch .`
+  - Observed no static circular dependencies, but the analyzer only found a
+    root/tests directory layer because the repo is intentionally flat. It
+    reported a large root graph, not meaningful bounded packages.
+- `llm-tldr dead . --entry inbox_server.py inbox.py mcp_server.py inbox_mcp_readonly.py message_sync.py`
+  - Observed 92 static "dead" candidates. Many are dynamic registry or test
+    false positives, so this is evidence that dynamic dispatch limits static
+    analysis, not proof of dead behavior.
+- `rg -n 'credentials|token|secret|api_key|INBOX_|GEMINI|OPENAI|GOOGLE|GITHUB' .gitignore config pyproject.toml README.md CLAUDE.md services.py inbox_server.py mcp_server.py tools_registry.py`
+  - Observed local credential/config paths and ignored token/key files.
+
+## 4. Repo Purpose
+
+`inbox-sym-119` is a local-first personal inbox and control-plane application.
+It combines:
+
+- A Textual TUI in `inbox.py`.
+- A local FastAPI server in `inbox_server.py`.
+- A Python HTTP client in `inbox_client.py`.
+- MCP servers and tool registry surfaces in `mcp_server.py`,
+  `inbox_mcp_readonly.py`, `inbox_mcp_stdio.py`, `tools_registry.py`, and
+  `mcp_backend.py`.
+- Provider and local OS integration logic in `services.py`.
+- A local normalized message index in `message_index_store.py` and
+  `message_sync.py`.
+- Supporting local state in `memory_store.py`, `scheduler.py`,
+  `ambient_notes.py`, and related modules.
+
+The product direction in `PLAN.md` is not just "show raw inbox data." Lines
+24-33 say the inbox should not default to raw provider dumps. Lines 35-62
+describe a four-layer target architecture: raw sources, an operational index,
+inbox views, and interfaces. That direction is partly implemented through the
+message index, but raw source APIs still remain prominent across REST, TUI, and
+MCP surfaces.
+
+## 5. Entrypoints
+
+Primary human and agent entrypoints:
+
+- `inbox.py`
+  - TUI entrypoint. The bottom of the file instantiates `InboxApp` and calls
+    `app.run()`.
+  - `InboxApp` begins at `inbox.py:1147`; it owns CSS, bindings, tab state,
+    refresh loops, compose/reply flows, and view rendering.
+  - Boot logic at `inbox.py:2082-2114` starts or connects to the local server
+    through `InboxClient`.
+- `dev.sh`
+  - Development wrapper. Lines 1-11 set `INBOX_SERVER_PORT` default `9850` and
+    execute `uv run python "${1:-inbox.py}"`.
+- `scripts/run_inbox_backend.sh`
+  - Backend wrapper. Lines 1-9 set `UV_CACHE_DIR` and execute
+    `uv run python inbox_server.py`.
+- `inbox_server.py`
+  - REST server. Lines 3936-3940 run uvicorn on `INBOX_SERVER_PORT`.
+  - `create_app()` at `inbox_server.py:1288-1307` constructs the FastAPI app
+    and copies routes from the global app when routes already exist.
+- `mcp_server.py`
+  - Full MCP HTTP server. Lines 1-15 document environment defaults. Lines
+    142-151 register registry tools and run uvicorn on port 8000 by default.
+- `inbox_mcp_readonly.py`
+  - Read-only MCP HTTP server. Lines 1-6 identify the read-only surface. Lines
+    77 and 83-87 register read-only tools and run the server.
+- `inbox_mcp_stdio.py`
+  - Stdio MCP entrypoint. Lines 1-9 describe the local stdio transport, and
+    lines 13-17 import the full MCP server object and run stdio mode.
+- `message_sync.py`
+  - CLI/sync entrypoint. Lines 638-659 parse `bootstrap` or `incremental` and
+    run the corresponding sync flow.
+- `main.py`
+  - Stale placeholder. Lines 1-6 only print `Hello from inbox!`; it is not a
+    meaningful product entrypoint.
+
+## 6. Actual Architecture Map
+
+The current architecture is a flat-module local app with these practical
+ownership zones.
+
+### UI zone
+
+- `inbox.py` owns the TUI shell, visual state, tab state, polling, compose
+  dialogs, and rendering.
+- `tui_tabs.py` is a small shared tab-definition module. Lines 19-120 define
+  `TABS`, including Now, Actionable, Waiting On, iMessage, Gmail, Calendar,
+  Notes, Reminders, GitHub, and Drive.
+- `inbox_client.py` is the UI/agent HTTP client. Lines 16-18 resolve
+  `SERVER_URL` from `INBOX_SERVER_URL` or `INBOX_SERVER_PORT`. Lines 49-77
+  start and health-check the local server.
+
+Architectural note: the TUI is mostly a thin client, but not perfectly. At
+`inbox.py:2082-2114`, boot logic imports `services.load_favorites` directly.
+That is a boundary exception to the documented "TUI as HTTP client" model.
+
+### REST/runtime zone
+
+- `inbox_server.py` owns route registration, auth middleware, global runtime
+  state, application lifespan, and API composition.
+- Lines 212-220 define process constants such as `PORT`, `AUTH_TOKEN_ENV`, and
+  `GOOGLE_SERVICE_SET`.
+- Lines 794-819 define `SourceAdapters` and `ServerState`. `ServerState` holds
+  Google service dictionaries, a conversation cache, event cache,
+  `AmbientService`, `DictationService`, `SchedulerStore`, and
+  `MessageIndexStore`.
+- Lines 821-823 create global `state` and `memory_store`.
+- Lines 826-834 define `InboxServerRuntime`, which is the strongest test seam
+  for injecting fake state and disabling startup side effects.
+- Lines 1198-1285 define `make_lifespan()`, which initializes contacts,
+  authenticates Google services, optionally prewarms conversations, starts
+  ambient services, starts scheduler polling, and cleans up on shutdown.
+- Lines 1313-1340 define optional bearer/x-api-key auth middleware.
+
+Architectural note: this zone is doing two different jobs. It is both the local
+REST facade and the runtime container for provider services, scheduler,
+ambient, memory, and index state. That makes `inbox_server.py` the highest
+traffic module after `services.py`.
+
+### Provider/service zone
+
+- `services.py` owns most provider, local OS, auth, data-fetching, mutation,
+  audio, and local ML logic. Its docstring at lines 1-4 explicitly says all
+  data fetching, auth, mutation, audio, and LLM logic lives there.
+- Lines 56-87 define key local paths: `credentials.json`, token files,
+  iMessage database, Notes database, Reminders database directory,
+  `github_token.txt`, `google_maps_key.txt`, and `gemini_api_key.txt`.
+- Lines 88-98 define broad Google OAuth scopes, including Gmail read/modify/send
+  and settings, Calendar, Drive, Sheets, Docs, and Tasks.
+- Lines 114-120 delegate live-write protection to `inbox_test_mode`.
+- Lines 194-212 implement token locking and atomic token writes.
+- Lines 215-253 implement `SQLiteConnectionManager` for read-only SQLite
+  connection reuse.
+- Lines 276-309 implement `_run_sqlite_read()` with retries and an empty-list
+  fallback on read failure.
+- Lines 330-416 implement `google_auth_all()` and build six service
+  dictionaries: Gmail, Calendar, Drive, Sheets, Docs, and Tasks.
+- Lines 444-623 implement iMessage contacts, thread reads, and sends.
+- Lines 786-1244 implement Gmail contact/thread/read/send/reply and mutations.
+- Lines 2620-3095 implement Reminders read and write behavior, including
+  AppleScript mutation flows.
+- Lines 3101-3225 implement Google Tasks behavior.
+- Lines 3246-3475 implement optional Gemini-backed summary, smart reply,
+  categorization, digest, and action extraction.
+- Lines 4546-4824 implement ambient/dictation availability and OS-level
+  dictation behavior.
+- Lines 4829 onward implement local ML model loading and extraction helpers.
+
+Architectural note: `services.py` is a compatibility shell and a feature bucket.
+It has useful stable behavior, but it is too broad to be a coherent ownership
+unit. Any implementation task in this module risks accidental coupling between
+provider auth, local SQLite, AppleScript, audio, ML, and API behavior.
+
+### Data model zone
+
+- `service_models.py` is a good stable boundary. Lines 1-2 state that it
+  contains stable pure data models shared by service providers and callers.
+- `Contact` at `service_models.py:11-26` includes provider routing fields such
+  as `reply_to`, `thread_id`, `message_id_header`, and `gmail_account`.
+- `Msg` at `service_models.py:28-37` is the normalized message shape.
+- `CalendarEvent` at `service_models.py:39-53` is the normalized calendar
+  shape.
+- `DriveFile` at `service_models.py:102-113` includes `account`, which matters
+  for multi-account routing.
+- `ThreadSummary` at `service_models.py:143-153` includes `owning_account`,
+  participants, labels, body snippets, and account-sensitive fields.
+
+Architectural note: this is the clearest low-risk extraction point already in
+the repo. Future service splitting should keep imports flowing through these
+models rather than reintroducing provider-specific shapes at boundaries.
+
+### Account policy zone
+
+- `google_account_resolution.py` centralizes multi-account selection and
+  write-preflight policy.
+- Lines 14-21 define `GoogleMultiAccountState`, a protocol over service
+  dictionaries and conversation cache.
+- Lines 24-33 implement `default_google_account()`, honoring
+  `INBOX_DEFAULT_GOOGLE_ACCOUNT` when configured and available.
+- Lines 36-58 choose Gmail services from cache or explicit account.
+- Lines 85-106 choose a Gmail service for a message or thread by explicit
+  account, cached conversation metadata, existence probing, or fallback.
+- Lines 109-157 choose Sheets, Drive, Tasks, Docs, and Calendar services.
+- Lines 160 onward implement `preflight_google_write_payload()`.
+
+Architectural note: this is a real policy module, but it still imports
+`Contact`, `drive_get`, and `tasks_lists` from `services.py`. The policy layer
+therefore depends on the broad service module instead of a narrow read-only
+capability interface.
+
+### Operational index zone
+
+- `message_index_store.py` owns the local normalized SQLite message index.
+- Lines 12-13 define the default `.inbox_index.sqlite3` path.
+- Lines 69-168 initialize the schema: `sync_state`, `items`, `threads`, and
+  `sender_stats`.
+- Lines 185-237 upsert indexed items.
+- Lines 239-356 manage sync-state progress, errors, and counts.
+- Lines 407-563 rebuild thread rows by grouping items and calling
+  `thread_classifier.classify_thread()`.
+- Lines 565-612 list threads by actionability, source, sender, needs-reply,
+  open-loop, and sort mode.
+- `message_sync.py` owns index ingestion. Lines 51-82 normalize Gmail messages
+  into `IndexedItem`; lines 181-269 implement Gmail bootstrap; lines 272-449
+  implement Gmail incremental; lines 452-582 implement iMessage bootstrap and
+  incremental; lines 602-627 orchestrate both sources and rebuild changed
+  threads.
+
+Architectural note: this is closest to the `PLAN.md` operational index target.
+The main gap is that raw live endpoints and raw TUI views still sit beside the
+index-backed views instead of being clearly subordinate drill-downs.
+
+### Thread intelligence zone
+
+- `thread_classifier.py` owns index-time heuristic classification.
+- Lines 6-16 define `ThreadClassification`.
+- Lines 18-47 implement `classify_thread()`.
+- Lines 58-130 implement heuristic scoring and classification.
+- Lines 133-150 implement open-loop detection and summary construction.
+- `gmail_triage.py` owns Gmail/thread workflow triage output.
+- Lines 17-31 define `GmailThreadSummaryOut`.
+- Lines 44-125 define workflow keyword maps and display metadata.
+- Lines 172-177 classify workflow kind.
+- Lines 203-225 rank raw thread summaries.
+- Lines 228-305 convert both `Contact` and indexed rows into
+  `GmailThreadSummaryOut`.
+
+Architectural note: classification currently has two centers:
+`thread_classifier.py` for index rows and `gmail_triage.py` for Gmail workflow
+output. They are related but not a single source of truth. Drift here affects
+Now, Actionable, Waiting, Gmail triage, and MCP agent views.
+
+### MCP/tooling zone
+
+- `tools_registry.py` centralizes many tool definitions.
+- Lines 1-12 explain that the registry drives both full and read-only MCP
+  servers.
+- Lines 26-45 define `Param` and `Tool`.
+- Lines 52-107 build handlers and enforce confirmation for confirm-gated
+  tools.
+- Lines 110-119 register tools into an MCP server.
+- Lines 126-851 define 60 tools. They include read tools, write tools, raw
+  Sheets/Drive/Docs operations, Gmail mutations, iMessage send, Reminders,
+  Tasks, scheduling, memory, and GitHub tools.
+- `mcp_backend.py` is the HTTP adapter for MCP tools. Lines 9-11 define local
+  URL defaults; lines 29-56 implement the shared request wrapper; lines 61-540
+  expose per-endpoint methods.
+- `mcp_server.py` adds non-HTTP note/memory tools and registers the full tool
+  registry.
+- `inbox_mcp_readonly.py` adds read-only note/memory tools and registers only
+  read-only registry entries.
+
+Architectural note: the registry is a strong shared surface, but the exposed
+contract is still mostly endpoint-shaped. The roadmap asks for intent-level
+tools, while the registry still has raw provider syntax such as Sheets ranges,
+Drive paths, Docs document IDs, and Gmail label/filter primitives.
+
+### Local state zone
+
+- `scheduler.py` and `memory_store.py` own local persistent state for scheduled
+  actions and memory. They are injected into server state and MCP behavior.
+- `.gitignore` lines 41-43 ignore `.claude`, `.inbox_memory.sqlite3`, and
+  `.inbox_scheduler.sqlite3`; line 58 ignores `.inbox_index.sqlite3`.
+- `services.py` lines 56-87 define many local data and credential paths,
+  including personal database paths and token/key files.
+
+Architectural note: local state is intentionally private and local-first, but
+the paths are spread across modules. New workers need a clear boundary between
+tracked repo state, ignored local state, and external/personal data.
+
+## 7. Data Flow Sketches
+
+### TUI refresh flow
+
+1. `inbox.py` starts or connects to the server through `InboxClient`.
+2. `InboxClient` resolves `SERVER_URL` from environment defaults in
+   `inbox_client.py:16-18`.
+3. `InboxApp._collect_auxiliary_data()` at `inbox.py:2295-2361` fetches
+   calendar, notes, reminders, GitHub, and index-backed views.
+4. `InboxApp._refresh_data()` at `inbox.py:2363-2387` also fetches raw
+   conversations.
+5. `InboxApp._poll_data()` at `inbox.py:2389-2458` compares raw conversation
+   IDs and index thread IDs.
+6. Rendering mixes raw sidebars and index-backed Now/Actionable/Waiting views
+   in `inbox.py:1577-1724`.
+
+Risk: the TUI still depends on raw `/conversations` refresh even though the
+product direction wants index-first views.
+
+### Raw conversation flow
+
+1. `/conversations` at `inbox_server.py:1396-1407` calls `_fetch_conversations()`.
+2. `_fetch_conversations()` at `inbox_server.py:1363-1393` concurrently reads
+   iMessage contacts and each Gmail service.
+3. The endpoint clears and rebuilds `state.conv_cache`.
+4. `/messages/{source}/{conv_id}` at `inbox_server.py:1413-1431` uses cache for
+   Gmail account selection and falls back to the first Gmail service when cache
+   is absent.
+5. `/messages/send` at `inbox_server.py:1434-1450` requires the contact to
+   exist in `state.conv_cache`.
+
+Risk: conversation cache is a hidden routing contract. Sending and Gmail thread
+loading depend on previous read behavior.
+
+### Index flow
+
+1. `message_sync.py` authenticates Gmail through `google_auth_all()` and reads
+   iMessage SQLite directly.
+2. It upserts normalized `IndexedItem` rows into `MessageIndexStore`.
+3. `MessageIndexStore.rebuild_threads()` groups items and calls
+   `thread_classifier.classify_thread()`.
+4. `inbox_server.py` exposes `/index/status`, `/index/health`,
+   `/index/views/{view_name}`, `/index/sync/bootstrap`, and
+   `/index/sync/incremental` at lines 3805-3853.
+5. `_index_view_rows()` at `inbox_server.py:2771-2807` maps Now, Actionable,
+   Waiting, and recent views to store filters.
+6. `inbox.py` renders index rows as synthetic messages at `inbox.py:2720-2748`.
+
+Risk: the index exists and is useful, but it is not yet the only read contract
+for high-level inbox work.
+
+### Google write flow
+
+1. `google_account_resolution.py` chooses default or explicit account.
+2. `_preflight_google_write()` in `inbox_server.py:2906-2919` wraps policy.
+3. `/preflight/google-write` at `inbox_server.py:3009-3020` exposes policy
+   checks.
+4. Raw write routes for Drive, Sheets, Docs, Tasks, Gmail, and Calendar are
+   still exposed elsewhere in `inbox_server.py` and `tools_registry.py`.
+
+Risk: preflight exists as a tool, but the architecture does not make it a
+universal gate for all Google writes.
+
+## 8. Stale Or Unsupported Architecture Claims
+
+1. `README.md` says Python 3.10+ at line 32, while `pyproject.toml:5` requires
+   `>=3.12,<3.15`.
+2. `DOCS_INDEX.md` lines 40-45 and 136-140 mention a test claim of "736 tests"
+   passing. That was not validated in this audit, and the current test tree is
+   large enough that the exact count is likely stale.
+3. `.factory/library/architecture.md` describes `services.py` as owning data
+   models, but the current pure model boundary is `service_models.py`.
+4. `.factory/library/architecture.md` describes several features as planned
+   additions that now exist in code, including Reminders, GitHub, Drive, and
+   multi-tab surfaces.
+5. `CLAUDE.md` and `README.md` document a thin client-server shape. That is
+   directionally true, but `inbox.py:2082-2114` still imports
+   `services.load_favorites` directly.
+6. `CONNECTOR_ROADMAP.md` lines 60-76 prefer intent-level tools, but
+   `tools_registry.py:126-851` still exposes a large raw provider/API surface.
+7. `PLAN.md` wants the operational index to mediate inbox views, but
+   `/gmail/threads/needing-reply` at `inbox_server.py:3672-3695` still runs raw
+   Gmail search and local heuristics.
+8. `main.py` is a placeholder entrypoint that can mislead automation or new
+   agents expecting `python main.py` to launch the app.
+
+## 9. Risks And Shallow Boundaries
+
+### Risk 1: `services.py` is the dominant shared dependency
+
+Evidence:
+
+- `services.py:1-4` explicitly places data fetching, auth, mutation, audio, and
+  LLM logic in one file.
+- `services.py` is 6467 lines and has 205 top-level functions/classes by local
+  command observation.
+- `inbox_server.py:61-200` imports a very wide function set from `services.py`.
+- `message_sync.py:10-11` imports both constants/helpers and `google_auth_all()`
+  from `services.py`.
+- `google_account_resolution.py` imports service helpers for policy checks.
+
+Why this matters:
+
+- Any provider-specific change risks unrelated behavior.
+- It is hard to assign ownership to one worker without hot-file conflicts.
+- The module mixes pure transforms, provider calls, OS automation, auth, ML, and
+  credential path ownership.
+
+### Risk 2: REST server is both API facade and runtime container
+
+Evidence:
+
+- `inbox_server.py` is 3940 lines with 160 route decorators.
+- `ServerState` at `inbox_server.py:794-819` holds provider services,
+  conversation cache, event cache, ambient service, dictation service,
+  scheduler store, and index store.
+- `make_lifespan()` at `inbox_server.py:1198-1285` initializes auth, contacts,
+  ambient, scheduler, and cleanup.
+- `create_app()` at `inbox_server.py:1288-1307` copies routes from a global app
+  into a fresh app, which is unusual and test-sensitive.
+
+Why this matters:
+
+- Route-only changes can accidentally affect startup, personal services, or
+  tests.
+- Runtime state is global by default and injected only through careful test
+  setup.
+- Adding another connector directly to the server will deepen the monolith.
+
+### Risk 3: Conversation cache is an implicit write/routing contract
+
+Evidence:
+
+- `/conversations` clears and rebuilds `state.conv_cache` at
+  `inbox_server.py:1396-1407`.
+- `/messages/{source}/{conv_id}` at `inbox_server.py:1413-1431` uses the cache
+  for Gmail account selection, otherwise falls back to the first Gmail service.
+- `/messages/send` at `inbox_server.py:1434-1450` requires the contact to be in
+  `state.conv_cache`.
+- `google_account_resolution.py:85-106` also consults cached metadata when
+  resolving Gmail services.
+
+Why this matters:
+
+- Write correctness can depend on a prior read call.
+- Agents using MCP or REST directly may not know they must warm the cache.
+- Multi-account routing failures can look like missing messages rather than
+  policy errors.
+
+### Risk 4: Index and triage intelligence can drift
+
+Evidence:
+
+- `message_index_store.py:407-563` rebuilds thread rows using
+  `thread_classifier.classify_thread()`.
+- `gmail_triage.py:44-125` contains separate workflow keyword and display
+  metadata.
+- `gmail_triage.py:228-305` converts contacts and indexed rows into
+  `GmailThreadSummaryOut`.
+- `inbox_server.py:3672-3695` still has a raw Gmail "needing reply" route.
+
+Why this matters:
+
+- Now/Actionable/Waiting can disagree with Gmail triage and agent tools.
+- New classification rules may be added in one place and not the other.
+- Morning review cannot reason about one authoritative thread-intelligence
+  contract yet.
+
+### Risk 5: Write policy is documented but not structurally mandatory
+
+Evidence:
+
+- `CONNECTOR_ROADMAP.md:32-44` defines source-of-truth policy for Google
+  account ownership and default account behavior.
+- `google_account_resolution.py` implements policy helpers.
+- `/preflight/google-write` exists at `inbox_server.py:3009-3020`.
+- Raw write endpoints and MCP tools remain exposed in `inbox_server.py` and
+  `tools_registry.py`.
+- `tools_registry.py:52-107` enforces confirmation, but confirmation is not the
+  same as account/source preflight.
+
+Why this matters:
+
+- A caller can do a confirmed but badly routed write.
+- Intent-level safety is optional unless every write path calls the policy.
+- The repo relies on discipline rather than a hard boundary.
+
+### Risk 6: External/local-only assumptions are easy to trip
+
+Evidence:
+
+- `services.py:56-87` names local credential and personal database paths.
+- `.gitignore` ignores credentials, tokens, API keys, logs, and local SQLite
+  state.
+- `inbox_server.py:3896-3934` has an optional `/query` endpoint coupled to
+  `~/projects/gemma4-hackathon`.
+- `services.py:576-623` and `services.py:2804-3095` include AppleScript
+  mutation flows.
+- `services.py:4546-4824` includes optional audio, ambient, and OS-level
+  dictation integrations.
+
+Why this matters:
+
+- Automation can accidentally invoke local personal state or OS automation.
+- Some routes only work on the author's machine or with private adjacent repos.
+- New workers need safe test-mode commands and explicit non-goals.
+
+## 10. Strong Existing Boundaries Worth Preserving
+
+1. `service_models.py` is the cleanest stable data model boundary.
+2. `InboxServerRuntime` at `inbox_server.py:826-834` allows tests to inject
+   fake state and avoid live startup behavior.
+3. `MessageIndexStore` is a cohesive local persistence boundary for indexed
+   message views.
+4. `tools_registry.py` gives full and read-only MCP servers one shared
+   definition list.
+5. `google_account_resolution.py` has the right policy shape, even though it
+   should depend on narrower provider interfaces.
+6. `tests/conftest.py:15-35` stubs heavy ML/hardware modules, which protects
+   local tests from optional runtime dependencies.
+7. `tests/test_server.py:29-56` builds a fake runtime fixture, which is the
+   pattern to use for route-level tests.
+8. `tests/test_api_contract.py:75-88` checks that every MCP tool path maps to a
+   FastAPI route, which is valuable contract protection for the registry.
+
+## 11. Validation Map For Architecture Work
+
+Required queue validation:
+
+| Command | Expected status | Notes |
+| --- | --- | --- |
+| `git status --short` | Pass | Required by queue item. Before report writing it produced no output. After committing the report it should again be clean. |
+
+Cheap architecture/doc validation candidates:
+
+| Command | Expected status | Notes |
+| --- | --- | --- |
+| `INBOX_TEST_MODE=1 uv run pytest -m safe` | Expected pass in a synced dev env | Documented as the safe default in `docs/TESTING_FOR_AGENTS.md:10`. Avoids live/personal integration tests. |
+| `INBOX_TEST_MODE=1 uv run pytest tests/test_api_contract.py -q` | Expected pass | Best small proof for MCP/REST route contract changes. |
+| `INBOX_TEST_MODE=1 uv run pytest tests/test_server.py -q` | Expected pass | Best small proof for server route/runtime behavior. Uses fake runtime fixtures at `tests/test_server.py:29-56`. |
+| `INBOX_TEST_MODE=1 uv run pytest tests/test_message_index_store.py tests/test_message_sync.py -q` | Expected pass for index-only refactors | Best small proof for operational index behavior. |
+| `INBOX_TEST_MODE=1 uv run pytest tests/test_thread_classifier.py tests/test_message_index_store.py -q` | Expected pass for thread-intelligence work | Best small proof for classification and indexed view changes. |
+| `uv run ruff check .` | Expected pass | Listed in `.factory/services.yaml` as lint command. Should be run after code changes. |
+| `uv run pyright` | Unknown until dependencies are installed | Listed in `.factory/services.yaml`. Pyright is configured with `reportMissingImports = true` in `pyproject.toml:48-51`; missing optional SDKs may affect local result. |
+| `uv run pytest -q` | Unknown and potentially broad | The repo contains tests for live/personal integrations. Prefer safe marker or focused tests for worker tasks. |
+
+Validation commands intentionally not run during this audit:
+
+- Live app startup through `uv run python inbox.py`.
+- Live backend startup against personal services.
+- OAuth, AppleScript, send, archive, delete, or external provider write flows.
+
+## 12. Independently Grabbable Next Tasks
+
+### Task 1: Extract a narrow provider adapter boundary from `services.py`
+
+Suggested issue title:
+`Extract source/provider adapter interfaces without changing behavior`
+
+Problem:
+
+`services.py` is the broadest shared dependency. `inbox_server.py`,
+`message_sync.py`, and `google_account_resolution.py` all depend on it directly
+for mixed concerns.
+
+Suggested scope:
+
+- Add narrow adapter/protocol modules for Gmail, iMessage, and Google account
+  service lookup.
+- Keep existing `services.py` function names as compatibility wrappers.
+- Move no business behavior in the first slice; only create interfaces and
+  wire one or two low-risk call sites.
+- Do not touch AppleScript, OAuth scopes, or local ML behavior in the same
+  slice.
+
+Acceptance criteria:
+
+- `inbox_server.py` imports adapter or protocol objects for at least Gmail
+  read/thread operations instead of importing all functions directly from
+  `services.py` at those call sites.
+- `services.py` still exports the old functions used by existing tests.
+- No route response shape changes.
+- No new external service calls in tests.
+
+Validation:
+
+- `INBOX_TEST_MODE=1 uv run pytest tests/test_server.py tests/test_api_contract.py -q`
+- `uv run ruff check .`
+
+### Task 2: Make thread intelligence one explicit contract
+
+Suggested issue title:
+`Consolidate indexed thread classification and Gmail triage summary rules`
+
+Problem:
+
+`thread_classifier.py` and `gmail_triage.py` both encode thread intelligence.
+They are currently adjacent but not one authoritative contract.
+
+Suggested scope:
+
+- Define one shared classifier or classification DTO used by both indexed
+  rows and Gmail triage output.
+- Keep `GmailThreadSummaryOut` as an API output type if needed.
+- Move duplicated workflow keyword or priority logic behind one helper.
+- Add fixtures for newsletter/noise, OTP/security, human opportunity, medical
+  admin, waiting-on-me, and waiting-on-others cases.
+
+Acceptance criteria:
+
+- Indexed views and Gmail triage use the same classification source.
+- Existing route output fields remain compatible.
+- Tests prove representative cases produce consistent actionability and
+  workflow classification.
+
+Validation:
+
+- `INBOX_TEST_MODE=1 uv run pytest tests/test_thread_classifier.py tests/test_message_index_store.py tests/test_message_sync.py -q`
+- `INBOX_TEST_MODE=1 uv run pytest tests/test_server.py -q`
+
+### Task 3: Make index-first views the explicit read contract
+
+Suggested issue title:
+`Harden Now/Actionable/Waiting as index-first views with stale-index reporting`
+
+Problem:
+
+The plan wants inbox views to sit over an operational index, but TUI refresh and
+REST endpoints still mix index-backed and raw provider flows.
+
+Suggested scope:
+
+- Document and enforce that Now, Actionable, and Waiting views read from
+  `MessageIndexStore`.
+- Keep raw Gmail/iMessage/Calendar/Drive tabs as drill-down/source views.
+- Surface index stale/error state in API and TUI without falling back silently
+  to raw provider scans.
+- Avoid changing sync algorithms in the same slice.
+
+Acceptance criteria:
+
+- Now/Actionable/Waiting rendering does not require `/conversations` to be
+  called first.
+- TUI displays a clear stale-index or sync-error state when index health is bad.
+- Tests prove index view endpoints do not call raw provider fetches.
+
+Validation:
+
+- `INBOX_TEST_MODE=1 uv run pytest tests/test_api_contract.py tests/test_client.py tests/test_inbox_app.py -q`
+- `INBOX_TEST_MODE=1 uv run pytest tests/test_message_index_store.py -q`
+
+### Task 4: Enforce Google write preflight across write routes
+
+Suggested issue title:
+`Make Google write account preflight mandatory for raw and intent write APIs`
+
+Problem:
+
+Preflight exists but is not yet a universal structural gate for all write
+surfaces.
+
+Suggested scope:
+
+- Inventory Google write routes in `inbox_server.py` and write tools in
+  `tools_registry.py`.
+- Route each write through a shared policy helper or require explicit policy
+  evidence.
+- Keep test mode write blocking intact through `inbox_test_mode`.
+- Add tests for default account, explicit account, missing account, and
+  destination mismatch.
+
+Acceptance criteria:
+
+- Every Google write route either calls the shared preflight helper or has a
+  documented, tested reason it does not.
+- MCP write tool descriptions point callers to preflight or account fields.
+- Existing route shapes remain backward compatible where possible.
+
+Validation:
+
+- `INBOX_TEST_MODE=1 uv run pytest tests/test_server.py tests/test_gmail_actions.py tests/test_drive.py -q`
+- `INBOX_TEST_MODE=1 uv run pytest tests/test_api_contract.py -q`
+
+### Task 5: Refresh stale architecture docs without product behavior changes
+
+Suggested issue title:
+`Update architecture docs to match current entrypoints, Python version, and index architecture`
+
+Problem:
+
+Several local docs contradict current code or make unvalidated claims.
+
+Suggested scope:
+
+- Update `README.md` Python version claim to match `pyproject.toml`.
+- Update `DOCS_INDEX.md` test-count claims or replace exact count with the
+  validation command that produced it.
+- Update `.factory/library/architecture.md` to point data models at
+  `service_models.py` and mark existing features as present rather than
+  planned.
+- Add a short architecture map to `CLAUDE.md` or a dedicated docs file only if
+  this repo wants a maintained map.
+
+Acceptance criteria:
+
+- Docs no longer claim Python 3.10+ when `pyproject.toml` requires 3.12+.
+- Docs do not claim exact passing test counts without a command and date.
+- Docs identify the current entrypoints: `inbox.py`, `inbox_server.py`,
+  MCP servers, and `message_sync.py`; `main.py` is identified as placeholder or
+  removed in a separate implementation task.
+
+Validation:
+
+- `rg -n '3\.10|736 tests|planned|service_models|main.py|inbox_server.py' README.md DOCS_INDEX.md CLAUDE.md .factory/library/architecture.md`
+- `git diff --check`
+
+## 13. Unknowns And Blockers
+
+- No `CONTEXT.md` or `docs/adr/` exists, so architecture intent must be inferred
+  from `PLAN.md`, `CONNECTOR_ROADMAP.md`, `CLAUDE.md`, and source.
+- Exact current full test status is unknown. This audit intentionally did not
+  run broad/live validation.
+- Current production/local data shape is unknown because personal data stores
+  and tokens are ignored local state.
+- The optional `gemma4-hackathon` dependency behind `/query` is outside this
+  repo, so this audit did not inspect it.
+- The static dead-code report is noisy because registry, MCP, and Textual flows
+  use dynamic dispatch; dead-code candidates need manual confirmation before
+  cleanup.
+- The intended fate of `main.py` is unknown. It may be harmless placeholder
+  scaffolding or a stale artifact that should be removed.
+
+## 14. Handoff Notes
+
+Files changed by this queue item:
+
+- `docs/overnight/inbox-sym-119-architecture-map.md`
+
+Validation command required by queue item:
+
+- `git status --short`
+
+Commit and PR status:
+
+- No PR created by this worker.
+- Commit was attempted with
+  `git add docs/overnight/inbox-sym-119-architecture-map.md && git commit -m "Add inbox architecture map overnight audit"`.
+- Commit is blocked in this sandbox because Git cannot create the worktree
+  index lock outside the writable root:
+  `fatal: Unable to create '/Users/jwalinshah/projects/inbox/.git/worktrees/inbox-sym-119-architecture-map/index.lock': Operation not permitted`.
+
+Expected final state after a human or runner with git metadata write access
+commits this report:
+
+- No product code changed.
+- No generated data changed.
+- No external service touched.
+- `git status --short` should be clean after the report commit.

--- a/docs/overnight/inbox-sym-119-docs-claims.md
+++ b/docs/overnight/inbox-sym-119-docs-claims.md
@@ -1,0 +1,147 @@
+# Deep Docs-Claims Audit: inbox-sym-119
+
+Date: 2026-05-07
+Queue item: `inbox-sym-119-docs-claims`
+Focus area: `docs-claims`
+Repo path: `/Users/jwalinshah/projects/agent-stack/.agent-stack-worktrees/2026-05-07-overnight-marathon/inbox-sym-119-docs-claims`
+
+## Scope And Decisions
+
+This audit only inspected local files and wrote this report. It did not run the app, start local services, touch product code, use credentials, call external APIs, create a PR, or update any tracker state.
+
+I treated docs claims as supported only when there was local code, tests, configuration, or command output behind them. Claims that require live Gmail, Google, Apple, GitHub, microphone, OAuth, or deployed MCP behavior are marked as not locally proven unless tests or static evidence cover the contract.
+
+## Repo Purpose And State
+
+The repo is a local-first personal inbox and productivity control plane. `README.md` describes a privacy-first Textual TUI that consolidates iMessage, Gmail, Google Calendar, Google Sheets, Apple Notes, Apple Reminders, GitHub notifications, and Google Drive behind a local FastAPI server. `PLAN.md` narrows the current product phase to Gmail, iMessage/SMS, calendar context, a local FastAPI server, a local SQLite operational index, and the TUI.
+
+Branch and dirty state:
+- `git branch --show-current` returned `codex/goal-inbox-sym-119-docs-claims`.
+- `git rev-parse HEAD` returned `2805b8400519da188ca7d3f6e39b19a8ca42b05a`.
+- Initial `git status --short` returned no output, so the worktree was clean before this report.
+- After this report is written, the expected dirty state is one untracked report file under `docs/overnight/`.
+
+## Commands Run
+
+- `llm-tldr tree .` - mapped the repo structure.
+- `git status --short` - confirmed initial clean state.
+- `git branch --show-current` - confirmed the queue branch.
+- `git rev-parse HEAD` - captured the handoff commit SHA.
+- `rtk read README.md DOCS_INDEX.md CLAUDE.md docs/TESTING_FOR_AGENTS.md` - reviewed top-level docs and test guidance.
+- `rtk read SHEETS.md SHEETS_QUICKSTART.md SHEETS_CHANGELOG.md MCP_SETUP.md MCP_V1_PLAN.md CONNECTOR_ROADMAP.md` - reviewed feature, setup, and roadmap claims.
+- `rg --count-matches "^[[:space:]]*def test_" tests test_autocomplete_dev.py` - counted checked-in test functions by file; summed total is 864, not the documented 736.
+- `rg -n "@app\.(get|post|put|delete|patch).*" inbox_server.py` - checked documented endpoint surface against FastAPI route declarations.
+- `rg -n "_assert_live_write_allowed|sheets_rename_sheet|sheets_format|docs_insert_text" services.py tests docs/TESTING_FOR_AGENTS.md` - checked the live-write blocking claim.
+- `rg --files -g '*.md'` - checked documentation inventory against `DOCS_INDEX.md`.
+- `rg --files -g '.claude/**' -g '.mcp.json' -g '.cursor/**'` - checked local MCP/skill files; only `.mcp.json` was present.
+
+## Supported Claims
+
+The client-server architecture claim is well supported. `inbox_server.py` declares the FastAPI app and a broad route surface, `inbox_client.py` is the sync HTTP client, `mcp_backend.py` calls the HTTP API, and `inbox.py` is the Textual TUI.
+
+The Google Sheets API claim is substantially supported at the server and service layer. `inbox_server.py` exposes `/sheets` CRUD, value, tab, copy, and format endpoints. `services.py` implements `sheets_list`, `sheets_get`, `sheets_create`, values read/write/batch/append/clear, tab add/delete/rename/copy, and formatting.
+
+The Google Docs API claim is supported by code, though it is less visible in user-facing docs than Sheets. `inbox_server.py` exposes `/docs`, `/docs/{id}`, `/docs/{id}/text`, `/docs/{id}/export`, and `/docs/workflow-doc`. `services.py` implements `docs_list`, `docs_get`, `docs_create`, `docs_delete`, `docs_export`, `docs_insert_text`, and `docs_get_text`.
+
+The MCP split is supported. `MCP_SETUP.md` describes private backend, full MCP gateway, readonly HTTP gateway, stdio entrypoints, and readonly stdio. The local files exist: `mcp_server.py`, `inbox_mcp_readonly.py`, `inbox_mcp_stdio.py`, `inbox_mcp_readonly_stdio.py`, `mcp_gateway.py`, `.mcp.json`, and scripts under `scripts/`.
+
+The token-auth claim is supported. `inbox_server.py` reads `INBOX_SERVER_TOKEN` and accepts Bearer or `X-API-Key`; `mcp_gateway.py` reads `INBOX_MCP_TOKEN`; `config/inbox.env.example` distinguishes server and MCP tokens; `MCP_SETUP.md` tells users not to reuse them.
+
+The secrets-are-gitignored claim is supported. `.gitignore` excludes `credentials.json`, `token.json`, `tokens/`, `github_token.txt`, `google_maps_key.txt`, `gemini_api_key.txt`, `config/inbox.env`, local SQLite state, coverage, server logs, and batch output state.
+
+The worktree dev routing guidance is supported. `CLAUDE.md` documents primary port 9849 and dev port 9850, and `dev.sh` actually defaults `INBOX_SERVER_PORT=9850` and derives `INBOX_SERVER_URL` from it.
+
+The safer agent-test-mode direction is partially supported. `docs/TESTING_FOR_AGENTS.md` defines `INBOX_TEST_MODE=1` and safe markers. `inbox_test_mode.py` implements `assert_live_writes_allowed`. Many mutating functions in `services.py` call `_assert_live_write_allowed`, and `tests/test_services.py` covers representative write guards.
+
+The TUI key map is test-backed for newer tabs. `inbox.py` binds `ctrl+6` to Reminders, `ctrl+7` to GitHub, `ctrl+8` to Drive, and `ctrl+shift+6` to Ambient. `tests/test_inbox_app.py` has explicit tests for `ctrl+6`, `ctrl+7`, and `ctrl+8`.
+
+## Unsupported Or Stale Claims
+
+`README.md` says Python 3.10+ is required, but `pyproject.toml` requires `>=3.12,<3.15`. The docs should advertise Python 3.12+ unless the package metadata changes.
+
+`DOCS_INDEX.md` and `SHEETS_CHANGELOG.md` claim "All 736 tests pass" and "production-ready." The checked-in test function count from `rg --count-matches "^[[:space:]]*def test_" tests test_autocomplete_dev.py` sums to 864. That is not the same as pytest collection count, but it is enough to show the hard-coded 736 claim is stale. I did not run the full suite.
+
+`DOCS_INDEX.md` says total documentation is 6 files. `rg --files -g '*.md'` returned 18 markdown files, including `PLAN.md`, `MCP_SETUP.md`, `MCP_V1_PLAN.md`, `CONNECTOR_ROADMAP.md`, `docs/TESTING_FOR_AGENTS.md`, mode prompts, and config profile docs. The index is no longer complete.
+
+`README.md` claims `Ctrl+6` toggles ambient listening. `inbox.py` binds `ctrl+6` to Reminders and `ctrl+shift+6` to Ambient. `tests/test_inbox_app.py` verifies `ctrl+6` switches to Reminders. `README.md` is stale here.
+
+`CLAUDE.md` says slash commands are routed by `.claude/skills/inbox/SKILL.md`, but `rg --files -g '.claude/**'` found no `.claude` skill tree because `.claude/` is gitignored. The mode prompt files exist under `modes/`, and `batch/batch-runner.sh` exists, but the slash-command router claim is not supported by tracked files in this worktree.
+
+The privacy claim in `README.md` is too broad. The local ML claim is supported by MLX dependencies and local model code, but "All data processing happens on-device" and "no cloud syncing" are misleading for a repo whose source adapters call Google Gmail, Calendar, Drive, Sheets, Docs, Tasks, GitHub, optional Google Maps, and optional Gemini. `services.py` imports Google API clients, `httpx`, and has Gemini functions using `gemini_api_key.txt`.
+
+The test-mode docs overclaim write blocking. `services.py` guards many writes, but `sheets_rename_sheet`, `sheets_format`, `sheets_copy_to`, and `docs_insert_text` do not call `_assert_live_write_allowed`. Their HTTP endpoints in `inbox_server.py` are direct mutations. `tests/test_services.py` covers some representative writes, not all mutating surfaces.
+
+The "full API coverage" Sheets language is stronger than the implementation evidence. The code covers many practical spreadsheet operations, including raw `batchUpdate` formatting, but it does not expose every Google Sheets API concept as first-class endpoints. The docs should say "broad Sheets CRUD, values, tab, copy, and raw formatting support."
+
+`PLAN.md` says the phase is intentionally narrow and excludes a general-purpose personal agent platform, while `README.md`, `CLAUDE.md`, `MCP_SETUP.md`, and `CONNECTOR_ROADMAP.md` describe a much broader connector platform with Drive, Sheets, Docs, Tasks, GitHub, MCP, memory, and workflow tools. That may reflect real evolution, but the docs do not clearly mark which document is current.
+
+## Risks And Stale Assumptions
+
+1. Safety documentation does not match the mutation surface. Agent-safe test mode can still miss direct HTTP mutations for sheet rename/copy/format and doc text insertion. This is a concrete risk for local agents because the repo handles personal data and external write APIs.
+
+2. Onboarding instructions can fail on Python version. A user following `README.md` with Python 3.10 will not satisfy `pyproject.toml`. This is a low-effort docs fix but high-friction if left stale.
+
+3. Production-readiness claims are unverifiable from current docs. The hard-coded 736 count is stale, the full suite was not run in this audit, and only two files are globally marked `safe`.
+
+4. Privacy wording may cause wrong operator expectations. The repo is local-first, but it intentionally reads and mutates cloud providers. The README should distinguish local UI/ML processing from provider API calls and remote writes.
+
+5. Slash-command documentation references a gitignored, absent tracked router path. A future agent may waste time looking for `.claude/skills/inbox/SKILL.md` instead of using tracked `modes/` files and MCP/tool registry surfaces.
+
+6. Multiple "source of truth" docs disagree. `PLAN.md` describes a narrow phase, `CONNECTOR_ROADMAP.md` describes the next connector platform, and `README.md` presents the broadest feature set as current. Morning review should choose a docs hierarchy.
+
+## Non-Claims And Unknowns
+
+This audit does not prove that live Gmail, Calendar, Drive, Sheets, Docs, Tasks, GitHub, Apple Notes, iMessage, Reminders, microphone, or MCP gateway flows work on this machine. I did not start `inbox_server.py`, authenticate accounts, use OAuth tokens, or call providers.
+
+This audit does not prove current pytest pass/fail status. I counted test functions and inspected targeted tests, but did not run the full suite or safe suite.
+
+This audit does not verify UI rendering in Textual, browser behavior, voice/dictation hardware behavior, or local ML model load behavior.
+
+This audit does not compare sibling repos because this repo is not small and the docs-claims surface was already broad enough for the slice.
+
+## Next Safe Work
+
+1. Reconcile docs version and test-count claims.
+   Acceptance criteria: `README.md` matches `pyproject.toml` on Python support; `DOCS_INDEX.md` removes hard-coded "736 pass" and "6 files" claims or replaces them with generated/current statements; no docs claim "production-ready" unless backed by a fresh validation artifact.
+   Validation: `uv run pytest --collect-only -q` expected to pass and provide the current collection count; `git diff -- README.md DOCS_INDEX.md SHEETS_CHANGELOG.md` expected to show docs-only changes.
+
+2. Close agent-safe write-guard gaps.
+   Acceptance criteria: `sheets_rename_sheet`, `sheets_format`, `sheets_copy_to`, and `docs_insert_text` call `_assert_live_write_allowed`; tests prove `INBOX_TEST_MODE=1` blocks each direct service mutation before mocked API calls execute.
+   Validation: `INBOX_TEST_MODE=1 uv run pytest tests/test_services.py -q -k "test_mode_blocks"` expected to pass after the fix; new focused tests should fail before the guard additions.
+
+3. Update TUI key-binding docs from code.
+   Acceptance criteria: `README.md` and `CLAUDE.md` list `Ctrl+6` as Reminders, `Ctrl+7` as GitHub, `Ctrl+8` as Drive, and `Ctrl+Shift+6` as Ambient; no stale Ambient-on-`Ctrl+6` claim remains.
+   Validation: `INBOX_TEST_MODE=1 uv run pytest tests/test_inbox_app.py -q -k "ctrl6 or ctrl7 or ctrl8"` expected to pass.
+
+4. Clarify privacy and cloud-provider boundaries.
+   Acceptance criteria: README privacy section distinguishes local storage/ML from OAuth-backed Google/GitHub/Maps/Gemini provider calls; docs explicitly identify which operations are local-only, provider reads, provider writes, and optional cloud AI.
+   Validation: `rg -n "All data processing happens on-device|no cloud syncing|Gemini|Google Maps|Google API" README.md CLAUDE.md services.py` expected to show narrower language.
+
+5. Replace absent slash-router claim with tracked entrypoints.
+   Acceptance criteria: `CLAUDE.md` either tracks an actual `.claude/skills/inbox/SKILL.md` in repo or describes the tracked `modes/`, `batch/batch-runner.sh`, `tools_registry.py`, and MCP entrypoints as the source of slash-command behavior.
+   Validation: `rg --files -g '.claude/**' -g 'modes/**' -g 'tools_registry.py' -g 'batch/batch-runner.sh'` expected to match the documented paths.
+
+## Validation Candidates
+
+Required queue validation:
+- `git status --short`
+- Expected status: command exits 0. After this report, expected output should show only `?? docs/overnight/inbox-sym-119-docs-claims.md` unless the runner has staged or otherwise moved the report.
+
+Useful follow-up validation:
+- `INBOX_TEST_MODE=1 uv run pytest tests/test_inbox_test_mode.py tests/test_mcp_gateway.py -q`
+- Expected status: pass, proving the currently marked global safe test files still work.
+
+- `INBOX_TEST_MODE=1 uv run pytest tests/test_services.py -q -k "test_mode_blocks"`
+- Expected status today: pass, but incomplete because it does not cover every mutating function listed above.
+
+- `uv run pytest --collect-only -q`
+- Expected status: pass if dependencies are available; expected collection count should be regenerated from pytest rather than hard-coded in docs.
+
+- `uv run ruff check .`
+- Expected status after docs-only changes: pass or unchanged from baseline.
+
+## Handoff Notes
+
+Changed files: this report only.
+
+No product code was edited. No validation beyond the required queue command was run in this slice. No PR was created because PR creation is out of scope for the overnight audit queue.

--- a/docs/overnight/inbox-sym-120-architecture-map.md
+++ b/docs/overnight/inbox-sym-120-architecture-map.md
@@ -1,0 +1,313 @@
+# Overnight Architecture Map: inbox-sym-120
+
+Queue item: `inbox-sym-120-architecture-map`
+Repo: `inbox-sym-120`
+Worktree: `/Users/jwalinshah/projects/agent-stack/.agent-stack-worktrees/2026-05-07-overnight-marathon/inbox-sym-120-architecture-map`
+Branch observed: `codex/goal-inbox-sym-120-architecture-map`
+Initial HEAD observed: `2805b84` (`Merge pull request #34 from jwalin-shah/codex/SYM-9-indexed-defaults`)
+Initial dirty state observed: clean, from `git status --short` producing no output.
+
+## Scope And Method
+
+This is a read-only architecture-map audit. Product code, secrets, generated data, pushes, deploys, external services, tracker updates, and PR creation are out of scope. The only intended repository mutation is this report.
+
+Commands and observations used as evidence:
+
+- `llm-tldr tree .` showed a flat Python repo with top-level modules, `tests/`, `scripts/`, `deploy/`, `config/`, `modes/`, `batch/`, and a single existing docs file before this report: `docs/TESTING_FOR_AGENTS.md`.
+- `git status --short --branch` showed `## codex/goal-inbox-sym-120-architecture-map` and no dirty files at audit start.
+- `git rev-parse --short HEAD` returned `2805b84`.
+- `git log --oneline -5` showed recent work around indexed inbox defaults and sync freshness health.
+- `wc -l *.py tests/*.py` showed `services.py` at 6,467 lines, `inbox.py` at 4,279 lines, `inbox_server.py` at 3,940 lines, and 36,403 Python lines total.
+- `rg -c "^@app\\." inbox_server.py` returned `160`, so the FastAPI surface is broad and route-heavy.
+- `rg -c "^(def|class) " services.py` returned `205`, so the data-access module has a very wide interface.
+- `rg -c "^    Tool\\(" tools_registry.py` returned `60`; `rg -c "readonly=True" tools_registry.py` returned `29`.
+- `fd -H -d 2 -t f . .` showed hidden local configs including `.mcp.json`, `.cursor/mcp.json`, `.factory/services.yaml`, `.env.mcp.example`, and `.gitignore`.
+- `rtk read docs/TESTING_FOR_AGENTS.md` documented the agent-safe command set: `INBOX_TEST_MODE=1 uv run pytest -m safe`, `uv run ruff check .`, and `uv run pyright`.
+
+## Repo Purpose
+
+Inbox is a local-first personal communication and productivity control plane. It combines iMessage, Gmail, Google Calendar, Google Drive, Google Sheets, Google Docs, Google Tasks, Apple Notes, Apple Reminders, GitHub notifications, ambient audio notes, dictation, local LLM features, and MCP access into one local backend plus terminal UI.
+
+The primary production shape is:
+
+```text
+Textual TUI or agent client
+  -> local HTTP client
+  -> FastAPI backend on 127.0.0.1:9849
+  -> provider adapters and local stores
+  -> macOS SQLite stores, Google APIs, GitHub API, local ML, AppleScript
+```
+
+The MCP shape is:
+
+```text
+MCP client
+  -> mcp_server.py or inbox_mcp_readonly.py
+  -> mcp_gateway.py / mcp_backend.py
+  -> private inbox_server.py
+  -> services.py and persistence modules
+```
+
+The repo is not a library-first package. It is a runnable application with several executable surfaces and many provider-specific integrations in the repository root.
+
+## Primary Entrypoints
+
+- `inbox.py` is the Textual TUI entrypoint. Its `InboxApp` class owns UI state, polling, tab switching, command handling, optimistic sends, notifications, and client calls.
+- `inbox_server.py` is the private FastAPI backend entrypoint. It defines Pydantic request/response models, global runtime state, lifecycle setup, schedulers, route handlers, and account routing wrappers.
+- `inbox_client.py` is the synchronous HTTP client used by the TUI and some agent workflows. It also starts `inbox_server.py` as a subprocess if the TUI cannot reach it.
+- `mcp_server.py` is the full MCP HTTP gateway. It has a few hand-written memory and daily-note tools, then registers the shared tool registry with `readonly_only=False`.
+- `inbox_mcp_readonly.py` is the read-only MCP HTTP gateway. It registers only registry tools marked `readonly=True`, plus read-only memory and daily-note tools.
+- `inbox_mcp_stdio.py` and `inbox_mcp_readonly_stdio.py` are small local subprocess wrappers around the HTTP MCP app surfaces.
+- `scripts/run_inbox_backend.sh`, `scripts/run_inbox_mcp_http.sh`, `scripts/run_inbox_mcp_http_readonly.sh`, `scripts/run_inbox_mcp_stdio.sh`, and `scripts/run_inbox_mcp_stdio_readonly.sh` are operational entrypoints.
+- `ambient_daemon.py`, `organize_inbox.py`, `unsubscribe_interactive.py`, `unsubscribe_bulk.py`, and `unsubscribe_all_newsletters.py` are utility entrypoints layered on top of the same backend or service functions.
+- `main.py` is a placeholder that prints `Hello from inbox!`; it is not the real application entrypoint despite being present in a `uv` project.
+
+## Module Map
+
+### Data And Provider Module
+
+`services.py` is the central data and provider module. Its file header explicitly says that all data fetching, auth, mutation, audio, and LLM logic lives there. It imports Google OAuth clients, `httpx`, SQLite, subprocess, threading, contacts, and shared service dataclasses. It defines local paths for `credentials.json`, `tokens/`, `github_token.txt`, `google_maps_key.txt`, `gemini_api_key.txt`, iMessage, Notes, and Reminders.
+
+The module owns these interfaces and implementations:
+
+- Google auth and account token loading via `google_auth_all`, `add_google_account`, and `reauth_google_account`.
+- iMessage listing, thread loading, and AppleScript sending via `imsg_contacts`, `imsg_thread`, and `imsg_send`.
+- Gmail listing, body cleanup, thread loading, reply/send, archive, delete, labels, filters, and search.
+- Calendar events, conflicts, reminders, RSVP, attendees, free/busy, free slots, and recurring instances.
+- Apple Notes, Apple Reminders, WhatsApp Accessibility access, Google Tasks, Gemini helpers, Google Maps, GitHub, Drive, Sheets, Docs, ambient audio, dictation, local LLM, autocomplete, cross-source search, notifications, favorites, contacts, briefing, triage, summarization, and voice-command routing.
+
+Architectural reading: `services.py` is a deep implementation module, but its interface is now too broad. Callers must know provider object ownership, account routing, write safety, local file side effects, optional ML availability, and macOS permission behavior. The module has leverage, but poor locality for a maintainer changing one provider.
+
+### Shared Data Models
+
+`service_models.py` is the pure dataclass model module. It defines `Contact`, `Msg`, `CalendarEvent`, `Note`, `Reminder`, `GoogleTask`, `GitHubNotification`, `DriveFile`, `SheetTab`, `Spreadsheet`, `Document`, and `ThreadSummary`.
+
+This is one of the cleaner modules. It is a small interface with stable data shapes shared by the backend and service functions. The main caveat is that the server separately defines many Pydantic DTOs in `inbox_server.py`, so there are two model layers to keep aligned.
+
+### FastAPI Server Module
+
+`inbox_server.py` is the server and orchestration module. Evidence:
+
+- It imports a large list of functions and classes from `services.py`.
+- It defines many Pydantic request/response models at the top of the file.
+- It defines `ServerState` with Google service dictionaries, conversation cache, event cache, `AmbientService`, `DictationService`, `SchedulerStore`, `MessageIndexStore`, and `SourceAdapters`.
+- It defines `InboxServerRuntime`, which lets tests inject fake state, fake auth, disabled scheduler, disabled ambient autostart, and a SQLite cleanup hook.
+- `create_app(runtime)` builds a new FastAPI app, but then copies routes and middleware from a global existing `app` if present.
+- The route surface is large: 160 route decorators were observed.
+
+The server owns policy-adjacent orchestration, but not consistently. Some account selection is centralized in `google_account_resolution.py`, while route handlers still directly choose services, read global state, and call provider functions.
+
+### TUI Module
+
+`inbox.py` is the Textual app. It contains many UI item classes and a single large `InboxApp` class. The class owns:
+
+- Server boot and auto-start through `InboxClient.ensure_server`.
+- Refresh and poll flows through `_collect_refresh_data`, `_collect_poll_data`, `_collect_auxiliary_data`, `_populate`, and background workers.
+- TUI tab state, sidebar rendering, selection routing, detail rendering, and compose-mode multiplexing.
+- User actions for messages, calendar, reminders, Gmail, GitHub, Drive, search, command palette, briefings, favorites, and AI summaries.
+
+This makes the TUI module a large interface for UI state transitions. It is test-covered, but the core class combines view state, interaction state, API orchestration, and per-provider action behavior.
+
+### HTTP Client Module
+
+`inbox_client.py` is a synchronous `httpx` wrapper. It reads `INBOX_SERVER_PORT`, `INBOX_SERVER_URL`, and `INBOX_SERVER_TOKEN`, constructs an authenticated client, exposes endpoint methods, and can start `inbox_server.py` as a subprocess with `server.log`.
+
+This is a useful seam for the TUI. It is less clearly the agent-facing seam now that MCP has its own `mcp_backend.py` and registry-driven handlers. There is overlap between `InboxClient` methods and `InboxBackend` methods.
+
+### MCP Modules
+
+`tools_registry.py` is a strong newer seam. A `Tool` describes MCP name, HTTP method, path, params, readonly flag, and confirm flag. `register_all` attaches handlers to FastMCP. `tests/test_tools_registry.py` verifies that mutating registry tools require confirmation, read-only registration excludes write tools, path params are URL-encoded, and body params are not URL-encoded.
+
+`mcp_backend.py` is an async HTTP backend for MCP. It also still carries many hand-written methods that mirror routes. `tools_registry.py` handlers bypass those methods and call `_request` directly, which means old backend convenience methods and registry entries can drift unless tests intentionally cover both.
+
+`mcp_gateway.py` provides Starlette app assembly, bearer auth for public MCP, health, backend creation, and memory-store creation.
+
+`mcp_server.py` and `inbox_mcp_readonly.py` are thin gateway compositions with different write exposure. This is a good separation, but the docs have older and newer claims that do not fully agree with the current registry.
+
+### Persistence And Index Modules
+
+`memory_store.py` is a local SQLite memory store with a separate `INBOX_MEMORY_DB` override in `mcp_gateway.py`.
+
+`scheduler.py` owns `.inbox_scheduler.sqlite3` and models scheduled messages, followup reminders, and task-message links. `inbox_server.py` owns the runtime scheduler loop that calls this store and provider functions every 30 seconds.
+
+`message_index_store.py` owns `.inbox_index.sqlite3`, sync state, indexed items, threads, and sender stats. It sets WAL mode and migrates schema in place.
+
+`message_sync.py` fills the index from Gmail and iMessage. It imports `IMSG_DB`, `_clean_body`, `_decode_body`, `_parse_email_address`, and `google_auth_all` from `services.py`, so indexing is coupled to the broad service module rather than to a narrow source adapter interface.
+
+`gmail_triage.py` owns workflow classification, action extraction, ranking, summaries, and Pydantic thread summary output. It imports `Contact` and `ThreadSummary` from `services.py`, where those names are re-exported from `service_models.py`.
+
+### Config, Deployment, And Local State
+
+- `README.md`, `CLAUDE.md`, `MCP_SETUP.md`, `CONNECTOR_ROADMAP.md`, `DOCS_INDEX.md`, and Sheets docs are the main architecture docs.
+- `.mcp.json` and `.cursor/mcp.json` point both full and read-only local MCP stdio servers at `http://127.0.0.1:9849`.
+- `dev.sh` defaults development worktrees to port `9850` and derives `INBOX_SERVER_URL`.
+- `.factory/services.yaml` starts the service from `/Users/jwalinshah/projects/inbox`, not from the current worktree. This is consistent for a primary checkout, but risky in worktree testing.
+- `.gitignore` correctly ignores credentials, token files, logs, `.inbox_memory.sqlite3`, `.inbox_scheduler.sqlite3`, and `.inbox_index.sqlite3`.
+- `deploy/Caddyfile.example` exposes only `/health` and `/mcp` for full and read-only MCP gateways.
+
+## Key Seams
+
+1. TUI-to-server seam: `InboxClient` hides HTTP details from `InboxApp`, including auth headers and server boot.
+2. Server-to-provider seam: currently mostly direct calls from `inbox_server.py` into `services.py`.
+3. Google account-routing seam: `google_account_resolution.py` is a narrower policy module shared by server and tests.
+4. MCP tool-definition seam: `tools_registry.py` centralizes tool exposure and read/write gating.
+5. MCP transport seam: `mcp_gateway.py` creates Starlette apps and public auth independent of tool definitions.
+6. Persistence seams: `SchedulerStore`, `MemoryStore`, and `MessageIndexStore` isolate local SQLite schemas.
+7. Test-mode seam: `inbox_test_mode.py` redirects local data paths and blocks live writes when `INBOX_TEST_MODE=1`.
+8. Runtime injection seam: `InboxServerRuntime` allows server tests to bypass real auth, real contacts, scheduler, and ambient autostart.
+
+## Risks And Stale Assumptions
+
+### Risk 1: `services.py` Is Too Broad For Safe Change Locality
+
+The module has 205 top-level definitions and owns most provider behavior. The deletion test says this module is not shallow because deleting it would scatter real complexity. The problem is that its public interface is nearly as broad as the implementation: the server must know specific provider functions, account service objects, local file assumptions, and mutation semantics.
+
+Why it matters: changes to one provider can accidentally affect import-time behavior, test stubs, write safety, or unrelated providers. New agents will tend to patch in place rather than identify the right source adapter.
+
+### Risk 2: Server Global State And App Factory Are Coupled
+
+`inbox_server.py` creates a global `state = ServerState()` and `app = create_app()`. `make_lifespan` swaps global state when a runtime is injected. `create_app(runtime)` copies routes from an existing global `app` into the new app.
+
+Why it matters: this makes test isolation possible, but the interface is subtle. Future route registration, middleware changes, or multiple app instances can behave differently depending on import order and prior global state.
+
+### Risk 3: MCP Documentation Is Partly Behind The Tool Surface
+
+`MCP_V1_PLAN.md` says Calendar stays on a built-in ChatGPT connector and destructive mail actions/deletes stay out of scope in v1. Current `tools_registry.py` exposes calendar and many mutation tools behind confirmation, including delete-style actions for tasks, Drive files, Docs, Sheets, and GitHub notifications.
+
+Why it matters: morning reviewers or external agents reading the plan may underestimate the live write surface. `MCP_SETUP.md` appears newer and more accurate than `MCP_V1_PLAN.md`.
+
+### Risk 4: Worktree Routing Can Silently Hit The Primary Backend
+
+Docs repeatedly warn that dev worktrees must set both `cwd` and `INBOX_SERVER_URL`. `.mcp.json`, `.cursor/mcp.json`, and `.factory/services.yaml` all point at primary `9849` or `/Users/jwalinshah/projects/inbox`.
+
+Why it matters: an agent in a worktree can believe it is testing local changes while the MCP or factory service is still talking to the daily-driver checkout.
+
+### Risk 5: Test Documentation Overstates The Safe Test Surface
+
+`docs/TESTING_FOR_AGENTS.md` says to run `INBOX_TEST_MODE=1 uv run pytest -m safe`, but `rg` only found module-level `pytestmark = pytest.mark.safe` in `tests/test_inbox_test_mode.py` and `tests/test_mcp_gateway.py`. Many deterministic unit tests appear unmarked. `DOCS_INDEX.md` also claims `uv run pytest` has 736 passing tests; this audit did not run that suite, and the claim is date-sensitive.
+
+Why it matters: agents following the safe command may get a narrow safety check while believing they proved the full deterministic surface.
+
+### Risk 6: Optional Experimental Surface Is Hidden In The Server
+
+`inbox_server.py` exposes `/query`, which imports `gemma4_hackathon` dynamically and returns 503 if missing. This dependency is not listed in `pyproject.toml`.
+
+Why it matters: it is fine as an optional experiment, but it is not visible in the main architecture docs or dependency surface. It adds another source of route ownership and runtime behavior.
+
+### Risk 7: Two HTTP Client Abstractions Can Drift
+
+`InboxClient` is the TUI/client wrapper. `InboxBackend` is the MCP wrapper. `tools_registry.py` now builds handlers that call `InboxBackend._request` directly, while `InboxBackend` also contains older named methods. This is manageable, but it is a drift risk.
+
+Why it matters: a backend method can be fixed without fixing the registry path, or a new endpoint can be added to the registry without a corresponding ergonomic client method.
+
+## Existing Strengths
+
+- The HTTP API seam is real. The TUI does not directly read Gmail, iMessage, or local databases.
+- `service_models.py` is small and stable.
+- `google_account_resolution.py` is a good example of extracting policy from route handlers.
+- `tools_registry.py` is a good example of turning a broad MCP surface into data, with tests proving confirmation and readonly behavior.
+- `InboxServerRuntime` gives tests a practical way to run the server without live auth and background loops.
+- `inbox_test_mode.py` and `docs/TESTING_FOR_AGENTS.md` show an explicit safety model for agents.
+- `.gitignore` covers the highest-risk local secrets and generated SQLite files.
+- `MCP_SETUP.md` documents a safer remote topology: expose MCP, keep the private backend loopback-only, prefer read-only MCP for cloud agents.
+
+## Next Safe Work
+
+### Task 1: Split The Provider Ownership Map Out Of `services.py`
+
+Acceptance criteria:
+
+- Add a docs-only ownership map listing each provider area in `services.py`, the current public functions, mutation functions, local side effects, and tests covering it.
+- Do not move code in this task.
+- Identify the first two low-risk provider modules that could later be extracted behind source adapters.
+
+Validation candidates:
+
+- `git status --short` should show only the new docs file while drafting or be clean after commit.
+- `uv run ruff check .` expected to pass because no Python changes are needed.
+
+### Task 2: Reconcile MCP Docs Against `tools_registry.py`
+
+Acceptance criteria:
+
+- Update or supersede `MCP_V1_PLAN.md` so it no longer claims calendar and destructive actions are out of scope if the current registry intentionally exposes them behind confirmation.
+- Add a generated or manually checked table of registry tool counts: total, readonly, mutating, confirmation-gated.
+- State which doc is authoritative: `MCP_SETUP.md`, the registry, or a new ADR.
+
+Validation candidates:
+
+- `uv run pytest tests/test_tools_registry.py -q` expected to pass.
+- `uv run ruff check tools_registry.py mcp_server.py inbox_mcp_readonly.py` expected to pass.
+
+### Task 3: Make App Factory State Less Surprising
+
+Acceptance criteria:
+
+- Document and then simplify the `create_app(runtime)` route-copying pattern, or add tests that prove multiple app instances do not duplicate routes or share unexpected mutable state.
+- Keep `InboxServerRuntime` as the test injection interface.
+- Preserve existing TestClient fixtures.
+
+Validation candidates:
+
+- `INBOX_TEST_MODE=1 uv run pytest tests/test_server.py tests/test_conversations_latency.py -q` expected to pass.
+- `uv run pyright` may expose existing type debt; if so, record the current baseline rather than expanding the task.
+
+### Task 4: Mark The Deterministic Safe Test Surface Deliberately
+
+Acceptance criteria:
+
+- Audit tests that do not touch live personal data or external writes and add `safe` markers or a repo-level marker strategy.
+- Keep local-data, live-write, slow, and ML/hardware tests opt-in.
+- Update `docs/TESTING_FOR_AGENTS.md` so `pytest -m safe` has clear coverage expectations.
+
+Validation candidates:
+
+- `INBOX_TEST_MODE=1 uv run pytest -m safe -q` expected to pass and collect a meaningful subset.
+- `INBOX_TEST_MODE=1 uv run pytest tests/test_inbox_test_mode.py tests/test_mcp_gateway.py -q` expected to pass as the current known safe subset.
+
+### Task 5: Add A Worktree Routing Self-Check
+
+Acceptance criteria:
+
+- Add a read-only endpoint or script that reports current repo path, branch, backend URL, and whether MCP is pointed at the same worktree.
+- Do not expose secrets.
+- Make the check easy for agents to run before exercising a dev backend.
+
+Validation candidates:
+
+- `uv run pytest tests/test_mcp_gateway.py tests/test_client.py -q` expected to pass if the check stays outside product routes.
+- If adding a server endpoint, also run `INBOX_TEST_MODE=1 uv run pytest tests/test_server.py -q`.
+
+## Validation Candidates For This Repo
+
+Observed authoritative docs list these commands:
+
+- Required queue validation: `git status --short`. Expected status for this report after commit: exit 0 and no output. If left uncommitted, expected output is only `?? docs/overnight/inbox-sym-120-architecture-map.md`.
+- Agent-safe default: `INBOX_TEST_MODE=1 uv run pytest -m safe`. Expected to pass for the currently marked safe tests, but likely narrower than the repo's deterministic test surface.
+- Lint: `uv run ruff check .`. Expected to pass based on repo docs, not executed during this audit.
+- Type check: `uv run pyright`. Expected status unknown because pyright was not executed during this audit.
+- Full tests: `uv run pytest`. Expected status unknown and potentially expensive because it spans provider-heavy modules, though tests stub many heavy dependencies.
+- Factory command: `.factory/services.yaml` defines `uv run pytest --ignore=tests/test_audio.py --ignore=tests/test_llm.py -x -q`. Expected status unknown and path-sensitive because the service config is hardcoded to the primary checkout.
+
+## Non-Goals
+
+- No product-code refactor.
+- No test, lint, or type-fix implementation.
+- No live server start.
+- No OAuth, Gmail, Calendar, Drive, Docs, Sheets, Tasks, GitHub, iMessage, Notes, Reminders, microphone, dictation, desktop notification, or AppleScript operation.
+- No external tracker update.
+- No push, deploy, or PR creation.
+- No sibling-repo comparison. The repo is large enough for the architecture-map scope; sibling comparison would be a separate queue item.
+
+## Unknowns
+
+- Whether the full test suite currently passes. This audit did not run it because the queue validation command is `git status --short` and the goal scope is read-only architecture mapping.
+- Whether the daily-driver backend on port 9849 was running or healthy. This audit intentionally did not call it.
+- Whether local credentials and token files exist in the primary checkout. They are intentionally ignored and were not inspected.
+- Whether `gemma4_hackathon` is installed in any local developer environment.
+- Whether the docs claim of 736 passing tests is still accurate on May 7, 2026.
+- Whether the current MCP write surface is intentional v1 scope or accumulated implementation drift.
+
+## Handoff Notes
+
+The best next architectural move is not a broad extraction. The safer first move is to document provider ownership in `services.py`, then extract one or two policy modules like `google_account_resolution.py` where tests already show value. The highest-leverage documentation cleanup is reconciling `MCP_V1_PLAN.md` against the live registry so future agents do not reason from a stale write-surface model.

--- a/docs/overnight/inbox-sym-120-docs-claims.md
+++ b/docs/overnight/inbox-sym-120-docs-claims.md
@@ -1,0 +1,254 @@
+# Overnight Docs Claims Audit: inbox-sym-120
+
+Queue item: `inbox-sym-120-docs-claims`
+Focus area: `docs-claims`
+Repo path: `/Users/jwalinshah/projects/agent-stack/.agent-stack-worktrees/2026-05-07-overnight-marathon/inbox-sym-120-docs-claims`
+Branch: `codex/goal-inbox-sym-120-docs-claims`
+Base HEAD before report: `2805b8400519da188ca7d3f6e39b19a8ca42b05a`
+
+## Purpose And Current State
+
+This repo is a local-first personal inbox system: a Textual TUI and FastAPI
+backend that unify Gmail, iMessage, Calendar, local Apple data stores, GitHub,
+Drive, Sheets, Docs, Tasks, audio/LLM helpers, MCP surfaces, and an indexed
+operational inbox. The product direction in `PLAN.md` is narrower than several
+top-level feature claims: Phase 1 is explicitly inbox-only and index-driven, not
+a general personal memory or broad connector platform.
+
+The worktree started on the expected goal branch. Initial `git status --short
+--branch` showed only:
+
+```text
+## codex/goal-inbox-sym-120-docs-claims
+```
+
+During audit, local validation probes created ignored artifacts only:
+`.venv/`, `.coverage`, and `.pytest_cache/`. A local commit was attempted, but
+git metadata for this worktree points outside the writable root, so the report
+must remain as an uncommitted docs-only file in this sandbox.
+
+## Commands Run
+
+- `llm-tldr tree .` - mapped repo structure and confirmed docs/code/test layout.
+- `git status --short --branch` - confirmed branch and initial clean tracked state.
+- `git rev-parse --show-toplevel && git rev-parse --abbrev-ref HEAD && git rev-parse HEAD` - captured repo root, branch, and base SHA.
+- `rg --files -g '*.md'` - found 18 markdown files, not the six claimed by `DOCS_INDEX.md`.
+- `rtk read README.md`, `rtk read DOCS_INDEX.md`, `rtk read CLAUDE.md`, `rtk read SHEETS*.md`, `rtk read MCP_SETUP.md`, `rtk read docs/TESTING_FOR_AGENTS.md` - reviewed user-facing docs.
+- `rg -n "^@app\.(get|post|put|delete|patch)" inbox_server.py | wc -l` - found 159 FastAPI route decorators.
+- `rg -n "^(GET|POST|PUT|DELETE|PATCH) +/" README.md CLAUDE.md SHEETS.md SHEETS_QUICKSTART.md modes/_shared.md MCP_V1_PLAN.md | wc -l` - counted 119 documented endpoint lines across docs.
+- `UV_CACHE_DIR=/private/tmp/inbox-sym-120-uv-cache INBOX_TEST_MODE=1 uv run pytest --collect-only -q` - collected 866 tests after first run failed on the default uv cache permission.
+- `UV_CACHE_DIR=/private/tmp/inbox-sym-120-uv-cache INBOX_TEST_MODE=1 uv run pytest -m safe -q` - passed 11 safe tests, 855 deselected.
+- `uv run python -V` - created the ignored `.venv/` and reported Python 3.12.12.
+- `git status --short --ignored=matching` - showed only ignored `.coverage`, `.pytest_cache/`, and `.venv/` artifacts before report write.
+- `git add docs/overnight/inbox-sym-120-docs-claims.md && git commit -m "Add inbox docs claims audit"` - failed because the sandbox cannot create `/Users/jwalinshah/projects/inbox/.git/worktrees/inbox-sym-120-docs-claims/index.lock`.
+
+## Supported Claims
+
+The client-server architecture claim is supported. `README.md` describes a
+FastAPI backend plus thin clients, and `inbox_server.py` defines the FastAPI app
+and routes while `inbox_client.py` reads `INBOX_SERVER_URL` and
+`INBOX_SERVER_TOKEN`.
+
+The macOS local data-source claims are substantially supported. `services.py`
+points iMessage, Notes, Reminders, AddressBook, credential, token, GitHub token,
+Gemini key, and Google Maps key paths at local files or user-library locations.
+Apple Reminders scan multiple `Data-*.sqlite` databases and list data via SQLite.
+
+The broad Google integration claim is supported at the code level. `services.py`
+defines OAuth scopes for Gmail readonly/modify/send/settings, Calendar, Drive,
+Sheets, Docs, and Tasks, and `google_auth_all()` builds six service maps:
+Gmail, Calendar, Drive, Sheets, Docs, and Tasks.
+
+The Sheets API exists locally. `services.py` implements list/get/create/delete,
+value get/update/append/clear, batch get/update, tab add/delete/rename/copy, and
+formatting helpers, while `inbox_server.py` exposes corresponding `/sheets`
+routes.
+
+The MCP setup guide is mostly aligned with current code. `MCP_SETUP.md`
+correctly separates private REST backend, full HTTP MCP, read-only HTTP MCP,
+full stdio entrypoint, and read-only stdio entrypoint. `mcp_server.py` is an
+HTTP gateway and `inbox_mcp_stdio.py` is the stdio wrapper.
+
+Secret-file claims are supported. `.gitignore` excludes `credentials.json`,
+`token.json`, `tokens/`, `github_token.txt`, `google_maps_key.txt`,
+`gemini_api_key.txt`, `config/inbox.env`, `.env*`, `.inbox_memory.sqlite3`,
+`.inbox_scheduler.sqlite3`, and `.inbox_index.sqlite3`.
+
+The test-mode documentation has a real implementation. `inbox_test_mode.py`
+raises `LiveWriteBlocked` when `INBOX_TEST_MODE` is enabled, and
+`docs/TESTING_FOR_AGENTS.md` documents the safe loop and live-write opt-in rule.
+The safe test slice passed locally.
+
+The newer index-driven product direction is supported by local code. `PLAN.md`
+describes a local SQLite operational index, and `inbox_server.py` exposes
+`/index/status`, `/index/health`, `/index/views/{view_name}`, and sync endpoints.
+
+## Unsupported Or Stale Claims
+
+1. `README.md` says Python 3.10+ is sufficient, but `pyproject.toml` requires
+   `>=3.12,<3.15` and configures Ruff/Pyright for Python 3.12. The local
+   interpreter used by uv is Python 3.12.12. Update docs to Python 3.12+.
+
+2. `DOCS_INDEX.md` says "Total documentation: 6 files" and repeatedly frames
+   Sheets docs as the only new docs. `rg --files -g '*.md'` found 18 markdown
+   files, including MCP setup, connector roadmap, testing, modes, and plan docs.
+
+3. `DOCS_INDEX.md` and `SHEETS_CHANGELOG.md` claim "All 736 tests pass." Local
+   collection found 866 tests, and this audit did not run the full suite. The
+   only executed test command was the safe slice: 11 passed, 855 deselected.
+
+4. `README.md` keybindings are stale. It says `Ctrl+6` toggles ambient
+   listening, but `inbox.py` binds `Ctrl+6` to Reminders and `Ctrl+Shift+6` to
+   ambient. It omits `Ctrl+8` Drive, `Ctrl+9` Actionable, `Ctrl+0` Waiting On,
+   `Ctrl+P` command palette, `Ctrl+\` search, `Ctrl+Shift+A` re-auth,
+   `Ctrl+D` delete event, `Ctrl+G` date jump, and `Ctrl+B` briefing.
+
+5. The README API reference is a quick reference, but it says "All endpoints
+   available" above a partial list. Code currently has 159 route decorators.
+   Missing or under-documented surfaces include Tasks, Docs, WhatsApp, scheduled
+   messages, followups, task links, contacts, memory extraction, indexed views,
+   workflow object creation, free/busy, conflicts, and several Gmail actions.
+
+6. `CLAUDE.md` claims a complete endpoint list, but its endpoint block is also
+   stale. It documents `POST /preflight/write`, while code exposes
+   `GET /preflight/google-write`. It does not include many current `/tasks`,
+   `/whatsapp`, `/index`, `/memory`, and workflow endpoints.
+
+7. `CLAUDE.md` says `mcp_server.py` is stdio-based. Current code has
+   `mcp_server.py` as the HTTP gateway (`stateless_http=True`) and
+   `inbox_mcp_stdio.py` as the stdio transport wrapper.
+
+8. `CLAUDE.md` says MCP exposes all inbox functionality. The registry exposes a
+   curated subset, not all 159 REST routes. For example, Sheets MCP tools include
+   list/read/create/append, but not every REST Sheets operation.
+
+9. The privacy/ML wording is too broad. README says no cloud dependencies and
+   no API calls for ASR or LLM, but `pyproject.toml` includes
+   `google-generativeai`, `services.py` has a Gemini API key file/env path, and
+   `inbox_server.py` exposes Gemini-backed AI endpoints. The local ML path is
+   real, but the docs should call Gemini an optional cloud backend instead of
+   claiming no cloud dependency unqualified.
+
+10. Sheets docs overclaim "any operation available in Sheets API" and
+    "production-ready." The local API covers many high-value operations and raw
+    formatting passthrough, but it is not a complete Google Sheets API wrapper.
+    `SHEETS_CHANGELOG.md` also says Sheets functionality is not directly tested
+    in the suite.
+
+11. The test-mode docs say live writes are blocked through
+    `assert_live_writes_allowed`, but coverage is partial. Representative tests
+    cover one Sheets value update, while `sheets_rename_sheet`,
+    `sheets_format`, and `sheets_copy_to` do not call `_assert_live_write_allowed`
+    before using the Google Sheets API.
+
+12. "All mutations return operation stats" is not accurate for Sheets. Some
+    mutation helpers return booleans or objects instead of stats: delete/clear
+    return `ok`, tab add/copy return `SheetTab`, and create returns metadata.
+
+## Risks And Stale Assumptions
+
+1. Agent safety risk: docs imply `INBOX_TEST_MODE=1` blocks live writes, but
+   several Sheets mutation helpers bypass that guard. A safe test run could miss
+   live mutation paths if a future test or agent hits rename, formatting, or tab
+   copy with a real service.
+
+2. User setup risk: README's Python 3.10+ claim can send users into an
+   unsupported interpreter. The package metadata and tooling require Python
+   3.12+, so install failures or type/runtime differences are likely on 3.10.
+
+3. Operational risk: endpoint docs do not match the actual server surface.
+   Agents following README or CLAUDE may miss safer indexed endpoints, use the
+   wrong preflight route, or attempt stale keybindings/workflows.
+
+4. Security communication risk: the privacy section does not distinguish local
+   ML from optional Gemini-backed cloud AI. That can mislead a reviewer about
+   when text leaves the machine.
+
+5. MCP handoff risk: CLAUDE's transport description contradicts MCP_SETUP and
+   code. A worker may configure `mcp_server.py` as a local stdio process instead
+   of using `inbox_mcp_stdio.py`.
+
+6. Test-claims risk: docs advertise a specific passing test count. The repo has
+   since changed to 866 collected tests, and only the safe slice was executed in
+   this audit.
+
+## Validation Map And Expected Status
+
+- `git status --short` - required queue validation. Expected exit code 0 with
+  `?? docs/overnight/` in this sandbox because committing is blocked by git
+  metadata permissions. Ignored `.venv/`, `.coverage`, and `.pytest_cache/` are
+  not shown by this command.
+- `UV_CACHE_DIR=/private/tmp/inbox-sym-120-uv-cache INBOX_TEST_MODE=1 uv run pytest -m safe -q` - passed locally: 11 passed, 855 deselected. Use this as the safe agent proof command.
+- `UV_CACHE_DIR=/private/tmp/inbox-sym-120-uv-cache INBOX_TEST_MODE=1 uv run pytest --collect-only -q` - passed locally after overriding uv cache: 866 tests collected. Expected to pass, but note pytest coverage output is noisy because `pyproject.toml` adds coverage globally.
+- `INBOX_TEST_MODE=1 uv run pytest -m safe` - documented command. Expected to pass, but may fail in this sandbox unless `UV_CACHE_DIR` is redirected away from `/Users/jwalinshah/.cache/uv`.
+- `uv run pytest` - documented full-suite command. Not run in this audit. Expected status unknown; docs should not claim a pass count without a fresh run.
+- `uv run ruff check .` - documented lint command. Not run; expected status unknown.
+- `uv run pyright` - documented type command. Not run; expected status unknown and likely more expensive/noisy.
+
+## Next Safe Work
+
+1. Fix setup and validation claims.
+   Acceptance criteria: README says Python 3.12+, DOCS_INDEX removes the stale
+   six-file and 736-test claims, and validation docs separate "safe slice
+   passed" from "full suite not run." Validation: `git diff --check` and
+   `UV_CACHE_DIR=/private/tmp/inbox-sym-120-uv-cache INBOX_TEST_MODE=1 uv run pytest -m safe -q`.
+
+2. Generate a server-route documentation snapshot.
+   Acceptance criteria: README labels its API section as a quick reference,
+   CLAUDE either links to generated route output or includes all current major
+   surfaces, and `/preflight/google-write` replaces stale `/preflight/write`.
+   Validation: `rg -n "^@app\\.(get|post|put|delete|patch)" inbox_server.py`
+   and a focused docs review comparing listed route families.
+
+3. Align TUI and MCP docs with code.
+   Acceptance criteria: README and CLAUDE keybindings match `InboxApp.BINDINGS`;
+   CLAUDE says `mcp_server.py` is HTTP and `inbox_mcp_stdio.py` is stdio; MCP
+   docs clearly call the tool surface curated rather than complete. Validation:
+   `rg -n "Binding\\(" inbox.py` and `rg -n "Tool\\(" tools_registry.py`.
+
+4. Harden live-write guard coverage for Sheets.
+   Acceptance criteria: `sheets_rename_sheet`, `sheets_format`, and
+   `sheets_copy_to` call `_assert_live_write_allowed`; tests prove each raises
+   `LiveWriteBlocked` under `INBOX_TEST_MODE=1` before touching a fake live
+   service. Validation:
+   `UV_CACHE_DIR=/private/tmp/inbox-sym-120-uv-cache INBOX_TEST_MODE=1 uv run pytest tests/test_services.py -q`.
+
+5. Add a docs-claims CI/check script.
+   Acceptance criteria: a local script or test checks Python version docs,
+   markdown file count claims, keybinding docs, and route family drift without
+   calling external services. Validation:
+   `UV_CACHE_DIR=/private/tmp/inbox-sym-120-uv-cache INBOX_TEST_MODE=1 uv run pytest tests/test_docs_claims.py -q`.
+
+## Non-Goals
+
+- No product code was changed for this audit.
+- No credentials, tokens, personal data stores, external APIs, cloud services,
+  deploys, pushes, PRs, or external trackers were used.
+- No live Inbox server was started.
+- No full pytest, lint, typecheck, or live integration suite was run.
+- No attempt was made to verify real Gmail, Calendar, Drive, Docs, Sheets,
+  Tasks, GitHub, iMessage, Notes, Reminders, WhatsApp, microphone, or desktop
+  notification behavior.
+
+## Unknowns
+
+- Whether the full test suite currently passes.
+- Whether `uv run ruff check .` and `uv run pyright` are currently clean.
+- Whether the daily-driver primary checkout has tokens or server state that
+  differ from this isolated worktree.
+- Whether docs should optimize for morning human review, external users, or
+  agent handoff first; the current docs try to serve all three.
+- Whether optional Gemini endpoints should remain user-facing or move behind a
+  clearer "cloud optional" section.
+
+## Handoff
+
+Changed file: `docs/overnight/inbox-sym-120-docs-claims.md`
+PR URL: none; PR creation is out of scope for this queue item.
+External tracker status: not changed.
+Commit status: not committed. `git commit` failed with `fatal: Unable to create
+'/Users/jwalinshah/projects/inbox/.git/worktrees/inbox-sym-120-docs-claims/index.lock':
+Operation not permitted`.
+Blockers: commit creation is blocked by sandbox permissions on the shared git
+metadata outside this worktree. Product fixes above require a separate
+implementation queue item.

--- a/docs/overnight/inbox-sym-120-risk-register.md
+++ b/docs/overnight/inbox-sym-120-risk-register.md
@@ -1,0 +1,364 @@
+# inbox-sym-120 risk register audit
+
+Queue item: `inbox-sym-120-risk-register`
+Audit date: 2026-05-07
+Scope: risk-register audit only. No product code, generated data, secrets, external services, deploys, pushes, or PRs were touched.
+
+## Repo State
+
+- Purpose: `inbox-sym-120` is a local-first Python inbox assistant/TUI with a FastAPI backend, MCP gateways, macOS data-source readers, Google/GitHub integrations, local ML/audio features, and agent-facing tools. Evidence: `README.md`, `CLAUDE.md`, `services.py`, `inbox_server.py`, `mcp_server.py`, `tools_registry.py`.
+- Branch at audit start: `codex/goal-inbox-sym-120-risk-register`.
+- HEAD at audit start: `2805b8400519da188ca7d3f6e39b19a8ca42b05a`.
+- Dirty state at audit start: `git status --short --branch` printed only `## codex/goal-inbox-sym-120-risk-register`; `git status --short` printed no entries.
+- Dirty state after report creation: `git status --short` exits 0 and prints `?? docs/overnight/`, representing this one report directory/file.
+- Commit status: local commit is blocked in this sandbox because `git add docs/overnight/inbox-sym-120-risk-register.md && git diff --cached --stat` failed while trying to create `/Users/jwalinshah/projects/inbox/.git/worktrees/inbox-sym-120-risk-register/index.lock` with `Operation not permitted`. The worktree contents are updated, but the report is not committed.
+- Sibling-repo comparison: skipped. This repo is not small: `llm-tldr tree .` showed 30+ Python modules, deployment/config/script directories, `.factory` validation artifacts, and 31 tests under `tests/`. The risk surface was large enough to use the full slice inside this repo.
+
+## Commands Run
+
+- `llm-tldr tree .`: mapped top-level modules, config/deploy/scripts/docs/tests, MCP entrypoints, and local data stores.
+- `git status --short --branch`: confirmed the branch and clean starting state.
+- `git rev-parse --show-toplevel && git rev-parse --abbrev-ref HEAD && git rev-parse HEAD`: captured repo root, branch, and starting SHA.
+- `rtk read README.md`, `rtk read CLAUDE.md`, `rtk read pyproject.toml`, `rtk read docs/TESTING_FOR_AGENTS.md`: read purpose, workflow, dependencies, and test policy.
+- `rtk read MCP_SETUP.md`, `rtk read config/inbox.env.example`, `rtk read config/codex.inbox.example.toml`, `rtk read config/gemini-settings.inbox.example.json`: read auth/deployment guidance and token examples.
+- `rg -n "_assert_live_write_allowed\\(" services.py inbox_server.py mcp_backend.py tools_registry.py`: counted 44 service-level live-write guard occurrences.
+- `rg -n "drive_upload|upload_to_drive|/drive/upload" tests services.py inbox_server.py tools_registry.py README.md CLAUDE.md`: found Drive upload is exposed in docs/API and tested for upload behavior, but not covered by a test-mode live-write assertion.
+- `git check-ignore -v credentials.json token.json tokens/foo.json github_token.txt google_maps_key.txt gemini_api_key.txt .inbox_scheduler.sqlite3 .inbox_index.sqlite3 .inbox_memory.sqlite3 config/inbox.env .env batch/triage-output.tsv batch/archive-state.tsv`: confirmed core secrets and generated state are ignored by `.gitignore`.
+- `git status --short --ignored`: printed no entries at audit time, so no ignored local secrets or generated DBs were present in this worktree.
+- `rg --files -uu`: confirmed tracked hidden surfaces include `.mcp.json`, `.cursor/mcp.json`, `.env.mcp.example`, `.factory` validation artifacts, and `.gitignore`.
+
+## Positive Controls Already Present
+
+- Secrets and generated state are gitignored: `.gitignore:13-21` ignores Google credentials/tokens, GitHub/Maps/Gemini key files, config env files, and generic secret files; `.gitignore:42-43` ignores local memory/scheduler SQLite; `.gitignore:58` ignores `.inbox_index.sqlite3`.
+- Private backend binds to loopback by default: `inbox_server.py:3939-3940` runs uvicorn on `127.0.0.1`; `mcp_server.py:148-151` and `inbox_mcp_readonly.py:83-87` do the same for MCP HTTP servers.
+- Backend auth compares bearer or `X-API-Key` with `secrets.compare_digest`: `inbox_server.py:1313-1339`.
+- MCP write tools are confirmation-gated in the registry: `tools_registry.py:52-79` injects `confirm`, and `tools_registry.py:41-43`/`tests/test_tools_registry.py:41-43` enforce that mutating registry tools require confirmation.
+- The read-only MCP server filters non-readonly registry tools: `inbox_mcp_readonly.py:77`, `tools_registry.py:110-118`, `tests/test_tools_registry.py:46-53`.
+- Agent-safe test mode exists: `inbox_test_mode.py:18-24` blocks live writes when `INBOX_TEST_MODE` is set, and `services.py` calls `_assert_live_write_allowed` in many external write functions.
+- Prior local validation exists for token locking and AppleScript escaping: `.factory/validation/architecture-hardening/scrutiny/reviews/token-safety-applescript.json` records a pass for locked token writes and AppleScript sanitizer coverage at commit `dde493c`.
+
+## Risk Register
+
+### R1. Raw backend auth is optional even for mutating REST routes
+
+Evidence:
+- `README.md:50` describes auth as optional via `INBOX_SERVER_TOKEN`.
+- `inbox_server.py:1317-1320` returns authorized when the token env var is unset.
+- `tests/test_server.py:371-375` explicitly asserts `/health` is available when token is unset.
+- Mutating routes are numerous: `inbox_server.py:1434`, `1489`, `1496`, `1819`, `1883`, `1962`, `1994`, `2028`, `2051`, `2548`, `2586`, `2612`, `2632`, `2940`, `2960`, `2978`.
+
+Impact:
+- On loopback this is acceptable for a trusted local TUI, but it becomes high risk if a reverse proxy, local malware, browser extension, or misconfigured agent can reach `localhost:9849`.
+- Raw HTTP bypasses the MCP confirmation layer. A caller can send, delete, archive, upload, create tasks, edit calendars, or mutate docs/sheets without an explicit human-confirmation field.
+
+Current controls:
+- Loopback binding by default.
+- Optional bearer token.
+- MCP-facing registry confirmation for many tool paths.
+
+Next safe work:
+- Require `INBOX_SERVER_TOKEN` for all non-GET routes by default, with an explicit `INBOX_ALLOW_UNAUTH_LOCAL_WRITES=1` development escape hatch.
+- Add tests proving missing auth rejects representative mutating endpoints while health/read endpoints retain the intended behavior.
+- Update README/MCP setup to state unauthenticated backend mode is read-only or development-only.
+
+### R2. Public MCP health can disclose backend state without MCP auth
+
+Evidence:
+- `mcp_gateway.py:48-58` allows `/health` through before checking `INBOX_MCP_TOKEN`.
+- `mcp_gateway.py:61-82` health includes backend health, memory DB path, and `auth_enabled`.
+- `inbox_server.py:1346-1357` backend health returns linked Gmail/Calendar/Drive/Sheets account names and GitHub configured status.
+- `deploy/Caddyfile.example:3-11` and `deploy/Caddyfile.example:17-27` expose `/health` for full and read-only MCP hostnames.
+
+Impact:
+- If the MCP gateways are exposed publicly as documented, `/health` can leak local filesystem paths and account emails even when `/mcp` is token-protected.
+- This weakens the "public read-only endpoint is safer" story because metadata still reveals personal infrastructure shape.
+
+Current controls:
+- `/mcp` itself is token-gated when `INBOX_MCP_TOKEN` is set.
+- HTTP MCP servers bind loopback; Caddy is the external exposure point.
+
+Next safe work:
+- Split `/health` into unauthenticated liveness with no account/path payload and authenticated diagnostics with backend details.
+- Add an MCP gateway test asserting public `/health` does not include account emails, backend detail, or memory DB paths.
+- Update `MCP_SETUP.md` and `deploy/Caddyfile.example` to expose only the minimal health endpoint publicly.
+
+### R3. MCP confirmation does not protect raw REST clients or local scripts
+
+Evidence:
+- `tools_registry.py:73-79` requires `confirm=True` only inside generated MCP handlers.
+- `mcp_server.py:41-45` gates hand-written memory/note writes.
+- Raw REST endpoints in `inbox_server.py` accept writes without a confirmation field, for example `/messages/send` at `inbox_server.py:1434-1447`, `/calendar/events` at `inbox_server.py:1819-1837`, `/drive/upload` at `inbox_server.py:2548-2574`, and `/docs/{document_id}/text` at `inbox_server.py:2978-2983`.
+- `batch/batch-runner.sh:74-80` archives Gmail messages directly through `/gmail/batch-modify`.
+
+Impact:
+- Agents or scripts that target REST instead of MCP can mutate live personal data without the user-visible confirmation contract that MCP tools advertise.
+- The docs present both REST and MCP as agent-accessible surfaces, so this is not just theoretical.
+
+Current controls:
+- Service-level `INBOX_TEST_MODE` blocks many live writes in tests.
+- Backend token can restrict callers if configured.
+
+Next safe work:
+- Add server-side confirmation or preflight enforcement for mutating REST endpoints used by agents.
+- Convert batch scripts to require `--confirm` for live runs and keep `--dry-run` as the default.
+- Add tests that representative raw REST writes reject missing confirmation when called outside the TUI trust path.
+
+### R4. Drive upload lacks the live-write guard used by other external writes
+
+Evidence:
+- `services.py:3864-3882` defines `drive_upload` and calls `drive_service.files().create(...)` without `_assert_live_write_allowed`.
+- `inbox_server.py:2548-2574` exposes `/drive/upload` and calls `drive_upload`.
+- `rg -n "_assert_live_write_allowed\\(" services.py` counted 44 guard occurrences, including Drive folder/delete at `services.py:3912-3949`, but not upload.
+- `tests/test_drive.py:69-112` tests upload behavior with mocks but does not assert `INBOX_TEST_MODE` blocks upload.
+- `tests/test_services.py:934-951` covers many extended live-write blockers, including Drive folder, but not Drive upload.
+
+Impact:
+- In `INBOX_TEST_MODE=1`, a test or local agent path can still reach a mocked or real Drive upload call if it hits `drive_upload`.
+- This is the clearest concrete gap found in the live-write safety model.
+
+Current controls:
+- The MCP registry does not currently expose an upload tool.
+- The endpoint still requires whatever backend auth policy is configured.
+
+Next safe work:
+- Add `_assert_live_write_allowed("upload Google Drive file")` at the start of `drive_upload`.
+- Add a regression test in `tests/test_services.py` or `tests/test_drive.py` that `INBOX_TEST_MODE=1` blocks `drive_upload` before `MediaFileUpload` or the Drive client is touched.
+- Add an API endpoint test for `/drive/upload` under `INBOX_TEST_MODE=1` if multipart test helpers are already available.
+
+### R5. Scheduled message and follow-up state can trigger future live writes
+
+Evidence:
+- `scheduler.py:118-148` stores scheduled messages in `.inbox_scheduler.sqlite3`.
+- `inbox_server.py:982-1036` sends due scheduled Gmail/iMessage messages in the background loop.
+- `inbox_server.py:1179-1187` runs the scheduler loop every 30 seconds by default.
+- `InboxServerRuntime.start_scheduler` defaults to `True` at `inbox_server.py:825-832`.
+- `tools_registry.py:570-585` confirmation-gates schedule creation for MCP, but `inbox_server.py:2066-2076` raw REST schedule creation does not include confirmation.
+
+Impact:
+- A scheduled write is a delayed live mutation. The original confirmation context is not persisted in a way the scheduler can review at send time.
+- A stale or accidental scheduled row can send later after the user has forgotten the original command.
+
+Current controls:
+- Under `INBOX_TEST_MODE`, the eventual send functions should block if the process still has that env var.
+- Scheduled rows can be listed and cancelled.
+
+Next safe work:
+- Persist `created_by`, `confirmed_at`, and a human-readable preview for scheduled writes.
+- Add a startup warning or block when pending scheduled sends exist and the backend is unauthenticated.
+- Add a safe test around scheduler processing in `INBOX_TEST_MODE=1`.
+
+### R6. Broad OAuth scopes plus default-account fallback increase blast radius
+
+Evidence:
+- `services.py:88-98` requests broad Google scopes: Gmail read/modify/send/settings, Calendar, Drive, Sheets, Docs, and Tasks.
+- `google_account_resolution.py:24-33` defaults to `INBOX_DEFAULT_GOOGLE_ACCOUNT` or the first service key.
+- `google_account_resolution.py:51-58`, `119-126`, `129-136`, and `149-157` resolve Gmail/Drive/Tasks/Calendar writes to a default account when no account is provided.
+- `google_account_resolution.py:160-304` implements preflight payloads, but `inbox_server.py:3009-3020` exposes preflight as a separate GET endpoint rather than enforcing it on writes.
+
+Impact:
+- A missing `account` parameter can create/delete/update in the wrong Google account.
+- A compromised token or backend grants a wide cross-product write surface.
+
+Current controls:
+- Per-account token files in `tokens/`.
+- Account-specific service helpers and preflight endpoint exist.
+- Docs warn about multi-account routing in `CLAUDE.md`.
+
+Next safe work:
+- Require explicit `account` on mutating Google endpoints unless `INBOX_DEFAULT_GOOGLE_ACCOUNT` is set and acknowledged.
+- Tie confirmation payloads to a preflight result showing resolved account and destination.
+- Add tests for "missing account rejects write" on high-risk endpoints: Drive, Docs, Sheets, Calendar, Tasks.
+
+### R7. Privacy/local-first claim has optional cloud AI and Maps egress paths
+
+Evidence:
+- `README.md:24-25` claims local-first ML and no cloud dependencies.
+- `README.md:169-174` says all data processing happens on-device.
+- `services.py:3249-3264` configures `google.generativeai` from `GEMINI_API_KEY` or `gemini_api_key.txt`.
+- `services.py:3270-3291` sends conversation text to Gemini summarization.
+- `inbox_server.py:2197-2263` exposes Gemini summarize, smart reply, categorize, digest, and action-items endpoints.
+- `services.py:3510-3522` reads Google Cloud/Maps keys and `services.py:3578-3582` calls the Google Distance Matrix API with origin/destination.
+
+Impact:
+- If keys are configured, personal messages, calendar/task summaries, and locations can leave the device.
+- The current docs say Gemini is optional in `CLAUDE.md`, but the README privacy section is stronger than the code supports.
+
+Current controls:
+- Cloud calls require explicit key files/env vars.
+- Local ML remains available.
+
+Next safe work:
+- Add a visible cloud-egress policy flag, for example `INBOX_ALLOW_CLOUD_AI=1`, and make cloud AI endpoints return 403 unless enabled.
+- Label `/ai/gemini-*`, `/ai/digest`, `/ai/action-items`, and Maps endpoints as cloud egress in docs and OpenAPI descriptions.
+- Add tests proving cloud endpoints are disabled by default when the new flag is unset.
+
+### R8. Logs can contain personal data, paths, recipients, and locations
+
+Evidence:
+- `_format_log_context` in `services.py:139-147` only truncates long strings; it does not redact emails, locations, document IDs, message IDs, or file paths.
+- `_log_service_failure` in `services.py:150-155` logs exceptions with that context.
+- `services.py:1199` logs Gmail compose recipient and subject on failure.
+- `services.py:3598` logs Maps origin and destination on failure.
+- `inbox_server.py:1011-1032` logs scheduled send recipients/contact names.
+- `ambient_notes.py:73-76` logs and prints a preview of captured ambient transcript/summary.
+- Deploy examples write logs under `/tmp`: `deploy/com.inbox.backend.plist.example`, `deploy/com.inbox.mcp.plist.example`, `deploy/com.inbox.mcp-readonly.plist.example`, and `scripts/setup_inbox_mcp.sh:52-59`.
+
+Impact:
+- Logs can preserve sensitive recipients, calendar locations, note previews, and local filesystem paths outside the app's normal privacy boundary.
+- `/tmp` service logs can be copied into debugging reports or read by local processes depending on host permissions.
+
+Current controls:
+- The logger truncates long string values.
+- Token file contents are not printed by the reviewed paths.
+
+Next safe work:
+- Centralize log redaction for emails, tokens, addresses, message IDs, and local paths before calling logger.
+- Default service logs to `~/Library/Logs/inbox` or another user-scoped directory with documented permissions.
+- Add tests for `_format_log_context` redaction behavior.
+
+### R9. Local generated databases store sensitive indexed content in repo root
+
+Evidence:
+- `memory_store.py:9-11` defaults to `.inbox_memory.sqlite3` in repo root.
+- `scheduler.py:15-17` defaults to `.inbox_scheduler.sqlite3` in repo root and stores scheduled message text at `scheduler.py:70-80`.
+- `message_index_store.py:12-15` defaults to `.inbox_index.sqlite3`; its `items` table stores sender, recipients, subject, snippet, body text, labels, and raw pointers at `message_index_store.py:100-120`.
+- `.gitignore:42-43` and `.gitignore:58` ignore those DB files.
+
+Impact:
+- The ignore rules prevent accidental commits, but root-local databases are easy to copy with the repo, include in manual archives, or leave in multiple worktrees.
+- The index DB can contain substantial message bodies and metadata, not just harmless cache state.
+
+Current controls:
+- `.gitignore` covers the generated DB names.
+- `INBOX_MEMORY_DB` can override memory DB path through `mcp_gateway.py:26-29`; `INBOX_TEST_DATA_DIR` redirects some service paths under test mode.
+
+Next safe work:
+- Move runtime DB defaults to a user data directory such as `~/.local/share/inbox` or `~/Library/Application Support/inbox`.
+- Add startup diagnostics that warn if runtime DBs live inside a git worktree.
+- Document backup/cleanup and file-permission expectations.
+
+### R10. Batch archive runner can mutate Gmail with brittle JSON/state handling
+
+Evidence:
+- `batch/batch-runner.sh:15-19` defaults to `MODE=archive`, `DRY_RUN=false`, and `PARALLEL=1`.
+- `batch/batch-runner.sh:74-80` posts directly to `/gmail/batch-modify`.
+- `batch/batch-runner.sh:78-79` interpolates `SERVER_TOKEN` and `thread_id` into a shell/curl command and JSON body.
+- `batch/batch-runner.sh:92-101` rewrites the shared state file via `awk` and `mv`; parallel workers can race when `--parallel N` is used.
+
+Impact:
+- A malformed TSV row can produce invalid JSON or target unexpected input.
+- Parallel runs can lose state updates.
+- Live archive behavior is one flag away from a dry run, but dry run is not the default.
+
+Current controls:
+- Input/state/output files are separated; generated state/logs are ignored.
+- Unsupported sources return an error.
+
+Next safe work:
+- Make `--dry-run` the default and require `--confirm-live` for archive mode.
+- Use `jq -n --arg` or a small Python/HTTP client to build JSON safely.
+- Add file locking around `archive-state.tsv` updates.
+
+## Validation Candidates
+
+Required queue validation:
+- `git status --short`
+- Actual result after report creation: exit 0 with `?? docs/overnight/`.
+- Expected if a human or less-restricted runner stages/commits the report: exit 0 with no output.
+
+Commit/blocker evidence:
+- `git add docs/overnight/inbox-sym-120-risk-register.md && git diff --cached --stat`
+- Actual result: failed before staging with `fatal: Unable to create '/Users/jwalinshah/projects/inbox/.git/worktrees/inbox-sym-120-risk-register/index.lock': Operation not permitted`.
+
+Cheap safety commands for future implementation tasks:
+- `INBOX_TEST_MODE=1 uv run pytest -m safe`
+- Expected: pass, but narrow. Local evidence from `rg -n "pytestmark = pytest.mark.safe|@pytest.mark.safe" tests` found only `tests/test_inbox_test_mode.py` and `tests/test_mcp_gateway.py` marked safe.
+
+- `INBOX_TEST_MODE=1 uv run pytest tests/test_inbox_test_mode.py tests/test_mcp_gateway.py -q`
+- Expected: pass. Covers the two currently safe-marked risk-control files.
+
+- `INBOX_TEST_MODE=1 uv run pytest tests/test_services.py::test_test_mode_blocks_extended_live_writes tests/test_drive.py::TestDriveUpload -q`
+- Expected today: likely pass without proving Drive upload blocking, because `TestDriveUpload` does not set `INBOX_TEST_MODE`. After fixing R4, add a new assertion that currently would fail: `drive_upload` should raise `LiveWriteBlocked` before touching Drive.
+
+- `uv run ruff check .`
+- Expected: candidate pass based on repo docs and prior `.factory/validation/architecture-hardening/scrutiny/synthesis.json`.
+
+- `uv run pyright`
+- Expected: candidate pass based on repo docs and prior `.factory/validation/architecture-hardening/scrutiny/synthesis.json`.
+
+- `uv run bandit -c pyproject.toml -r .`
+- Expected: limited signal. `pyproject.toml` skips `B404`, `B603`, and `B607`, which are relevant because this repo intentionally uses subprocess/AppleScript.
+
+## Independently Grabbable Next Tasks
+
+1. Server-side write confirmation for REST mutators
+   - Acceptance criteria:
+     - Representative raw REST mutators reject missing confirmation or auth according to a documented policy.
+     - TUI-owned local flows still work through a clear trust path.
+     - README/CLAUDE/MCP docs explain which clients may call REST writes.
+   - Validation:
+     - `INBOX_TEST_MODE=1 uv run pytest tests/test_server.py -q`
+     - `uv run ruff check inbox_server.py tests/test_server.py`
+
+2. Close the Drive upload live-write gap
+   - Acceptance criteria:
+     - `drive_upload` calls `_assert_live_write_allowed` before `MediaFileUpload` or Drive client calls.
+     - A regression test proves `INBOX_TEST_MODE=1` blocks upload.
+     - Existing mocked upload tests still pass outside test mode.
+   - Validation:
+     - `INBOX_TEST_MODE=1 uv run pytest tests/test_drive.py tests/test_services.py::test_test_mode_blocks_extended_live_writes -q`
+     - `uv run ruff check services.py tests/test_drive.py tests/test_services.py`
+
+3. Harden public MCP health
+   - Acceptance criteria:
+     - Unauthenticated `/health` returns only liveness/mode/auth-enabled, not backend account emails, local paths, or backend error details.
+     - Authenticated diagnostics remain available through a separate endpoint or header-gated mode.
+     - Caddy/deploy docs describe the public health payload.
+   - Validation:
+     - `INBOX_TEST_MODE=1 uv run pytest tests/test_mcp_gateway.py -q`
+     - `uv run ruff check mcp_gateway.py tests/test_mcp_gateway.py`
+
+4. Require explicit account or preflight-bound confirmation for Google writes
+   - Acceptance criteria:
+     - High-risk Drive/Docs/Sheets/Calendar/Tasks writes either require `account` or include a confirmed preflight token/object with resolved account and destination.
+     - Tests cover missing-account rejection and explicit-account success.
+     - Docs show the safe call sequence.
+   - Validation:
+     - `INBOX_TEST_MODE=1 uv run pytest tests/test_server.py tests/test_drive.py tests/test_calendar.py tests/test_gmail_actions.py -q`
+     - `uv run pyright`
+
+5. Redact logs and relocate runtime DBs
+   - Acceptance criteria:
+     - `_format_log_context` redacts emails, tokens, addresses, paths, and IDs in common contexts.
+     - Runtime DB defaults move outside repo root or warn when inside a git worktree.
+     - Deploy examples write logs to a user-scoped directory.
+   - Validation:
+     - `INBOX_TEST_MODE=1 uv run pytest tests/test_services.py tests/test_memory_store.py tests/test_message_index_store.py -q`
+     - `uv run ruff check services.py memory_store.py message_index_store.py scheduler.py`
+
+## Non-goals
+
+- No fixes were implemented in this queue item.
+- No live Gmail, Calendar, Drive, Docs, Sheets, Tasks, GitHub, Maps, Gemini, iMessage, Notes, Reminders, WhatsApp, audio, notification, or Obsidian operations were run.
+- No dev server was started.
+- No browser QA was run.
+- No generated runtime DBs, token files, local env files, or batch state files were created.
+- No external trackers were updated.
+- No PR was opened.
+
+## Unknowns
+
+- Whether production/daily-driver runs always set `INBOX_SERVER_TOKEN` and `INBOX_MCP_TOKEN`.
+- Whether the raw REST API is considered a trusted local-only implementation detail or an agent-supported public contract.
+- Whether cloud Gemini/Maps endpoints are actively used or legacy features.
+- Whether runtime DBs in the primary checkout already contain sensitive indexed content; this worktree had no ignored DB files at audit time.
+- Whether Caddy/deployment examples are copied verbatim into a live host.
+- Whether scheduled messages/followups have existing rows in the primary checkout.
+
+## Decisions
+
+- Treated MCP confirmation as a useful control but not sufficient for the raw FastAPI backend.
+- Treated `INBOX_TEST_MODE` coverage as a safety boundary because `docs/TESTING_FOR_AGENTS.md` instructs agents to rely on it.
+- Did not run pytest, lint, typecheck, servers, or cloud/local integration commands; the queue validation command is `git status --short`, and this task is an audit report.
+- Did not inspect or copy any ignored secrets or generated personal-data DBs.
+- Did not create a local commit because the linked-worktree git administrative directory is outside the writable sandbox.

--- a/docs/overnight/inbox-sym-120-workflow-handoff.md
+++ b/docs/overnight/inbox-sym-120-workflow-handoff.md
@@ -1,0 +1,232 @@
+# Overnight Audit: inbox-sym-120 Workflow Handoff
+
+Queue item: `inbox-sym-120-workflow-handoff`
+Date: 2026-05-07
+Repo: `inbox-sym-120`
+Worktree: `/Users/jwalinshah/projects/agent-stack/.agent-stack-worktrees/2026-05-07-overnight-marathon/inbox-sym-120-workflow-handoff`
+Focus area: `workflow-handoff`
+
+## Handoff Summary
+
+This repo is a local-first personal inbox control plane: a FastAPI backend wraps Gmail, iMessage, Calendar, Google Workspace, Apple Notes/Reminders, GitHub, local ML/audio, an operational SQLite index, and a Textual TUI. The handoff-sensitive work is not missing feature scaffolding; it is missing a clean bridge from the existing workflow-level backend endpoints into the safer, agent-facing tool surface and validation story.
+
+No product code was changed in this audit. The only intended write is this report.
+
+## Repo State
+
+- Branch: `codex/goal-inbox-sym-120-workflow-handoff`
+- Initial HEAD: `2805b8400519da188ca7d3f6e39b19a8ca42b05a`
+- Remote: `origin https://github.com/jwalin-shah/inbox.git`
+- Initial dirty state: clean (`git status --short --branch` printed only `## codex/goal-inbox-sym-120-workflow-handoff`)
+- Recent history observation: current HEAD is also `origin/main` and a family of audit branches; latest visible merge is `Merge pull request #34 from jwalin-shah/codex/SYM-9-indexed-defaults`.
+- Repo size observation: `rg --files | wc -l` returned `104`; key source/test/docs files sampled total `20,556` lines by `wc -l`.
+- Existing `docs/overnight` state: `git ls-files docs/overnight` returned no tracked reports before this write.
+
+## Evidence Map
+
+- `README.md` describes a privacy-first terminal UI and claims Python 3.10+ quick-start support, local FastAPI server on port 9849, and agent access through the backend API.
+- `CLAUDE.md` is the most complete current project context. It documents primary vs dev backend routing, `INBOX_SERVER_PORT`, `INBOX_SERVER_URL`, `INBOX_SERVER_TOKEN`, MCP routing, and the worktree caveat that macOS personal data stores are shared across worktrees.
+- `pyproject.toml` requires Python `>=3.12,<3.15`, configures `ruff`, `pyright`, pytest coverage, and test markers `safe`, `integration`, `local_data`, `slow`, and `live_write`.
+- `docs/TESTING_FOR_AGENTS.md` defines the safe loop as `INBOX_TEST_MODE=1 uv run pytest -m safe`, `uv run ruff check .`, and `uv run pyright`; it explicitly forbids live-write and local-data tests without opt-in.
+- `inbox_server.py` contains the primary FastAPI surface. `ServerState` owns Google services, caches, ambient/dictation services, scheduler state, and the message index; `InboxServerRuntime` lets tests inject fake state and disable scheduler/ambient startup.
+- `inbox_server.py` enforces optional API token auth via `INBOX_SERVER_TOKEN`; if the env var is absent, all local API requests are accepted.
+- `services.py` is the large integration layer. It contains the live-write guard `_assert_live_write_allowed`, which delegates to `inbox_test_mode.assert_live_writes_allowed` when `INBOX_TEST_MODE` is set.
+- `inbox_test_mode.py` blocks live writes with `LiveWriteBlocked`, redirects test-local data through `INBOX_TEST_DATA_DIR`, and supports deterministic time through `INBOX_TEST_NOW`.
+- `google_account_resolution.py` implements `INBOX_DEFAULT_GOOGLE_ACCOUNT` routing and `preflight_google_write_payload` for doc, sheet, Drive folder, task, and calendar writes.
+- `tools_registry.py` centralizes MCP tools and confirm-gates all tools marked mutating. The registry currently stops at Gmail, iMessage, Notes, Reminders, Tasks, Calendar/Maps, search, WhatsApp, scheduled/followup links, memory extraction, Drive, Docs, and GitHub.
+- `tests/test_tools_registry.py` proves all mutating registry tools require `confirm`, read-only registration excludes write tools, path params are URL encoded, and body params remain raw.
+- `tests/test_api_contract.py` checks every registered MCP tool path maps to an actual FastAPI endpoint and that `InboxClient` index methods match server response shape.
+- `tests/test_server.py` has extensive mocked endpoint coverage for auth, runtime injection, index health, preflight, workflow classification, workflow event/doc/sheet/folder endpoints, and `/inbox/needs-action`.
+- `CONNECTOR_ROADMAP.md` sets the target architecture: source adapters, normalization, policy, and intent tools. It explicitly says common workflows should be tool operations rather than prompt improvisation.
+- `MCP_V1_PLAN.md` states the security model: private `inbox_server.py`, assistant-facing MCP layer, `INBOX_MCP_TOKEN`, `INBOX_SERVER_TOKEN`, confirmation-gated writes, and audit logging as future work.
+- `MCP_SETUP.md` documents two MCP access patterns and warns that dev worktree testing silently talks to primary port 9849 unless both `cwd` and `INBOX_SERVER_URL` are changed.
+- `inbox.py` contains an "Ask Inbox Assistant" TUI flow that imports `agents.runner.Supervisor` at call time, but no tracked `agents/` package exists in this worktree.
+- `inbox_server.py` has a `/query` endpoint that imports optional `gemma4_hackathon` modules at request time and returns HTTP 503 when they are not installed; `pyproject.toml` does not list that package.
+
+## Workflow-Handoff Assessment
+
+The backend already exposes several workflow-oriented primitives:
+
+- `/preflight/google-write` resolves destination and account before Google writes.
+- `/gmail/threads/needing-reply` searches stale reply-needed inbox threads.
+- `/calendar/workflow-event` prefixes event kinds and tags descriptions with workflow labels.
+- `/inbox/needs-action` rolls up indexed threads, tasks, and near-term calendar events.
+- `/drive/workflow-folder`, `/docs/workflow-doc`, and `/sheets/workflow-sheet` create workflow-specific Google Workspace artifacts.
+- `/index/status`, `/index/health`, `/index/views/{view_name}`, and `/index/threads` expose the operational index status and compact read models.
+
+Those endpoints are tested in `tests/test_server.py`, but they are not yet visible in `tools_registry.py`. That creates a handoff gap: future agents using MCP get many low-level CRUD actions, but not the intent-level workflow tools that the roadmap says they should prefer.
+
+The second gap is validation clarity. The repo has an explicit `safe` marker system, but only `tests/test_inbox_test_mode.py` and `tests/test_mcp_gateway.py` are marked safe. Important deterministic safety tests in `tests/test_services.py` are not marked safe, so the documented safe command under-exercises the live-write guard surface.
+
+The third gap is optional/runtime dependency clarity. The TUI assistant control path references `agents.runner`, and `/query` references `gemma4_hackathon`. Both are runtime-optional in practice, but they are not represented in `pyproject.toml` or clearly excluded from type-check expectations. This is a predictable handoff trap for agents asked to run `pyright` or inspect assistant behavior.
+
+## Risks And Stale Assumptions
+
+1. MCP workflow drift: `tools_registry.py` is the single MCP registry, but it does not expose `/preflight/google-write`, `/inbox/needs-action`, `/calendar/workflow-event`, `/drive/workflow-folder`, `/docs/workflow-doc`, or `/sheets/workflow-sheet`. This conflicts with `CONNECTOR_ROADMAP.md`, which says the model should use intent-level tools.
+
+2. Direct backend writes bypass MCP confirmation: the MCP registry adds `confirm=True`, but FastAPI write endpoints themselves do not require confirmation. Any local caller with `INBOX_SERVER_TOKEN` can hit write endpoints directly. The service-level `INBOX_TEST_MODE` guard is good for tests, not production confirmation policy.
+
+3. Preflight is advisory, not enforced: `google_account_resolution.py` can explain where writes will land, and `tests/test_server.py` covers it, but write endpoints such as workflow doc/sheet/folder and task/calendar creation do not require a successful preflight result before mutating provider state.
+
+4. Safe test marker coverage is stale: docs tell agents to run `INBOX_TEST_MODE=1 uv run pytest -m safe`, but marker search found only two safe-marked files. Representative live-write guard tests in `tests/test_services.py` are deterministic but not safe-marked.
+
+5. Documentation claims are inconsistent: `README.md` says Python 3.10+, while `pyproject.toml` and `.python-version` require Python 3.12. `DOCS_INDEX.md` claims "All 736 tests pass", but this audit did not find a current command observation supporting that claim.
+
+6. Optional assistant dependencies are underspecified: `inbox.py` imports `agents.runner.Supervisor` at runtime and `/query` imports `gemma4_hackathon`; neither is tracked in the repo or declared as an optional dependency. Agents running type checks or TUI assistant flows may chase missing modules instead of intended product work.
+
+7. Worktree isolation is partial: `CLAUDE.md` correctly warns that iMessage, Notes, Reminders, and AddressBook stores are shared across worktrees. Starting a dev backend without `INBOX_TEST_MODE=1`, alternate ports, and disabled ambient/scheduler settings can still touch personal data or external services.
+
+8. Public HTTP MCP still needs audit hardening: `MCP_V1_PLAN.md` lists audit logging as a next step. Until then, token auth and confirm gates are the main controls, with no durable tool-call audit trail for remote/cloud clients.
+
+## Next Grabbable Tasks
+
+### Task 1: Expose Workflow Intent Tools Through MCP
+
+Acceptance criteria:
+- Add MCP registry entries for `preflight_google_write`, `get_needs_action`, `get_threads_needing_reply`, `create_workflow_event`, `create_workflow_folder`, `create_workflow_doc`, and `create_workflow_sheet`.
+- Mark read-only tools as `readonly=True`.
+- Mark all mutating workflow tools as `confirm=True`.
+- Ensure read-only MCP registration excludes all mutating workflow tools.
+- Keep one source of truth in `tools_registry.py`; do not add duplicated hand-written MCP handlers.
+
+Suggested validation:
+- `INBOX_TEST_MODE=1 uv run pytest tests/test_tools_registry.py tests/test_api_contract.py -q`
+- Expected status: pass after registry/path updates.
+
+### Task 2: Repair Agent-Safe Validation Coverage
+
+Acceptance criteria:
+- Mark deterministic live-write guard tests in `tests/test_services.py` as `safe`, or split them into a dedicated safe test file.
+- Reconcile docs so `README.md`, `DOCS_INDEX.md`, `docs/TESTING_FOR_AGENTS.md`, `.python-version`, and `pyproject.toml` agree on Python version and test claims.
+- Replace the stale "736 tests pass" claim with a reproducible command and last-known observation, or remove the count.
+- Keep live provider, local-data, audio, and external-write tests outside the default safe loop.
+
+Suggested validation:
+- `INBOX_TEST_MODE=1 uv run pytest -m safe -q`
+- `uv run ruff check .`
+- Expected status: pass; the safe suite should include representative live-write guard coverage.
+
+### Task 3: Enforce Preflight On Google Workflow Writes
+
+Acceptance criteria:
+- For workflow Google writes, require either a successful preflight or a shared helper that resolves the same destination/account before mutation.
+- Include resolved account and destination in responses for workflow doc/sheet/folder/event/task writes.
+- Add tests for missing account services, invalid Drive folder, invalid task list, and explicit non-default account writes.
+- Update `config/inbox.env.example` and MCP docs to mention `INBOX_DEFAULT_GOOGLE_ACCOUNT`.
+
+Suggested validation:
+- `INBOX_TEST_MODE=1 uv run pytest tests/test_server.py -k "Preflight or workflow" -q`
+- Expected status: pass after endpoint/helper tests are updated.
+
+### Task 4: Harden Optional Assistant Features
+
+Acceptance criteria:
+- Decide whether `agents.runner` is an in-repo package, optional external package, or obsolete feature.
+- If optional, hide or degrade the TUI command when unavailable and document setup requirements.
+- Add a deterministic test for the command palette or assistant action so missing optional packages produce a user-readable failure instead of an implementation mystery.
+- Treat `/query` the same way: either declare the optional `gemma4_hackathon` dependency or document that 503 is the expected unavailable state.
+
+Suggested validation:
+- `INBOX_TEST_MODE=1 uv run pytest tests/test_command_palette.py tests/test_inbox_app.py -q`
+- `uv run pyright`
+- Expected status: command tests pass; `pyright` may currently fail until optional imports are modeled or ignored.
+
+## Validation Command Candidates
+
+- Required queue validation: `git status --short`
+  - Observed after writing the report: `?? docs/overnight/`; exit status 0.
+
+- Safe agent loop: `INBOX_TEST_MODE=1 uv run pytest -m safe -q`
+  - Expected today: likely pass, but coverage is too narrow because only two test files are safe-marked.
+
+- MCP registry/API contract proof: `INBOX_TEST_MODE=1 uv run pytest tests/test_tools_registry.py tests/test_api_contract.py -q`
+  - Expected today: likely pass for the current registry; should be rerun after adding workflow tools.
+
+- Workflow/preflight endpoint proof: `INBOX_TEST_MODE=1 uv run pytest tests/test_server.py -k "Preflight or workflow" -q`
+  - Expected today: likely pass based on existing tests; should fail first if used TDD for preflight enforcement.
+
+- Lint: `uv run ruff check .`
+  - Expected today: unknown in this worktree because the audit did not create a venv or run lint.
+
+- Type check: `uv run pyright`
+  - Expected today: higher risk than lint because optional imports like `agents.runner` and `gemma4_hackathon` are not represented in `pyproject.toml`.
+
+## Non-Goals For This Queue Item
+
+- No product code changes.
+- No generated data, cache, or local database changes.
+- No live backend startup.
+- No live Google, Gmail, Calendar, Drive, Docs, Sheets, Tasks, iMessage, Notes, Reminders, GitHub, WhatsApp, audio, notification, or MCP calls.
+- No external service writes.
+- No deploys.
+- No pushes or PR creation.
+- No external tracker state changes.
+
+## Unknowns
+
+- Whether `agents.runner` is intentionally supplied by another checkout, a generated folder, or a stale missing package.
+- Whether the primary daily-driver backend is currently running on port 9849; this audit intentionally did not call it.
+- Whether `INBOX_DEFAULT_GOOGLE_ACCOUNT` is set in the user's real environment.
+- Whether the full test suite currently passes in a fully hydrated local environment.
+- Whether `gemma4_hackathon` is expected to be installed for this repo or only for an old experiment.
+- Whether morning review expects a commit for report-only audit work; this worker left the report uncommitted unless the runner handles commits.
+
+## Commands Run
+
+- `llm-tldr tree .`
+- `git status --short --branch`
+- `git rev-parse HEAD`
+- `git branch --show-current`
+- `rtk read AGENTS.md`
+- `rtk read README.md`
+- `rtk read CLAUDE.md`
+- `rtk read pyproject.toml`
+- `rtk read docs/TESTING_FOR_AGENTS.md`
+- `rtk read DOCS_INDEX.md`
+- `rg -n "^(class|def|async def) |^app =|^@app" inbox_server.py`
+- `rg -n "^(class|def|async def) " services.py`
+- `rg -n "^(class|def|async def) " inbox.py`
+- `rg -n "^(class|def|async def)|^@mcp|FastMCP|tool" mcp_backend.py mcp_server.py inbox_mcp_stdio.py inbox_mcp_readonly.py inbox_mcp_readonly_stdio.py`
+- `rg -n "INBOX_TEST_MODE|assert_live_writes_allowed|live_write|safe" .`
+- `nl -ba inbox_server.py | sed -n '750,1355p'`
+- `nl -ba inbox_server.py | sed -n '2900,3025p'`
+- `nl -ba inbox_test_mode.py | sed -n '1,120p'`
+- `nl -ba mcp_backend.py | sed -n '1,220p'`
+- `nl -ba tools_registry.py | sed -n '1,170p'`
+- `nl -ba tools_registry.py | sed -n '170,360p'`
+- `nl -ba tools_registry.py | sed -n '360,880p'`
+- `nl -ba tests/test_tools_registry.py | sed -n '1,260p'`
+- `nl -ba tests/test_inbox_test_mode.py | sed -n '1,260p'`
+- `nl -ba tests/conftest.py | sed -n '1,260p'`
+- `nl -ba tests/test_mcp_gateway.py | sed -n '1,240p'`
+- `nl -ba tests/test_server.py | sed -n '1,260p'`
+- `rg -n "workflow|preflight|confirm|live_write|scheduler|ambient|create_app|auth|INBOX_SERVER_TOKEN" tests/test_server.py tests/test_server_endpoints.py tests/test_api_contract.py tests/test_mcp_gateway.py tests/test_tools_registry.py tests/test_services.py tests/test_gmail_actions.py tests/test_message_sync.py`
+- `nl -ba CONNECTOR_ROADMAP.md | sed -n '1,220p'`
+- `nl -ba MCP_V1_PLAN.md | sed -n '1,180p'`
+- `nl -ba PLAN.md | sed -n '1,180p'`
+- `nl -ba gmail_triage.py | sed -n '1,360p'`
+- `nl -ba message_index_store.py | sed -n '1,260p'`
+- `nl -ba message_sync.py | sed -n '1,280p'`
+- `git log --oneline -8 --decorate`
+- `git remote -v`
+- `git diff --stat`
+- `git ls-files docs/overnight`
+- `rg --files | wc -l`
+- `wc -l services.py inbox_server.py inbox.py tools_registry.py message_sync.py message_index_store.py tests/test_server.py tests/test_tools_registry.py tests/test_inbox_test_mode.py docs/TESTING_FOR_AGENTS.md README.md CLAUDE.md CONNECTOR_ROADMAP.md PLAN.md`
+- `rg -n "pytestmark = pytest.mark.safe|@pytest.mark.safe|@pytest.mark.integration|@pytest.mark.local_data|@pytest.mark.live_write|@pytest.mark.slow" tests`
+- `rg -n "\[project\]|requires-python|dependencies =|\[dependency-groups\]|\[tool.ruff\]|\[tool.pyright\]|\[tool.pytest|markers|safe:|live_write" pyproject.toml`
+- `nl -ba google_account_resolution.py | sed -n '1,260p'`
+- `nl -ba tests/test_gmail_actions.py | sed -n '1,180p'`
+- `nl -ba tests/test_server.py | sed -n '1488,1622p'`
+- `mkdir -p docs/overnight`
+- `git status --short`
+- `rtk read docs/overnight/inbox-sym-120-workflow-handoff.md`
+- `wc -l docs/overnight/inbox-sym-120-workflow-handoff.md`
+
+## Final Handoff Fields
+
+- Files changed: `docs/overnight/inbox-sym-120-workflow-handoff.md`
+- Commit SHA at audit time: `2805b8400519da188ca7d3f6e39b19a8ca42b05a`
+- Validation result: `git status --short` exited 0 and printed `?? docs/overnight/`.
+- PR URL: none; PR creation is out of scope for this queue item.
+- Blockers: none for the audit report. Follow-up implementation should not run live provider tests or external writes without explicit human approval.

--- a/docs/overnight/inbox-sym-214-architecture-map.md
+++ b/docs/overnight/inbox-sym-214-architecture-map.md
@@ -1,0 +1,307 @@
+# inbox-sym-214 architecture-map audit
+
+Queue item: `inbox-sym-214-architecture-map`
+Repo/worktree: `/Users/jwalinshah/projects/agent-stack/.agent-stack-worktrees/2026-05-07-overnight-marathon/inbox-sym-214-architecture-map`
+Branch observed: `codex/goal-inbox-sym-214-architecture-map`
+Initial dirty state: `git status --short --branch` returned only `## codex/goal-inbox-sym-214-architecture-map`, so the worktree was clean before this report.
+
+This was a read-only architecture audit except for this report. I did not touch product code, generated data, credentials, deploys, external services, trackers, or PRs.
+
+## Purpose
+
+Inbox is a local-first personal inbox/control-plane app. The documented core is a Python Textual TUI plus a local FastAPI backend that reads and writes across iMessage, Gmail, Google Calendar, Notes, Reminders, Drive, Sheets, Docs, GitHub, audio/LLM, and MCP surfaces.
+
+The current product direction is narrower than the current code surface. `PLAN.md` says this phase should focus on Gmail, iMessage/SMS, calendar context, a local FastAPI server, a local SQLite operational index, and the Textual TUI. The implementation has already widened into a general personal assistant platform: `services.py`, `inbox_server.py`, `inbox_client.py`, `tools_registry.py`, and the deploy configs expose many more source and workflow modules.
+
+## Commands And Observations
+
+- `pwd`: confirmed the worker is in the queue worktree path above.
+- `git status --short --branch`: clean branch before report creation.
+- `git log --oneline -5`: HEAD was `2805b84 Merge pull request #34 from jwalin-shah/codex/SYM-9-indexed-defaults`; recent merges include indexed-defaults, thread rebuild cleanup, and sync freshness health.
+- `llm-tldr tree .`: repo is a flat Python app with `batch/`, `config/`, `deploy/`, `docs/`, `modes/`, `scripts/`, `tests/`, and many top-level modules.
+- `rg --files`: found 30 test files and top-level modules including `services.py`, `inbox_server.py`, `inbox.py`, `inbox_client.py`, `message_index_store.py`, `message_sync.py`, `tools_registry.py`, `mcp_backend.py`, and MCP entrypoints.
+- `wc -l *.py`: 21,703 Python LOC across top-level modules; largest are `services.py` 6,467 LOC, `inbox.py` 4,279 LOC, `inbox_server.py` 3,940 LOC, `inbox_client.py` 947 LOC.
+- `rg -c "^@app\\." inbox_server.py`: 160 FastAPI app decorators, including middleware and HTTP routes.
+- `rg -c "^    Tool\\(" tools_registry.py`: 60 MCP registry tools; `rg -c "confirm=True"` found 34 confirm-gated tools and `rg -c "readonly=True"` found 29 readonly tools.
+- `rg -c "_assert_live_write_allowed\\(" services.py`: 44 service-level live-write guard call sites.
+- `rg -n "pytestmark = pytest.mark.safe|@pytest.mark.safe" tests`: only `tests/test_inbox_test_mode.py` and `tests/test_mcp_gateway.py` are explicitly marked safe, while `rg -c "^def test_|^    def test_" tests | awk ...` counted 864 test functions.
+- `fd -a -H '^CONTEXT\\.md$|^docs/adr$|^adr$|^decisions$|^docs/architecture$' .`: no domain glossary, ADR directory, or architecture-doc directory found.
+- `git status --ignored --short docs/overnight`: no existing overnight report or ignored output under `docs/overnight` before this write.
+
+## Architecture Map
+
+Current shape:
+
+```text
+Textual TUI: inbox.py
+  -> sync HTTP client: inbox_client.py
+  -> local FastAPI backend: inbox_server.py
+       -> source implementation module: services.py
+       -> index store: message_index_store.py
+       -> sync pipeline: message_sync.py
+       -> scheduler store: scheduler.py
+       -> memory store: memory_store.py
+
+MCP entrypoints:
+  mcp_server.py / inbox_mcp_readonly.py / stdio wrappers
+  -> tools_registry.py
+  -> mcp_backend.py
+  -> inbox_server.py
+
+Source/local stores:
+  macOS SQLite data, Google OAuth tokens, local SQLite index, local scheduler DB,
+  local memory DB, Obsidian vault, token files, launchd/systemd/Caddy examples.
+```
+
+### Entrypoints
+
+- `inbox.py:1-5` says the TUI is a thin HTTP client that auto-starts `inbox_server.py`. The code mostly follows that through `InboxClient`, but it still imports `services` directly for LLM status and favorites (`inbox.py:1954-1965`, `inbox.py:2082-2097`, `inbox.py:4048-4065`).
+- `inbox_server.py:1-3` is the local REST server entrypoint. It binds at the bottom with `uvicorn.run(app, host="127.0.0.1", port=port)` and reads `INBOX_SERVER_PORT`.
+- `message_sync.py:638-659` is a CLI for `bootstrap`, `incremental`, `rebuild`, and `summary` against `MessageIndexStore`.
+- `mcp_server.py:1-15` is the full assistant-facing MCP HTTP gateway. It talks to the private inbox REST server and uses `INBOX_MCP_TOKEN`, `INBOX_SERVER_URL`, and `INBOX_SERVER_TOKEN`.
+- `inbox_mcp_readonly.py:1-6` is the read-only MCP surface for less-trusted clients; it registers only readonly tools from `tools_registry.py` and runs on port 8001 by default (`inbox_mcp_readonly.py:77-87`).
+- `scripts/run_inbox_backend.sh`, `scripts/run_inbox_mcp_http.sh`, and the stdio script wrappers all use `uv run python ...` with `UV_CACHE_DIR=/tmp/uv-cache`.
+- `dev.sh:1-11` is the worktree-safe launcher. It defaults to `INBOX_SERVER_PORT=9850` and derives `INBOX_SERVER_URL`.
+
+### Modules And Ownership
+
+`services.py` is the main source implementation module. Its docstring states that all fetching, auth, mutation, audio, and LLM logic lives there (`services.py:1-4`). In practice it owns:
+
+- local paths, credentials, and OAuth scopes (`services.py:54-98`);
+- a read-only SQLite connection manager for macOS data sources (`services.py:215-309`);
+- Google auth for Gmail, Calendar, Drive, Sheets, Docs, and Tasks (`services.py:330-416`);
+- iMessage, Gmail, calendar, Notes, WhatsApp, Reminders, Tasks, Gemini, Maps, GitHub, Drive, Sheets, Docs, audio, LLM, search, notifications, favorites, voice commands, and calendar utility implementations.
+
+This module has depth because deleting it would scatter provider complexity everywhere. The problem is its interface: callers must know too much about provider-specific objects, global paths, token state, write guards, side effects, and private helper functions. `message_sync.py:10-12` imports `IMSG_DB`, `_clean_body`, `_decode_body`, `_parse_email_address`, and `google_auth_all` from `services.py`, so the sync module crosses a private helper seam instead of a stable source-adapter interface.
+
+`service_models.py` is the stable shared data-model module. It holds dataclasses for contacts, messages, calendar events, notes, reminders, Google tasks, GitHub notifications, Drive files, Sheets, Docs, and `ThreadSummary` (`service_models.py:1-153`). This module is deep and relatively clean: callers can use simple dataclasses without knowing provider SDK shapes.
+
+`inbox_server.py` is the main orchestration module. It currently owns Pydantic response/request models, global state, production adapters, app lifecycle, auth middleware, route handlers, scheduler loops, index health, AI endpoints, workflow endpoints, and provider routing. Evidence:
+
+- imports many names from `services.py` (`inbox_server.py:61-90` and continuing through the large import block);
+- defines the only concrete `SourceAdapters`, currently Gmail and Calendar only (`inbox_server.py:750-799`);
+- creates global `ServerState` with all service dictionaries, caches, ambient/dictation services, scheduler, index store, and adapters (`inbox_server.py:802-818`);
+- uses `InboxServerRuntime` as a test seam for server state, contacts init, Google auth, scheduler startup, ambient autostart, prewarm, and SQLite cleanup (`inbox_server.py:825-833`);
+- builds lifecycle behavior in `make_lifespan`, including contacts, Google auth, optional conversation prewarm, optional ambient autostart, scheduler loop, and cleanup (`inbox_server.py:1198-1285`);
+- installs optional token auth middleware with bearer or `x-api-key` support (`inbox_server.py:1313-1340`);
+- implements index views and sync endpoints in the same file (`inbox_server.py:2771-2807`, `inbox_server.py:3739-3853`).
+
+`InboxServerRuntime` is a useful real seam. It has multiple adapters in tests (`tests/test_server.py:29-56`, `tests/test_api_contract.py:46-72`) and lets TestClient avoid real contacts, Google auth, scheduler, and ambient startup. `SourceAdapters` is only a partial seam: it has Gmail and Calendar adapters only, while most providers are still direct function calls from server routes to `services.py`. One adapter in production and few provider variants makes much of the adapter shape hypothetical rather than fully real.
+
+`inbox_client.py` is the sync HTTP client module. It reads `INBOX_SERVER_PORT`, `INBOX_SERVER_URL`, and `INBOX_SERVER_TOKEN` at import/init time (`inbox_client.py:16-25`), can spawn `inbox_server.py` as a background process and write `server.log` (`inbox_client.py:48-77`), and mirrors many server routes as thin methods. Its indexed view methods (`inbox_client.py:86-131`) are a clean interface for the TUI, but the full client is broad because it mirrors the entire backend surface.
+
+`inbox.py` is the TUI module. It is large but has a clearer external interface: the app talks mostly through `InboxClient` and renders Textual widgets. The module owns tab metadata consumption, state, polling, rendering, keyboard actions, optimistic message display, notifications, search overlays, command palette, AI actions, and cleanup. `tui_tabs.py:19-120` provides a small shared metadata module for tabs; this is a good deepening direction because commands and TUI navigation consume one shared tab table.
+
+The indexed inbox slice is the most coherent current module group:
+
+- `message_index_store.py:69-168` owns a local SQLite index with `sync_state`, `items`, `threads`, and `sender_stats`.
+- `message_index_store.py:407-612` owns thread rebuild/query behavior and calls `thread_classifier.classify_thread`.
+- `message_sync.py:181-269` implements resumable Gmail bootstrap.
+- `message_sync.py:422-449` chooses Gmail history API incremental sync or timestamp fallback.
+- `message_sync.py:452-560` reads iMessage by rowid and materializes indexed items.
+- `message_sync.py:585-627` rebuilds only changed source/account scopes after bootstrap or incremental sync.
+- `thread_classifier.py:18-47` concentrates actionability classification in one function, with small helper functions for human score, noise class, topic, urgency, open loop, and summary.
+
+This slice has good locality for index behavior, but it still depends on private helpers and live Google auth in `services.py`, which weakens testability and makes it harder to run sync command candidates without credentials.
+
+The MCP slice has a strong registry seam:
+
+- `tools_registry.py:1-12` documents the intent: one `Tool` table drives both full and readonly MCP servers.
+- `tools_registry.py:52-119` builds FastMCP handlers from registry metadata, adds confirmation for mutating tools, and dispatches through `backend._request`.
+- `mcp_backend.py:18-59` is a small adapter over the private REST backend.
+- `mcp_server.py:48-53` says HTTP-backed tools were migrated to `tools_registry.TOOLS`, leaving hand-written tools for ambient notes and memory.
+
+This is one of the better seams in the repo. The risk is that the registry exposes 60 tools while `MCP_V1_PLAN.md:28-61` describes a much narrower V1 surface. The plan may be stale or the implementation may have outgrown the documented risk model.
+
+### Local State And Deployment Surface
+
+- `.gitignore:12-23` excludes credential and token files including `credentials.json`, `tokens/`, `github_token.txt`, `google_maps_key.txt`, `gemini_api_key.txt`, and env files.
+- `.gitignore:41-58` excludes local MCP memory, scheduler DB, `.inbox_index.sqlite3`, logs, coverage, `.claude/`, and batch outputs.
+- `scheduler.py:1-17` persists scheduled messages, follow-up reminders, and task-message links to `.inbox_scheduler.sqlite3`.
+- `memory_store.py:1-10` persists structured memory to `.inbox_memory.sqlite3`.
+- `ambient_notes.py:14-25` writes daily notes and ambient captures under `~/vault`.
+- `deploy/Caddyfile.example:1-33` exposes only `/health` and `/mcp` for full and readonly MCP hostnames.
+- `deploy/*.service.example` and `deploy/*.plist.example` hard-code `/Users/jwalinshah/projects/inbox` as the production working directory, so worktree routing must be explicit during development.
+
+## Risks And Stale Assumptions
+
+1. `services.py` is too wide for the current product phase.
+   - Evidence: `services.py` is 6,467 LOC, owns all provider logic, and includes WhatsApp, Drive, Sheets, Docs, Maps, GitHub, audio, LLM, notifications, and favorites despite `PLAN.md` narrowing Phase 1 to Gmail, iMessage, calendar, index, and TUI.
+   - Architectural effect: the module has leverage, but the interface is shallow and implicit. Callers must know provider SDK details, private helpers, path globals, and auth side effects.
+   - Safe next move: introduce source-adapter modules around Gmail and iMessage sync/read paths first, because those are core to the plan and already have tests.
+
+2. `inbox_server.py` is a server, runtime, router, policy layer, scheduler host, index controller, and workflow module at once.
+   - Evidence: 3,940 LOC, 160 `@app.*` decorators, broad `services.py` imports, global `state`, lifecycle side effects, auth middleware, and index sync endpoints.
+   - Architectural effect: route changes have poor locality. A bug in account routing, runtime startup, index health, or endpoint response shape all require understanding the same file.
+   - Safe next move: split router groups only after preserving `create_app(runtime)` behavior and API contract tests.
+
+3. Startup has live side effects that are easy to trigger accidentally.
+   - Evidence: `make_lifespan` always calls contacts init and `google_auth_all` unless a runtime overrides them (`inbox_server.py:1209-1222`). `google_auth_all` can migrate legacy tokens and may run a browser OAuth flow if scopes are missing and `credentials.json` exists (`services.py:341-359`).
+   - Architectural effect: the app lifecycle interface includes hidden credential and browser behavior. Test fixtures avoid it, but manual server starts and some direct TestClient uses still need care.
+   - Safe next move: add an explicit startup mode/policy object that separates "load existing tokens" from "interactive reauth/migration".
+
+4. The read-only/write safety model is layered but not yet unified.
+   - Evidence: service-level `INBOX_TEST_MODE` blocks 44 representative live-write paths; MCP registry has 34 confirm-gated tools; FastAPI write endpoints are still callable directly if the server token allows them.
+   - Architectural effect: "safe" depends on which interface the caller used: tests use `INBOX_TEST_MODE`, MCP uses `confirm=True`, REST uses server auth plus service guards. These are related policies but not one module.
+   - Safe next move: define a small write-policy module that can be called from REST, MCP registry, and service functions.
+
+5. Validation documentation is stale or under-specified.
+   - Evidence: `docs/TESTING_FOR_AGENTS.md` recommends `INBOX_TEST_MODE=1 uv run pytest -m safe`, but only two test modules are marked safe. `DOCS_INDEX.md` and `SHEETS_CHANGELOG.md` claim "736 tests pass", while the current test tree has 864 `test_` functions by static count.
+   - Architectural effect: agents may run a tiny safe subset and believe they validated the repo, or trust an outdated test-count claim.
+   - Safe next move: audit test markers and split "agent-safe full unit suite" from "minimal smoke suite".
+
+6. Indexed views are now the default TUI path, but the assumptions are encoded as route logic rather than product terminology.
+   - Evidence: `_index_view_rows` hard-codes actionable/recent/waiting-on filters (`inbox_server.py:2771-2807`). `MessageIndexStore.list_threads` hard-codes `newest_only` as seven days and waiting-on-others depends on `latest_sender = "Me"` (`message_index_store.py:565-612`).
+   - Architectural effect: changing product language such as "Now", "Waiting On", or "Actionable" requires touching server route logic and store query predicates.
+   - Safe next move: create an index-view definition table with view names, predicates, and acceptance tests.
+
+7. MCP implementation and MCP V1 docs have drifted.
+   - Evidence: `MCP_V1_PLAN.md` lists a small V1 set, but `tools_registry.py` now has 60 tools spanning Gmail, Sheets, Drive, Docs, Calendar, Tasks, search, memory, and workflows.
+   - Architectural effect: security and UX review cannot rely on the plan file. The implementation may be correct, but the decision record is stale.
+   - Safe next move: generate a docs-only MCP surface inventory from `tools_registry.TOOLS`, including readonly/write/confirm status.
+
+8. No local architecture decision record exists.
+   - Evidence: no `CONTEXT.md`, `docs/adr/`, `adr/`, or `docs/architecture/` found. Architecture decisions are spread across `CLAUDE.md`, `PLAN.md`, `CONNECTOR_ROADMAP.md`, and implementation files.
+   - Architectural effect: future agents will keep rediscovering the same source-adapter, account-routing, index-default, and MCP-surface decisions.
+   - Safe next move: add a docs-only `docs/architecture/` or ADR index before large refactors.
+
+## Deepening Opportunities
+
+1. Deepen the source-adapter seam for index sync.
+   - Files: `services.py`, `message_sync.py`, `message_index_store.py`, `tests/test_message_sync.py`.
+   - Problem: `message_sync.py` imports private helpers and `google_auth_all` from `services.py`; testing and sync behavior are coupled to live auth unless heavily monkeypatched.
+   - Solution: define Gmail and iMessage source adapter interfaces owned by the sync slice, with production adapters wrapping `services.py` and fake adapters in tests.
+   - Benefit: better locality for sync correctness and more leverage from tests. The interface becomes "fetch changed source items" rather than a collection of private provider helpers.
+
+2. Deepen the server policy seam for Google account routing and write preflight.
+   - Files: `google_account_resolution.py`, `inbox_server.py`, `services.py`, `tests/test_server.py`, `tests/test_gmail_actions.py`.
+   - Problem: account routing is partly centralized but still spread through route wrappers, service calls, preflight, and docs. The default account policy is documented in `CONNECTOR_ROADMAP.md` but enforced only through helper behavior and env choices.
+   - Solution: make an explicit policy module that resolves account, destination, write safety, and explanation before each write.
+   - Benefit: higher leverage for all Google write paths and fewer account-routing regressions.
+
+3. Deepen indexed view definitions.
+   - Files: `inbox_server.py`, `inbox_client.py`, `inbox.py`, `message_index_store.py`, `tests/test_message_index_store.py`, `tests/test_client.py`.
+   - Problem: "Now", "Actionable", and "Waiting On" are product concepts, but their exact filters are scattered across server route helpers and store method parameters.
+   - Solution: create one view-definition module that maps product view names to store predicates, labels, and expected sorting.
+   - Benefit: callers get a smaller interface and tests can assert product meaning without duplicating predicate knowledge.
+
+4. Deepen MCP registry documentation and safety.
+   - Files: `tools_registry.py`, `mcp_server.py`, `inbox_mcp_readonly.py`, `MCP_V1_PLAN.md`, `MCP_SETUP.md`, `tests/test_tools_registry.py`, `tests/test_api_contract.py`.
+   - Problem: the implementation has a strong registry, but docs no longer match the tool surface.
+   - Solution: generate or hand-maintain a registry inventory table that lists tool name, route, readonly/write, confirm requirement, and exposure path.
+   - Benefit: security review and cloud-agent handoff become concrete and testable.
+
+## Independently Grabbable Next Tasks
+
+1. Test-marker audit and validation doc repair.
+   - Acceptance criteria:
+     - Identify which current tests are deterministic and agent-safe.
+     - Add or adjust `safe` markers, or update `docs/TESTING_FOR_AGENTS.md` so it no longer implies broad coverage from `pytest -m safe`.
+     - Replace stale "736 tests pass" claims with current evidence or remove exact count claims.
+   - Suggested validation:
+     - `INBOX_TEST_MODE=1 uv run pytest -m safe -q --no-cov`
+     - `uv run ruff check docs/TESTING_FOR_AGENTS.md DOCS_INDEX.md SHEETS_CHANGELOG.md` if markdown lint is configured; otherwise `git diff --check`.
+   - Owned files:
+     - `docs/TESTING_FOR_AGENTS.md`, `DOCS_INDEX.md`, `SHEETS_CHANGELOG.md`, selected `tests/*.py`.
+
+2. MCP surface inventory docs.
+   - Acceptance criteria:
+     - Add a docs-only table generated from or manually synchronized with `tools_registry.TOOLS`.
+     - Each row includes tool name, HTTP method/path, readonly/write, confirm-gated status, and whether it appears in full MCP, readonly MCP, or both.
+     - `MCP_V1_PLAN.md` either becomes historical or is updated to match the current surface.
+   - Suggested validation:
+     - `INBOX_TEST_MODE=1 uv run pytest tests/test_tools_registry.py tests/test_api_contract.py -q --no-cov`
+     - `git diff --check`
+   - Owned files:
+     - `MCP_V1_PLAN.md`, `MCP_SETUP.md`, possible new `docs/mcp-surface.md`.
+
+3. Indexed view definition module.
+   - Acceptance criteria:
+     - Move hard-coded view names/predicates from `_index_view_rows` into a small pure module.
+     - Preserve endpoint responses for `/index/views/{view_name}`.
+     - Add tests proving `recent`, `actionable`, `waiting-on`, `waiting-on-me`, and `waiting-on-others` map to expected store queries.
+   - Suggested validation:
+     - `INBOX_TEST_MODE=1 uv run pytest tests/test_message_index_store.py tests/test_server.py::TestIndexEndpoints tests/test_client.py::TestClientIndexedInbox -q --no-cov`
+     - `uv run ruff check inbox_server.py message_index_store.py tests/test_message_index_store.py tests/test_server.py tests/test_client.py`
+   - Owned files:
+     - `inbox_server.py`, new small index view module, `message_index_store.py` only if its interface must change, related tests.
+
+4. Source-adapter seam for sync.
+   - Acceptance criteria:
+     - Introduce explicit production/fake adapters for Gmail sync and iMessage sync.
+     - `message_sync.bootstrap` and `message_sync.incremental` accept injected adapters or a runtime object in tests.
+     - No behavior change to CLI defaults.
+   - Suggested validation:
+     - `INBOX_TEST_MODE=1 uv run pytest tests/test_message_sync.py tests/test_message_index_store.py -q --no-cov`
+     - `uv run ruff check message_sync.py message_index_store.py tests/test_message_sync.py`
+   - Owned files:
+     - `message_sync.py`, possible new adapter module, `tests/test_message_sync.py`.
+
+5. Server runtime/router split spike.
+   - Acceptance criteria:
+     - Move only one low-risk route group, preferably index routes, into a router module while preserving `create_app(runtime)`.
+     - API contract tests still prove MCP paths and client response shapes.
+     - No provider route behavior changes.
+   - Suggested validation:
+     - `INBOX_TEST_MODE=1 uv run pytest tests/test_api_contract.py tests/test_server.py::TestIndexEndpoints -q --no-cov`
+     - `uv run ruff check inbox_server.py <new_router_module>.py tests/test_api_contract.py tests/test_server.py`
+   - Owned files:
+     - `inbox_server.py`, new route module, index endpoint tests.
+
+## Validation Candidates
+
+Required queue validation:
+
+- `git status --short`
+  - Final observed status in this sandbox: command runs successfully and reports the untracked docs-only report path.
+  - Clean status would require staging/committing the report, but `git add docs/overnight/inbox-sym-214-architecture-map.md` is blocked by sandbox permissions because this worktree's Git metadata lives under `/Users/jwalinshah/projects/inbox/.git/worktrees/inbox-sym-214-architecture-map/index.lock`, outside the writable roots.
+
+Cheap architecture validation candidates not run during this audit:
+
+- `git diff --check`
+  - Expected status: pass for this docs-only report.
+
+- `INBOX_TEST_MODE=1 uv run pytest -m safe -q --no-cov`
+  - Expected status: pass, but coverage is currently narrow because only two modules are explicitly marked safe.
+
+- `INBOX_TEST_MODE=1 uv run pytest tests/test_message_index_store.py tests/test_message_sync.py -q --no-cov`
+  - Expected status: pass for the index/sync slice, assuming dependencies are installed.
+
+- `INBOX_TEST_MODE=1 uv run pytest tests/test_tools_registry.py tests/test_api_contract.py -q --no-cov`
+  - Expected status: pass for MCP registry route coverage, assuming dependencies are installed.
+
+- `uv run ruff check .`
+  - Expected status: likely pass if recent merges were clean, but unverified in this queue item.
+
+- `uv run pyright`
+  - Expected status: unknown. The repo config enables basic type checking and `reportMissingImports=true`; local ML/macOS/provider imports may affect this outside the pytest stubbing path.
+
+I did not run pytest, ruff, or pyright because the queue item validation is `git status --short`, the audit is read-only/docs-only, and pytest addopts include coverage by default unless overridden.
+
+## Non-Goals
+
+- No product-code refactor.
+- No endpoint, MCP tool, or TUI behavior change.
+- No live server start.
+- No Google, Gmail, Calendar, Drive, Docs, Sheets, GitHub, iMessage, Notes, Reminders, WhatsApp, audio, or external service calls.
+- No credential/token inspection beyond tracked example files and `.gitignore`.
+- No deploy, public exposure, push, PR creation, or external tracker update.
+- No sibling repo comparison. This repo is not small: the top-level Python modules alone are 21,703 LOC and warranted the full audit time locally.
+
+## Unknowns
+
+- Whether the primary daily-driver server on port 9849 is healthy today; not checked because this queue item avoids live local services.
+- Whether local OAuth token state matches documented multi-account assumptions.
+- Whether WhatsApp, Drive, Sheets, Docs, GitHub, memory, and voice are active product scope or historical accretion.
+- Whether all 864 statically counted tests pass; no test suite was run.
+- Whether the "736 tests pass" docs claim was true when written; it is stale against current static test count.
+- Whether `INBOX_DEFAULT_GOOGLE_ACCOUNT` is set in production and whether account routing matches the roadmap's desired default.
+- Whether the MCP full surface is intentionally public/trusted or simply ahead of `MCP_V1_PLAN.md`.
+
+## Handoff Notes
+
+Changed file from this queue item:
+
+- `docs/overnight/inbox-sym-214-architecture-map.md`
+
+No blockers encountered for writing the report. Commit evidence is blocked locally by Git metadata permissions outside the writable roots; the handoff should treat the uncommitted docs-only report as the artifact.

--- a/docs/overnight/inbox-sym-214-dependency-surface.md
+++ b/docs/overnight/inbox-sym-214-dependency-surface.md
@@ -1,0 +1,195 @@
+# inbox-sym-214 dependency-surface audit
+
+Queue item: `inbox-sym-214-dependency-surface`
+Focus area: `dependency-surface`
+Repo path: `/Users/jwalinshah/projects/agent-stack/.agent-stack-worktrees/2026-05-07-overnight-marathon/inbox-sym-214-dependency-surface`
+Audit date: 2026-05-07
+
+## Summary
+
+`inbox-sym-214` is a Python/uv personal inbox service and Textual TUI that bridges local macOS data stores, Google APIs, GitHub, local ML/audio, and MCP agent access. The dependency surface is broad for a personal local tool: FastAPI/uvicorn/httpx for the backend, Textual/Rich for the TUI, Google OAuth/API clients, MCP server tooling, pyobjc/macOS SQLite readers, sounddevice/whisper/MLX local ML, and optional Gemini/Google Maps/GitHub token files.
+
+The declared dependency source of truth is `pyproject.toml` plus `uv.lock`, not the README. `uv tree` with a sandbox-safe cache resolves 149 packages. The highest-leverage follow-up is to separate always-needed server/TUI dependencies from optional macOS/audio/ML/Gemini surfaces and to make cache, env, and worktree path assumptions explicit.
+
+## Repo State
+
+- Branch: `codex/goal-inbox-sym-214-dependency-surface`.
+- HEAD at start of audit: `2805b8400519da188ca7d3f6e39b19a8ca42b05a`.
+- Initial dirty state: `git status --short --branch` printed only `## codex/goal-inbox-sym-214-dependency-surface`, so the worktree started clean.
+- Required output written: `docs/overnight/inbox-sym-214-dependency-surface.md`.
+- External services, credentials, live data, deploys, pushes, and PR creation were not touched.
+
+## Commands Run
+
+- `llm-tldr tree .` - mapped tracked top-level repo shape and confirmed the project is a flat Python app with `tests/`, `scripts/`, `deploy/`, `config/`, `modes/`, `batch/`, and hidden `.factory/` artifacts.
+- `git status --short --branch` - observed starting branch and clean state.
+- `git rev-parse --show-toplevel` - confirmed the worktree root is the queue-item repo path.
+- `git rev-parse HEAD` - captured `2805b8400519da188ca7d3f6e39b19a8ca42b05a`.
+- `rtk read pyproject.toml` - inspected declared Python, runtime deps, dev deps, pytest markers, ruff, pyright, and bandit config.
+- `rtk read README.md` and `rtk read docs/TESTING_FOR_AGENTS.md` - compared docs claims and safe validation guidance against dependency declarations.
+- `rg --files --hidden -g '!.git'` - found hidden tracked surfaces including `.mcp.json`, `.env.mcp.example`, `.factory/services.yaml`, `.factory/validation/**`, `.cursor/mcp.json`, `.pre-commit-config.yaml`, `.python-version`, and `.gitignore`.
+- `git ls-files --others --ignored --exclude-standard` - produced no output; no ignored local secrets/caches/artifacts were present at audit time.
+- `rg -n "os\\.environ|os\\.getenv|getenv\\(|load_dotenv|dotenv|INBOX_|OPENAI|ANTHROPIC|GOOGLE|GMAIL|CALENDAR|DRIVE|GITHUB|TOKEN|SECRET|CREDENTIAL|PORT|HOST|HOME|Library|sqlite|\\.db|\\.sqlite|\\.json|tokens/|credentials\\.json|github_token" ...` - located env, token, local SQLite, and local config surfaces across code/docs/scripts.
+- `uv tree --locked --depth 1` - failed in this sandbox because `uv` tried to initialize `/Users/jwalinshah/.cache/uv` and hit `Operation not permitted`.
+- `UV_CACHE_DIR=/private/tmp/uv-cache-inbox-audit uv tree --locked --depth 1` - passed, used CPython 3.12.12, resolved 149 packages, and listed direct runtime/dev packages.
+- `rg -n -A80 '^name = "inbox"' uv.lock` - confirmed the lockfile package metadata matches direct runtime/dev deps.
+- `rg '^name = ' uv.lock --count` - counted 149 locked packages.
+- `rg -n 'name = "(torch|mlx|mlx-lm|mlx-whisper|transformers|sounddevice|pyobjc-framework-(applicationservices|quartz)|mcp|fastapi|uvicorn|google-api-python-client|google-generativeai|outlines|textual|numpy)"|cuda|nvidia|triton' uv.lock` - identified heavy platform-specific transitive dependency families.
+- `nl -ba ... | sed -n ...` slices - captured line-level evidence from `services.py`, `inbox_server.py`, `mcp_gateway.py`, `mcp_backend.py`, `dev.sh`, `.gitignore`, `docs/TESTING_FOR_AGENTS.md`, `pyproject.toml`, `.mcp.json`, and related config files.
+
+## Evidence Map
+
+### Dependency declarations and lockfile
+
+- `pyproject.toml:5` requires `>=3.12,<3.15`, while `.python-version` pins `3.12`. This conflicts with README's "Python 3.10+" quick-start claim in `README.md`.
+- `pyproject.toml:6-26` declares runtime deps: `fastapi`, Google clients, `httpx`, `loguru`, `mcp[cli]`, `mlx-lm`, `mlx-whisper`, `numpy`, `outlines`, `pydantic`, pyobjc ApplicationServices/Quartz, `python-multipart`, `rich`, `sounddevice`, `textual`, and `uvicorn`.
+- `pyproject.toml:28-38` declares dev deps: `bandit`, `hypothesis`, `pre-commit`, `pyright`, `pytest`, `pytest-cov`, `python-dotenv`, and `ruff`.
+- `pyproject.toml:53-66` configures pytest with coverage by default, safe/integration/local/live markers, ruff, pyright basic mode, and bandit skips. Running normal pytest will create coverage artifacts unless the caller overrides coverage.
+- `uv.lock:860-930` mirrors the `inbox` direct deps and dev deps, and `rg '^name = ' uv.lock --count` counted 149 package entries.
+- `UV_CACHE_DIR=/private/tmp/uv-cache-inbox-audit uv tree --locked --depth 1` resolved direct packages to current locked versions including `fastapi v0.135.3`, `mcp[cli] v1.27.0`, `mlx-lm v0.31.2`, `mlx-whisper v0.4.3`, `numpy v2.4.4`, `textual v8.2.3`, `uvicorn v0.44.0`, and dev tools such as `pytest v9.0.3` and `ruff v0.15.10`.
+- `uv.lock` includes platform-heavy ML transitive packages: `torch`, `transformers`, `triton`, `cuda-*`, and `nvidia-*` packages are present behind markers from `mlx-whisper`/ML tooling, even though this repo is documented as macOS/local-first.
+
+### Runtime entrypoints and scripts
+
+- `README.md` documents `uv run python inbox.py` as the default TUI/server launcher and `uv run python inbox_server.py` for server-only use.
+- `dev.sh:1-11` is the worktree launcher and sets `INBOX_SERVER_PORT=9850` plus `INBOX_SERVER_URL=http://127.0.0.1:${INBOX_SERVER_PORT}` before `uv run python "${1:-inbox.py}"`.
+- `inbox_server.py:212-213` defaults the backend to port `9849` and uses `INBOX_SERVER_TOKEN` for optional auth.
+- `inbox_server.py:3936-3940` reads `INBOX_SERVER_PORT` only in the `__main__` uvicorn path, binding to `127.0.0.1`.
+- `mcp_backend.py:9-21` reads `INBOX_SERVER_URL` and `INBOX_SERVER_TOKEN`, defaulting to `http://127.0.0.1:9849`.
+- `scripts/run_inbox_backend.sh:1-9`, `scripts/run_inbox_mcp_http.sh`, `scripts/run_inbox_mcp_http_readonly.sh`, `scripts/run_inbox_mcp_stdio.sh`, and `scripts/run_inbox_mcp_stdio_readonly.sh` all set `UV_CACHE_DIR="${UV_CACHE_DIR:-/tmp/uv-cache}"` before `uv run`.
+- `.factory/services.yaml:1-14` duplicates operational commands and hardcodes `/Users/jwalinshah/projects/inbox` plus port `9849`.
+
+### Env vars, secrets, and local-only state
+
+- `config/inbox.env.example:1-9` defines `INBOX_SERVER_URL`, `INBOX_SERVER_TOKEN`, `INBOX_MCP_TOKEN`, and optional `INBOX_MEMORY_DB`.
+- `.env.mcp.example:1-10` defines a similar MCP-specific env surface but leaves `INBOX_SERVER_TOKEN` empty and warns to set `INBOX_MCP_TOKEN` before exposing publicly.
+- `.mcp.json:1-25` and `.cursor/mcp.json` provide repo-local MCP stdio servers for full and read-only tools, both using `${INBOX_SERVER_TOKEN}` and `127.0.0.1:9849`.
+- `config/codex.inbox.example.toml:1-29` hardcodes `cwd = "/Users/jwalinshah/projects/inbox"` for the main config and only shows worktree `cwd` as a commented example.
+- `services.py:56-86` defines credential and token files in repo root: `credentials.json`, `token.json`, `tokens/`, `github_token.txt`, `google_maps_key.txt`, and `gemini_api_key.txt`.
+- `services.py:88-98` requests broad Google scopes: Gmail readonly/modify/send/settings, Calendar, Drive, Spreadsheets, Documents, and Tasks.
+- `inbox_test_mode.py:9-31` defines `INBOX_TEST_MODE`, `INBOX_TEST_DATA_DIR`, and `INBOX_TEST_NOW`, with test data defaulting to `/tmp/inbox-test-data`.
+- `mcp_gateway.py:18-39` reads `INBOX_MCP_TOKEN` and `INBOX_MEMORY_DB`. If `INBOX_MCP_TOKEN` is unset, `_is_publicly_authorized` returns true because there is no token to compare.
+- `services.py:3249-3264` loads Gemini via `GEMINI_API_KEY` or `gemini_api_key.txt`, despite the README's local-first positioning.
+- `services.py:3485-3504` supports `INBOX_HOME_ADDRESS` for commute/location fallback.
+- `services.py:4829-4835` sets the local MLX autocomplete model and `INBOX_LLM_LARGE` override.
+- `inbox_server.py:1230-1258` reads `INBOX_PRE_WARM_CONVERSATIONS` and `INBOX_DISABLE_AMBIENT`.
+- `inbox_server.py:3939` reads `INBOX_SERVER_PORT`.
+- `inbox.py:44-48` reads `INBOX_POLL_INTERVAL`.
+
+### Local data stores and generated artifacts
+
+- `services.py:67-80` reads iMessage, Notes, and Reminders SQLite paths from the real macOS home directory unless `INBOX_TEST_MODE` redirects them into test data.
+- `contacts.py:39-78` reads AddressBook SQLite from `~/Library/Application Support/AddressBook/...` in read-only SQLite mode.
+- `message_sync.py:452-456` reads iMessage messages via `sqlite3.connect(...mode=ro...)`.
+- `message_index_store.py:12-13` defaults the local index DB to `.inbox_index.sqlite3` in the repo root.
+- `memory_store.py:9-10` defaults the MCP memory DB to `.inbox_memory.sqlite3` in the repo root.
+- `scheduler.py:15-16` defaults scheduler state to `.inbox_scheduler.sqlite3` in the repo root.
+- `services.py:5429-5433`, `services.py:5560-5564`, and `services.py:6090-6100` default notification, favorite, and voice config to `~/.config/inbox/*.json` plus `~/vault`.
+- `.gitignore:12-25` ignores credentials, tokens, env files, and key/secret patterns.
+- `.gitignore:27-58` ignores coverage, logs, `.tldr/`, `.claude/`, `.inbox_memory.sqlite3`, `.inbox_scheduler.sqlite3`, `.inbox_index.sqlite3`, and batch outputs.
+- `rg --files --hidden -g '!.git'` shows many tracked `.factory/validation/**` JSON artifacts. They are hidden generated-looking evidence files but are committed, not ignored.
+- `git ls-files --others --ignored --exclude-standard` returned no ignored files, so no local secrets, `.venv`, SQLite DBs, coverage, logs, or caches were visible in this worktree during the audit.
+
+### Deployment and external exposure surfaces
+
+- `deploy/inbox-backend.service.example`, `deploy/inbox-mcp.service.example`, and `deploy/inbox-mcp-readonly.service.example` hardcode `WorkingDirectory=/Users/jwalinshah/projects/inbox`, `EnvironmentFile=/Users/jwalinshah/projects/inbox/config/inbox.env`, and scripts under that same path.
+- `deploy/com.inbox.backend.plist.example`, `deploy/com.inbox.mcp.plist.example`, and `deploy/com.inbox.mcp-readonly.plist.example` hardcode `cd /Users/jwalinshah/projects/inbox && source config/inbox.env && ...` and write logs to `/tmp/inbox-*.log`.
+- `deploy/Caddyfile.example` exposes `/health` and `/mcp*` for full MCP on `127.0.0.1:8000` and read-only MCP on `127.0.0.1:8001`.
+- `scripts/setup_inbox_mcp.sh` copies `config/inbox.env.example` to `config/inbox.env` with `chmod 600`, installs launch agents, and prints guidance to keep `INBOX_SERVER_TOKEN` out of Codex config.
+- `batch/batch-runner.sh` is an external-write surface: it reads `INBOX_SERVER_URL`/`INBOX_SERVER_TOKEN`, calls `/gmail/batch-modify`, writes `batch/archive-state.tsv`, and writes per-thread logs under `batch/logs/`.
+
+## Risks And Stale Assumptions
+
+1. Python version docs are stale. `pyproject.toml` requires Python `>=3.12,<3.15` and `.python-version` is `3.12`, while `README.md` still says Python `3.10+`. A new agent or human following README may build the wrong environment before hitting type syntax or locked dependency issues.
+
+2. The "local-first ML/no cloud dependencies" story is not cleanly separated from optional cloud LLMs. Runtime deps include `google-generativeai`; `services.py` reads `GEMINI_API_KEY`/`gemini_api_key.txt`; `inbox_server.py` exposes Gemini endpoints. This may be intentional, but it is not visible as an optional extra or feature flag in the dependency model.
+
+3. MCP public auth can fail open if the token is unset. `mcp_gateway.py:36-39` authorizes all requests when `INBOX_MCP_TOKEN` is empty, while `deploy/Caddyfile.example` documents an externally exposed `/mcp*` route. The docs do warn to require `INBOX_MCP_TOKEN`, but the code-level default remains permissive.
+
+4. Worktree safety depends on remembering several path overrides. `dev.sh` handles a dev port, but `.mcp.json`, `.cursor/mcp.json`, `config/codex.inbox.example.toml`, `config/gemini-settings.inbox.example.json`, `.factory/services.yaml`, and deploy templates default to `/Users/jwalinshah/projects/inbox` or `9849`. Agents can accidentally test the primary checkout/server while editing a worktree.
+
+5. The dependency lock is heavy and platform-sensitive. `mlx-lm`, `mlx-whisper`, `sounddevice`, pyobjc, `torch`, `transformers`, `triton`, and CUDA/NVIDIA packages make the install surface much larger than a backend/TUI baseline. This creates higher sync time, storage, native library, and non-macOS failure risk.
+
+6. Local generated state lives beside source unless test mode or env overrides redirect it. `.inbox_index.sqlite3`, `.inbox_memory.sqlite3`, `.inbox_scheduler.sqlite3`, `tokens/`, `token.json`, and key files are gitignored, but a worktree can still accumulate personal state. This is especially risky for isolated worker runs and morning dirty-worktree review.
+
+7. `uv` cache behavior is inconsistent by entrypoint. The service wrapper scripts set `UV_CACHE_DIR=/tmp/uv-cache`; `dev.sh` and raw validation commands do not. In the Codex sandbox, raw `uv tree --locked --depth 1` failed on `/Users/jwalinshah/.cache/uv`, while the same command passed with a temp `UV_CACHE_DIR`.
+
+8. Batch tooling is an externally visible mutation path under a local-looking folder. `batch/batch-runner.sh` writes state/logs and performs Gmail batch modify calls. The generated outputs are ignored, but the input TSV is tracked and the script can mutate Gmail if pointed at a live server.
+
+## Decisions Made During Audit
+
+- Treat `pyproject.toml` and `uv.lock` as the dependency source of truth over README claims.
+- Treat env vars, local SQLite paths, ignored artifacts, deploy templates, and MCP config as part of the dependency surface because they determine whether dependency commands touch live data or the intended worktree.
+- Do not run live tests, servers, MCP tools, OAuth flows, launchctl, Caddy, batch archive, or any command that could touch personal data or external services.
+- Use `UV_CACHE_DIR=/private/tmp/uv-cache-inbox-audit` only for dependency inspection, outside the repo, to avoid mutating project caches.
+- Leave code and operational templates unchanged; this audit is a report-only artifact.
+
+## Validation Candidates
+
+| Command | Expected status | Evidence / notes |
+| --- | --- | --- |
+| `git status --short` | Pass. After this report is written, expected output is the new report path only. | Required queue validation. |
+| `UV_CACHE_DIR=/private/tmp/uv-cache-inbox-audit uv tree --locked --depth 1` | Pass. | Ran successfully; CPython 3.12.12; resolved 149 packages. |
+| `uv tree --locked --depth 1` | Fail in current sandbox unless cache is redirected. | Ran and failed with `failed to open file /Users/jwalinshah/.cache/uv/sdists-v9/.git: Operation not permitted`. |
+| `INBOX_TEST_MODE=1 UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/test_inbox_test_mode.py -q --no-cov` | Expected pass; safe focused smoke candidate. | Not run in this audit because the issue validation is `git status --short`. `--no-cov` avoids default coverage artifact churn from `pyproject.toml`. |
+| `INBOX_TEST_MODE=1 UV_CACHE_DIR=/tmp/uv-cache uv run pytest -m safe --no-cov` | Expected pass if safe markers remain coherent; safest broader test candidate. | Not run in this audit. `docs/TESTING_FOR_AGENTS.md` names `INBOX_TEST_MODE=1 uv run pytest -m safe` as the default safe loop. |
+| `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check .` | Expected pass candidate, but not proven here. | Listed in `docs/TESTING_FOR_AGENTS.md` and `.factory/services.yaml`; not run because report-only validation was requested. |
+| `UV_CACHE_DIR=/tmp/uv-cache uv run pyright` | Expected pass candidate, but not proven here. | Listed in `docs/TESTING_FOR_AGENTS.md` and `.factory/services.yaml`; not run because report-only validation was requested. |
+
+## Next Safe Work
+
+1. Align Python/runtime docs with the locked dependency contract.
+   - Scope: `README.md`, `CLAUDE.md`, `docs/TESTING_FOR_AGENTS.md`, maybe `DOCS_INDEX.md`.
+   - Acceptance criteria: README says Python 3.12+ and points to `.python-version`; docs mention `UV_CACHE_DIR=/tmp/uv-cache` for sandboxed agents; validation commands avoid accidental coverage artifacts when appropriate.
+   - Validation: `git diff --check`; `UV_CACHE_DIR=/tmp/uv-cache uv tree --locked --depth 1`; `git status --short`.
+
+2. Split optional dependency groups/extras for ML, audio, macOS private data, and cloud Gemini.
+   - Scope: `pyproject.toml`, `uv.lock`, import guards in modules that use optional deps, and docs.
+   - Acceptance criteria: a backend-only or test-only sync does not require MLX/audio/torch/CUDA/Gemini packages; full local app still installs all existing functionality; missing optional deps produce actionable messages instead of import-time crashes.
+   - Validation: `UV_CACHE_DIR=/tmp/uv-cache uv sync --locked`; `INBOX_TEST_MODE=1 UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/test_inbox_test_mode.py -q --no-cov`; `UV_CACHE_DIR=/tmp/uv-cache uv run pyright`.
+
+3. Build a documented env-var inventory and drift check.
+   - Scope: new docs section or generated markdown plus a small script/test that compares `INBOX_*`, `GEMINI_API_KEY`, and local key-file references in code against examples/docs.
+   - Acceptance criteria: every runtime env var has owner, default, secret/non-secret classification, live-data risk, and worktree guidance; examples do not disagree on required tokens.
+   - Validation: `rg -n 'INBOX_|GEMINI_API_KEY|github_token|credentials.json|tokens/' .`; new focused unit test or script; `git diff --check`.
+
+4. Make MCP and deploy templates worktree-safe and fail-closed.
+   - Scope: `.mcp.json`, `.cursor/mcp.json`, `config/codex.inbox.example.toml`, `config/gemini-settings.inbox.example.json`, `deploy/*.example`, `scripts/setup_inbox_mcp.sh`, `MCP_SETUP.md`.
+   - Acceptance criteria: examples clearly distinguish primary checkout from worktree checkout; HTTP MCP examples require `INBOX_MCP_TOKEN`; docs warn that unset `INBOX_MCP_TOKEN` is open; no template accidentally points a worktree worker at `/Users/jwalinshah/projects/inbox` without an explicit note.
+   - Validation: `rg -n '/Users/jwalinshah/projects/inbox|INBOX_MCP_TOKEN|INBOX_SERVER_URL' .mcp.json .cursor/mcp.json config deploy MCP_SETUP.md`; `git diff --check`.
+
+5. Move or parameterize repo-root SQLite state.
+   - Scope: `message_index_store.py`, `memory_store.py`, `scheduler.py`, docs, and tests.
+   - Acceptance criteria: default runtime state follows an XDG-ish per-user state directory or documented env override; test mode remains isolated; repo-root `.inbox_*.sqlite3` compatibility is preserved or migrated intentionally.
+   - Validation: `INBOX_TEST_MODE=1 UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/test_memory_store.py tests/test_message_index_store.py tests/test_inbox_test_mode.py -q --no-cov`.
+
+6. Audit batch mutation tooling before any automated worker uses it.
+   - Scope: `batch/batch-runner.sh`, `batch/archive-input.tsv`, docs for dry-run/live-run boundaries.
+   - Acceptance criteria: dry-run is the default for agent usage; live Gmail mutation requires explicit confirmation; state/log writes are robust under parallelism; token/header handling is shell-safe.
+   - Validation: `bash -n batch/batch-runner.sh`; `batch/batch-runner.sh --mode archive --dry-run` only against non-live fixtures or mocked server.
+
+## Non-Goals
+
+- No product code changes.
+- No dependency upgrades, lockfile rewrite, or install changes.
+- No OAuth, Gmail, Calendar, Drive, Sheets, Docs, Tasks, GitHub, iMessage, Notes, Reminders, microphone, Caddy, launchd, systemd, or MCP live calls.
+- No reading ignored secrets or local credential files.
+- No server startup, deploy, push, PR creation, or tracker state mutation.
+- No sibling repo comparison; this repo is large enough that the dependency-surface audit did not need to borrow scope from related repos.
+
+## Unknowns
+
+- Whether `google-generativeai` is intended as a first-class runtime dependency or should become an optional extra.
+- Whether non-macOS installation is supported at all, given `pyobjc`, MLX, Homebrew whisper paths, and local macOS SQLite data sources.
+- Whether full MCP HTTP is ever intentionally exposed outside localhost; current docs imply remote exposure is possible through Caddy.
+- Whether repo-root `.inbox_*.sqlite3` defaults are intentional for portability or historical leftovers.
+- Whether tracked `.factory/validation/**` JSON files are durable project evidence or generated artifacts that should age out.
+- Whether `uv run pytest -m safe` currently covers enough of the dependency surface, since only a subset of test files visibly carry `pytest.mark.safe`.
+
+## Handoff
+
+- Changed files: `docs/overnight/inbox-sym-214-dependency-surface.md`.
+- Current HEAD SHA: `2805b8400519da188ca7d3f6e39b19a8ca42b05a`.
+- Required validation: `git status --short` exited 0 and printed `?? docs/overnight/`.
+- PR URL: none; PR creation is out of scope for this Goal Pack item.
+- Blockers: none for the report. Raw `uv` commands need `UV_CACHE_DIR` redirected in this sandbox.

--- a/docs/overnight/inbox-sym-214-docs-claims.md
+++ b/docs/overnight/inbox-sym-214-docs-claims.md
@@ -1,0 +1,220 @@
+# Overnight docs-claims audit: inbox-sym-214
+
+Queue item: `inbox-sym-214-docs-claims`
+Focus area: docs claims, supported evidence, unsupported claims, non-claims, and next safe work
+Worktree: `/Users/jwalinshah/projects/agent-stack/.agent-stack-worktrees/2026-05-07-overnight-marathon/inbox-sym-214-docs-claims`
+
+## Repo purpose and state
+
+This repo is a local-first personal inbox/control-plane application. The tracked surface is a Python FastAPI backend, a Textual TUI, MCP gateways, Google and Apple data-source adapters, indexing/scheduler stores, and agent-facing workflow docs.
+
+Current local state observed before writing this report:
+
+- Branch: `codex/goal-inbox-sym-214-docs-claims`.
+- HEAD before this report: `2805b84`.
+- `git status --short --branch` initially printed only `## codex/goal-inbox-sym-214-docs-claims`, so the tracked worktree was clean.
+- `llm-tldr tree .` showed the expected repo-local surface: root Python modules, `tests/`, `docs/`, `modes/`, `config/`, `deploy/`, and `scripts/`.
+- `rg --files -g '*.md' | wc -l` found 18 visible Markdown files, not the 6-file documentation set claimed by `DOCS_INDEX.md`.
+- `rg -c '@app\.' inbox_server.py` found 160 FastAPI route decorators.
+- `rg '^\s*def test_' tests | wc -l` found 864 test definitions.
+- `rg -l 'pytestmark = pytest.mark.safe|@pytest.mark.safe' tests` found only `tests/test_inbox_test_mode.py` and `tests/test_mcp_gateway.py` marked safe at file or test level.
+- A validation probe, `UV_CACHE_DIR=/tmp/uv-cache INBOX_TEST_MODE=1 uv run pytest --collect-only -q`, failed before collection because `uv` attempted to download `pyobjc-framework-quartz==12.1` and network/DNS is unavailable in this sandbox. The temporary ignored `.venv` from that failed probe was removed.
+
+## Documentation surface reviewed
+
+Core docs reviewed:
+
+- `README.md`
+- `CLAUDE.md`
+- `DOCS_INDEX.md`
+- `MCP_SETUP.md`
+- `MCP_V1_PLAN.md`
+- `CONNECTOR_ROADMAP.md`
+- `PLAN.md`
+- `SHEETS.md`
+- `SHEETS_QUICKSTART.md`
+- `SHEETS_CHANGELOG.md`
+- `docs/TESTING_FOR_AGENTS.md`
+- `modes/_shared.md`
+- `modes/morning-brief.md`
+- `modes/triage.md`
+- `modes/followup-sweep.md`
+- `modes/batch-archive.md`
+- `config/_profile.md`
+
+Implementation and validation evidence reviewed:
+
+- `pyproject.toml`
+- `services.py`
+- `inbox_server.py`
+- `inbox.py`
+- `inbox_client.py`
+- `google_account_resolution.py`
+- `mcp_gateway.py`
+- `mcp_server.py`
+- `inbox_mcp_stdio.py`
+- `inbox_mcp_readonly.py`
+- `inbox_mcp_readonly_stdio.py`
+- `tools_registry.py`
+- `.mcp.json`
+- `.cursor/mcp.json`
+- `.gitignore`
+- `tests/test_server.py`
+- `tests/test_server_endpoints.py`
+- `tests/test_tools_registry.py`
+- `tests/test_services.py`
+- `tests/test_inbox_test_mode.py`
+- `tests/test_mcp_gateway.py`
+
+## Supported claims
+
+The README's high-level purpose claim is mostly supported. `README.md:3` says the app consolidates iMessage, Gmail, Calendar, Sheets, Notes, Reminders, GitHub, and Drive. The backend has route families for conversations/messages, Calendar, Notes, Reminders, GitHub, Drive, Sheets, Docs, Tasks, WhatsApp, index views, workflow helpers, and AI endpoints in `inbox_server.py`. The TUI has tabs and state handlers for all/iMessage/Gmail/Calendar/Notes/Reminders/GitHub/Drive/actionable/waiting in `inbox.py:1179-1195` and `inbox.py:1830-1857`.
+
+The client-server claim is supported. `README.md:24` and `CLAUDE.md:80-85` describe `services.py`, `inbox_server.py`, `inbox_client.py`, and `inbox.py` as data layer, FastAPI server, HTTP client, and TUI. The route list in `inbox_server.py` and client methods in `inbox_client.py` match that split.
+
+The token-auth claim is supported for the private REST API and public MCP gateway. `README.md:50` and `CLAUDE.md:115-116` document `INBOX_SERVER_TOKEN`. `inbox_client.py:23` reads that env var for the HTTP client, and `inbox_server.py:213` defines `AUTH_TOKEN_ENV = "INBOX_SERVER_TOKEN"`. `MCP_SETUP.md:142-154` documents separate `INBOX_SERVER_TOKEN` and `INBOX_MCP_TOKEN`; `mcp_gateway.py:18-45` implements `INBOX_MCP_TOKEN` bearer auth for public MCP paths while allowing `/health`.
+
+The MCP split in `MCP_SETUP.md` is broadly supported. The doc says `mcp_server.py` is the full HTTP gateway, `inbox_mcp_readonly.py` is the read-only HTTP gateway, and the `*_stdio.py` files are local subprocess entrypoints. Code matches: `mcp_server.py:145-151` exposes a Starlette `/mcp` app through uvicorn on `127.0.0.1:8000`, `inbox_mcp_readonly.py:80-87` does the same on `INBOX_MCP_READONLY_PORT` defaulting to `8001`, and `inbox_mcp_stdio.py:16-17` / `inbox_mcp_readonly_stdio.py:10-11` run the same MCP objects over stdio.
+
+The confirmation-gating claim is supported for MCP tools registered through `tools_registry.py`. `tools_registry.py:35-42` defines `readonly` and `confirm`; `tools_registry.py:73-78` rejects confirmation-gated tool calls unless `confirm=True`; `tools_registry.py:110-118` omits non-readonly tools when registering the read-only MCP surface. Examples include `send_email_reply`, `create_sheet`, and `append_sheet_rows` in `tools_registry.py:153-229`.
+
+The local test-mode safety claim is partly supported. `docs/TESTING_FOR_AGENTS.md:21-29` says `INBOX_TEST_MODE=1` blocks live writes and redirects test data. `inbox_test_mode.py` implements `assert_live_writes_allowed`, and `services.py:114-119` routes representative writes through it. `tests/test_services.py:909` and `tests/test_services.py:934` cover representative and extended live-write blocking.
+
+The Google account routing roadmap is partly implemented. `CONNECTOR_ROADMAP.md:32-44` says `INBOX_DEFAULT_GOOGLE_ACCOUNT` should be backend-enforced. `google_account_resolution.py:24-33` implements that default helper, and `google_account_resolution.py:109-157` uses it for Gmail, Sheets, Drive, Tasks, Docs, and Calendar service resolution. The preflight layer is also present at `inbox_server.py:3009-3020`, backed by `google_account_resolution.py:160-303`.
+
+The Sheets endpoint tables in `SHEETS.md` and `SHEETS_QUICKSTART.md` are mostly supported by route evidence. `SHEETS.md:63-100` lists 15 Sheets endpoints, and `inbox_server.py:2596-2758` defines the corresponding `/sheets` route family. The MCP tools expose a narrower Sheets subset: list/read/create/append in `tools_registry.py:174-230`.
+
+The credential ignore claims are supported. `README.md:171-174` and `CLAUDE.md:91-93` document local credentials and tokens; `.gitignore:12-25` ignores `credentials.json`, `token.json`, `token.json.lock`, `tokens/`, `github_token.txt`, `google_maps_key.txt`, `gemini_api_key.txt`, `config/inbox.env`, and dotenv/secret files.
+
+## Stale or unsupported claims
+
+The Python version requirement is stale. `README.md:31-34` says Python 3.10+, but `pyproject.toml:5` requires `>=3.12,<3.15`, and Ruff/Pyright target Python 3.12 in `pyproject.toml:40-50`. A new agent following the README can choose an unsupported interpreter.
+
+The README and CLAUDE key-binding docs are stale. `README.md:120-122` and `CLAUDE.md:193-196` say `Ctrl+6` toggles ambient listening and `Ctrl+7` is GitHub. Code now maps `Ctrl+6` to Reminders, `Ctrl+7` to GitHub, `Ctrl+8` to Drive, `Ctrl+9` to Actionable, `Ctrl+0` to Waiting On, and `Ctrl+Shift+6` to Ambient in `inbox.py:1179-1195`. The docs omit Drive/actionable/waiting bindings and point the ambient shortcut at the wrong action.
+
+The "no cloud dependencies" privacy claim is too strong. `README.md:25` says local-first ML has no cloud dependencies, and `README.md:171` says all data processing happens on-device. The repo now has optional cloud integrations: `services.py:84-97` defines `google_maps_key.txt`, `gemini_api_key.txt`, and Google scopes for Gmail/Calendar/Drive/Sheets/Docs/Tasks; `CLAUDE.md:294-297` documents Gemini API and Google Maps as optional; `inbox_server.py:2197-2260` includes Gemini summarization/reply/digest/action-item endpoints. A safer claim is "local-first by default for ASR/autocomplete; optional cloud providers exist for explicit workflows."
+
+The documentation index is stale. `DOCS_INDEX.md:173-175` says the docs were last updated April 2026, Sheets is complete/production-ready, and total documentation is 6 files. Local evidence finds 18 visible Markdown files and 160 backend routes. The index also undercounts system docs by not treating `MCP_SETUP.md`, `MCP_V1_PLAN.md`, `PLAN.md`, `docs/TESTING_FOR_AGENTS.md`, `modes/*.md`, and `config/_profile.md` as first-class docs.
+
+The "All 736 tests pass" claim is stale and unverifiable here. `DOCS_INDEX.md:140` and `SHEETS_CHANGELOG.md:38,114` claim 736 passing tests. Local static evidence found 864 `def test_` definitions. The test command could not be run in this sandbox because `uv` tried to download a missing macOS wheel over a network-restricted connection. The report should not keep a fixed pass count unless CI evidence is linked or the count is generated.
+
+The Sheets changelog is stale about auth tuple shape. `SHEETS_CHANGELOG.md:14` says `google_auth_all()` returns a 4-tuple, and `SHEETS_CHANGELOG.md:30` says the lifespan was updated to unpack a 4-tuple. Code now returns six values: Gmail, Calendar, Drive, Sheets, Docs, and Tasks in `services.py:330-338` and `services.py:416`, and the server lifespan unpacks six values at `inbox_server.py:1216-1222`.
+
+The Sheets docs overstate complete API coverage. `SHEETS_CHANGELOG.md:106` says agents can perform any Sheets operation. The REST API provides 15 broad operations, including raw formatting, but it is not equivalent to every Google Sheets API operation. The MCP tool registry exposes only list/read/create/append for Sheets, so "any operation" is inaccurate for MCP agents. Better wording: "common CRUD, values, tab, copy, clear, batch read/write, and raw formatting requests are exposed over REST; MCP exposes a curated subset."
+
+The Sheets default-account docs are stale. `SHEETS.md:195` and `SHEETS_QUICKSTART.md:130` say omitted account means first available account. `google_account_resolution.py:24-33` now prioritizes `INBOX_DEFAULT_GOOGLE_ACCOUNT` when present, then falls back to the first service key. The connector roadmap says that source-of-truth account should be enforced, so the Sheets docs should mention the env-driven policy.
+
+CLAUDE's MCP architecture section is stale. `CLAUDE.md:83-85` and `CLAUDE.md:274-278` call `mcp_server.py` stdio-based and say agents can use MCP without hitting the server HTTP API. Current code makes `mcp_server.py` an HTTP gateway over `/mcp` that calls the private inbox REST server through `mcp_backend.py`; stdio is provided by `inbox_mcp_stdio.py`. The newer `MCP_SETUP.md` is more accurate than `CLAUDE.md`.
+
+CLAUDE's slash-command claim references ignored local state. `CLAUDE.md:336-352` says the inbox skill router is `.claude/skills/inbox/SKILL.md`; `.gitignore:40-43` ignores `.claude/`, and a local existence check found `.claude/skills/inbox/SKILL.md` missing in this worktree. Future agents should not rely on hidden local slash-command files as repo documentation unless a tracked fallback exists.
+
+The README API reference is not a complete API reference. It documents several main route families, but the server exposes many additional public routes for Gmail actions, Tasks, WhatsApp, Docs, preflight, contacts, index views, workflow helpers, query, notifications, AI helpers, Google Maps, and calendar scheduling. The command `rg -c '@app\.' inbox_server.py` found 160 route decorators, while `README.md:48-114` lists only a subset.
+
+The safe-test marker workflow is under-applied. `docs/TESTING_FOR_AGENTS.md:31-37` defines `safe`, `integration`, `local_data`, `slow`, and `live_write`; `pyproject.toml:53-62` registers them. But only `tests/test_inbox_test_mode.py` and `tests/test_mcp_gateway.py` are safe-marked. `INBOX_TEST_MODE=1 uv run pytest -m safe` may therefore run a very small slice rather than the default deterministic proof set implied by the docs.
+
+## Non-claims and boundaries
+
+The docs do not claim that every server route is safe to call without credentials. Many route families are credentialed by design, and the testing guide explicitly warns against live provider tests.
+
+The docs do not claim that a dev worktree has real Google tokens. `CLAUDE.md:55` explicitly says tokens are per-checkout, gitignored, and must be re-authed or copied.
+
+The docs do not claim that full REST access should be exposed publicly. `MCP_SETUP.md:306-313` says to expose MCP, keep the raw REST API private, prefer read-only MCP for cloud agents, and keep destructive tools confirmation-gated.
+
+The docs do not require a Sheets TUI tab today. `DOCS_INDEX.md:137` and `SHEETS_CHANGELOG.md:117` say a Sheets tab is later/future work; tests also show `tests/test_tui_tabs.py:16` expects detail tabs for Calendar, Notes, Reminders, GitHub, and Drive, not Sheets.
+
+The docs do not require direct provider tools to replace Inbox MCP. `CONNECTOR_ROADMAP.md:335-342` says agents should prefer Inbox MCP, verify `INBOX_SERVER_URL`, and avoid relying on prompt-only routing until implementation is complete.
+
+## Risks and stale assumptions
+
+1. New agents can choose the wrong runtime. README says Python 3.10+, but `pyproject.toml` requires Python 3.12+. This can waste setup time or create misleading validation failures.
+
+2. Shortcut docs can drive unsafe or confusing TUI behavior. A user pressing `Ctrl+6` expecting ambient listening will switch to Reminders; ambient is now `Ctrl+Shift+6`.
+
+3. Privacy language overpromises. Optional Gemini, Google Maps, Google APIs, OAuth tokens, and hosted provider endpoints mean "all processing happens on-device" is not universally true.
+
+4. Fixed test-count claims are stale. The docs say 736 pass while the local tree has 864 test definitions and validation cannot currently run from a cold sandbox without network/cache access.
+
+5. The "production-ready" Sheets claim is stronger than the evidence. There is endpoint coverage and a few MCP/tooling tests, but `SHEETS_CHANGELOG.md:116` admits Sheets functionality is not directly tested in the suite.
+
+6. API docs split creates source-of-truth ambiguity. README is partial, CLAUDE is broader but stale, MCP_SETUP is newer for MCP, and DOCS_INDEX undercounts docs. Agents can choose the wrong source for current behavior.
+
+7. Hidden local skill dependency is fragile. `.claude/skills/inbox/SKILL.md` is ignored and missing here, but CLAUDE describes it as the slash-command router.
+
+8. Preflight and default-account policy docs are behind code. The connector roadmap says the policy should exist; code has pieces of it; Sheets docs still say first account wins.
+
+## Next safe work
+
+1. Align runtime and validation docs.
+   Acceptance criteria: `README.md`, `DOCS_INDEX.md`, and `docs/TESTING_FOR_AGENTS.md` all state Python `>=3.12,<3.15`; no fixed "736 tests pass" claim remains unless backed by a CI link; validation docs mention `UV_CACHE_DIR=/tmp/uv-cache` for sandboxed runs.
+   Validation: `rg -n 'Python 3.10|736 tests|All 736|requires-python|UV_CACHE_DIR' README.md DOCS_INDEX.md docs/TESTING_FOR_AGENTS.md pyproject.toml`.
+
+2. Refresh TUI key-binding docs from code.
+   Acceptance criteria: README and CLAUDE list `Ctrl+6` Reminders, `Ctrl+7` GitHub, `Ctrl+8` Drive, `Ctrl+9` Actionable, `Ctrl+0` Waiting On, and `Ctrl+Shift+6` Ambient; docs do not claim `Ctrl+6` toggles ambient.
+   Validation: `rg -n 'Ctrl\\+6|Ctrl\\+8|Ctrl\\+9|Ctrl\\+0|Ctrl\\+Shift\\+6' README.md CLAUDE.md inbox.py`.
+
+3. Make docs source-of-truth explicit.
+   Acceptance criteria: `DOCS_INDEX.md` lists all first-class docs or clearly separates user docs, agent docs, plans, and mode prompts; it points MCP readers to `MCP_SETUP.md` as authoritative and marks CLAUDE MCP content as historical unless updated.
+   Validation: `rg --files -g '*.md' | sort` and `rg -n 'mcp_server.py|stdio|HTTP gateway|Total documentation' CLAUDE.md DOCS_INDEX.md MCP_SETUP.md`.
+
+4. Tighten Sheets claims and add direct Sheets tests.
+   Acceptance criteria: Sheets docs say REST supports a broad common subset rather than every Sheets API operation; default-account behavior mentions `INBOX_DEFAULT_GOOGLE_ACCOUNT`; tests cover at least list/create/read/update/append/clear/tabs/format endpoints with mocked services.
+   Validation: `INBOX_TEST_MODE=1 UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/test_server.py tests/test_tools_registry.py -q` once dependencies are available.
+
+5. Track or remove slash-command router claims.
+   Acceptance criteria: either a tracked skill/router doc exists outside `.claude/`, or `CLAUDE.md` explains that `.claude/skills/inbox/SKILL.md` is optional local state and the tracked fallback is `modes/*.md`.
+   Validation: `test -e .claude/skills/inbox/SKILL.md; git check-ignore -v .claude/skills/inbox/SKILL.md; rg -n 'Skill router|modes/\\*.md' CLAUDE.md`.
+
+6. Add an agent-safe dependency bootstrap note.
+   Acceptance criteria: testing docs describe that cold `uv run` may need network to download macOS wheels; they provide a local-cache or pre-sync expectation for overnight workers.
+   Validation: `UV_CACHE_DIR=/tmp/uv-cache INBOX_TEST_MODE=1 uv run pytest --collect-only -q` should either collect tests or fail with a documented known blocker.
+
+## Validation command candidates
+
+Required queue validation:
+
+- `git status --short`
+  Expected now: exit 0. Before commit, it should show only this report as an added file. After commit, it should be empty.
+
+Safe docs-only checks:
+
+- `rg --files -g '*.md' | sort`
+  Expected now: exit 0 and include this report under `docs/overnight/`.
+
+- `rg -n 'Python 3.10|All 736|Total documentation|Ctrl\\+6|no cloud dependencies|all data processing' README.md CLAUDE.md DOCS_INDEX.md SHEETS_CHANGELOG.md`
+  Expected now: exit 0 with known stale-claim hits.
+
+- `rg -n '@app\\.' inbox_server.py`
+  Expected now: exit 0 and show the route surface used to compare API docs.
+
+Blocked until dependencies are available locally:
+
+- `UV_CACHE_DIR=/tmp/uv-cache INBOX_TEST_MODE=1 uv run pytest --collect-only -q`
+  Observed status: failed. `uv` created a fresh `.venv` and attempted to download `pyobjc-framework-quartz==12.1`; network/DNS is unavailable in this sandbox.
+
+- `INBOX_TEST_MODE=1 uv run pytest -m safe`
+  Expected after dependency bootstrap: likely pass for the two currently safe-marked test modules, but this command under-validates the project because most deterministic tests are not marked `safe`.
+
+- `uv run ruff check .` and `uv run pyright`
+  Expected after dependency bootstrap: unknown. These were not run because `uv run` could not sync dependencies from a cold cache.
+
+## Unknowns
+
+- Whether CI currently passes; no GitHub/CI access was used for this read-only local audit.
+- Whether a primary checkout already has a populated `.venv` or uv cache; this isolated worktree did not.
+- Whether the intended product language is "privacy-first" with optional cloud integrations or "strictly local." Current code supports the former, while README text implies the latter.
+- Whether `.claude/skills/inbox/SKILL.md` exists in another local checkout; it is ignored and absent here.
+- Whether every route in `inbox_server.py` is meant to be public documentation or only internal/local power-user surface.
+
+## Handoff
+
+Changed files:
+
+- `docs/overnight/inbox-sym-214-docs-claims.md`
+
+No product code, generated data, secrets, deploy configs, external services, pushes, PRs, or tracker state were intentionally changed.
+
+Blockers:
+
+- Python validation through `uv run` is blocked in this sandbox without a pre-populated uv cache or network access to download macOS wheels.
+- Local commit creation is blocked in this sandbox. `git add docs/overnight/inbox-sym-214-docs-claims.md` failed because Git tried to create `/Users/jwalinshah/projects/inbox/.git/worktrees/inbox-sym-214-docs-claims/index.lock`, which is outside the writable roots.
+- The docs cannot be made accurate without product judgment on privacy wording and which API surface is authoritative; this audit only reports the claim gaps.

--- a/docs/overnight/inbox-sym-30-architecture-map.md
+++ b/docs/overnight/inbox-sym-30-architecture-map.md
@@ -1,0 +1,400 @@
+# Overnight Architecture Map: inbox-sym-30
+
+Queue item: `inbox-sym-30-architecture-map`
+Branch: `codex/goal-inbox-sym-30-architecture-map`
+Repo/worktree: `/Users/jwalinshah/projects/agent-stack/.agent-stack-worktrees/2026-05-07-overnight-marathon/inbox-sym-30-architecture-map`
+HEAD at audit start: `2805b8400519da188ca7d3f6e39b19a8ca42b05a`
+
+## Scope Decision
+
+This audit stayed docs-only. I did not edit product code, run live services, call external APIs, start the TUI, expose MCP, mutate personal data stores, or create a PR.
+
+The only intended artifact is this report.
+
+## Commands Run
+
+Discovery and state:
+
+```bash
+pwd
+git status --short
+git branch --show-current
+git rev-parse HEAD
+git ls-files | wc -l
+du -sh . 2>/dev/null
+llm-tldr tree .
+llm-tldr structure .
+llm-tldr arch .
+wc -l *.py tests/*.py docs/*.md *.md pyproject.toml
+```
+
+Project instructions and docs:
+
+```bash
+rtk read AGENTS.md
+rtk read CLAUDE.md
+rtk read README.md
+rtk read pyproject.toml
+rtk read DOCS_INDEX.md
+rtk read MCP_V1_PLAN.md
+rtk read MCP_SETUP.md
+rtk read PLAN.md
+rtk read docs/TESTING_FOR_AGENTS.md
+rtk read .gitignore
+rtk read .env.mcp.example
+rtk read config/inbox.env.example
+rtk read config/codex.inbox.example.toml
+rtk read deploy/Caddyfile.example
+```
+
+Architecture tracing:
+
+```bash
+llm-tldr search "FastAPI|APIRouter|@app|uvicorn|if __name__|Textual|class .*App|MCP|FastMCP" .
+llm-tldr context create_app --project . --depth 2
+llm-tldr context InboxApp --project . --depth 1
+llm-tldr context InboxBackend --project . --depth 2
+rg "^(class|def|async def) " -n --glob "*.py"
+rg "^(import|from) " -n --glob "*.py"
+rg "^@app\.(get|post|put|delete|patch)" -n inbox_server.py
+rg "self\._client\.(get|post|put|delete|patch)\(" -n inbox_client.py
+rg "from services import|import services|agents\.runner|from agents" -n . --glob "*.py"
+rg "_assert_live_write_allowed" -n services.py tests
+rg "create_app\(|InboxServerRuntime|TestClient\(|lifespan" -n tests inbox_server.py
+rg "class SourceAdapters|source_adapters|def _source_adapter|ProductionSource" -n inbox_server.py tests/test_server.py
+rg "pytest\.mark\.safe|@pytest.mark.safe|mark\.safe" -n tests
+rg "pytestmark|mark\.local_data|mark\.live_write|mark\.slow|mark\.integration" -n tests
+rg --files | rg "^agents/"
+```
+
+Representative file slices were read with `nl -ba ... | sed -n ...` for:
+
+- `inbox_server.py`
+- `services.py`
+- `inbox.py`
+- `inbox_client.py`
+- `mcp_backend.py`
+- `mcp_gateway.py`
+- `mcp_server.py`
+- `inbox_mcp_readonly.py`
+- `inbox_mcp_stdio.py`
+- `inbox_mcp_readonly_stdio.py`
+- `tools_registry.py`
+- `message_index_store.py`
+- `message_sync.py`
+- `scheduler.py`
+- `google_account_resolution.py`
+- `memory_store.py`
+- `service_models.py`
+- `tui_tabs.py`
+- `tests/conftest.py`
+- `tests/test_api_contract.py`
+
+## Observed Dirty State
+
+Before writing this report, `git status --short` returned no output.
+
+After writing this report, the expected dirty state is this docs-only artifact:
+
+```text
+?? docs/overnight/
+```
+
+## Current Architecture
+
+The repo is a flat Python application rather than a package tree. `llm-tldr tree .` found 196 tracked files in a small worktree, with core app modules at repo root and tests under `tests/`.
+
+The large modules are the real architectural owners:
+
+- `services.py`: 6,467 lines
+- `inbox.py`: 4,279 lines
+- `inbox_server.py`: 3,940 lines
+- `inbox_client.py`: 947 lines
+- `tools_registry.py`: 851 lines
+- `message_sync.py`: 659 lines
+- `message_index_store.py`: 616 lines
+- `mcp_backend.py`: 541 lines
+- `scheduler.py`: 437 lines
+
+The intended product stack is visible in `PLAN.md`: raw sources, a local SQLite operational index, indexed inbox views, and interfaces through Textual, FastAPI, and a curated MCP surface. The current code partially matches that direction.
+
+### Layer 1: Shared Models
+
+`service_models.py` is the cleanest shared contract. It defines dataclasses for source-agnostic records like `Contact`, `Msg`, `CalendarEvent`, `Reminder`, `GoogleTask`, `DriveFile`, `Spreadsheet`, `Document`, and `ThreadSummary` (`service_models.py:11`, `service_models.py:28`, `service_models.py:39`, `service_models.py:65`, `service_models.py:78`, `service_models.py:90`, `service_models.py:102`, `service_models.py:124`, `service_models.py:133`, `service_models.py:142`).
+
+This file is small, pure, and stable compared with the rest of the system.
+
+### Layer 2: Source and Capability Implementations
+
+`services.py` declares itself as the data access layer where all fetching, auth, mutation, audio, and LLM logic lives (`services.py:1`). That is accurate. It owns:
+
+- local paths and credential files (`services.py:54`)
+- Google OAuth scopes (`services.py:88`)
+- iMessage read/send (`services.py:441`)
+- Gmail read/write/search (`services.py:626`, `services.py:995`)
+- Calendar operations (`services.py:1472`)
+- Apple Notes (`services.py:1869`)
+- WhatsApp macOS Accessibility integration (`services.py:2021`)
+- Apple Reminders (`services.py:2617`)
+- Google Tasks (`services.py:3098`)
+- Gemini AI (`services.py:3243`)
+- Google Maps/departure times (`services.py:3507`)
+- GitHub notifications (`services.py:3659`)
+- Drive, Sheets, Docs (`services.py:3805`, `services.py:4023`, `services.py:4391`)
+- audio, ambient, dictation, local LLM, autocomplete, global search, notifications, favorites, contacts, and voice commands (`services.py:4523`, `services.py:4580`, `services.py:4699`, `services.py:4827`, `services.py:5028`, `services.py:5427`, `services.py:5558`, `services.py:6088`)
+
+This gives the repo a simple ownership model, but it also means most domain coupling accumulates in one file. The module has many unrelated reasons to change: OAuth scope changes, SQLite parsing, Gmail batching, AppleScript mutation, WhatsApp UI automation, ML loading, Drive/Sheets/Docs APIs, and desktop notification behavior.
+
+### Layer 3: Account Resolution and Source Adapters
+
+`google_account_resolution.py` extracts multi-account routing out of the server. It defines a state protocol over service dictionaries and `conv_cache` (`google_account_resolution.py:14`) and centralizes Gmail, Sheets, Drive, Tasks, Docs, and Calendar default-account resolution (`google_account_resolution.py:36`, `google_account_resolution.py:109`, `google_account_resolution.py:119`, `google_account_resolution.py:129`, `google_account_resolution.py:139`, `google_account_resolution.py:149`).
+
+`inbox_server.py` has a narrower `SourceAdapters` mechanism, but only Gmail search and calendar event reads use it (`inbox_server.py:750`, `inbox_server.py:776`, `inbox_server.py:795`). Tests verify that fake adapters can be installed and production adapters delegate to service functions (`tests/test_server.py:1021`, `tests/test_server.py:1071`, `tests/test_server.py:1089`).
+
+The account-resolution extraction is more complete than the source-adapter extraction. Source adapters are currently a testing convenience, not the general integration boundary.
+
+### Layer 4: FastAPI Runtime and API Surface
+
+`inbox_server.py` is the central process boundary. It imports a broad set of functions and dataclasses from `services.py` (`inbox_server.py:61`) and exposes a large route surface. `rg "^@app\."` found routes from `/health` (`inbox_server.py:1346`) through `/query` (`inbox_server.py:3896`), including conversations/messages, Gmail, Calendar, Notes, Reminders, Tasks, Scheduler, AI, WhatsApp, GitHub, Drive, Sheets, Docs, search, ambient/dictation, contacts, notifications, workflow helpers, index sync, and cross-silo query.
+
+Runtime state is centralized in `ServerState`, which holds service maps, caches, ambient/dictation services, `SchedulerStore`, `MessageIndexStore`, and source adapters (`inbox_server.py:802`). The module also exposes global `state` and `memory_store` (`inbox_server.py:821`).
+
+Tests can inject a runtime via `InboxServerRuntime` (`inbox_server.py:826`) and `create_app(runtime)` (`inbox_server.py:1288`). The app factory copies routes from the global `app` into each new app (`inbox_server.py:1297`). That keeps tests practical, but it also means routes are still authored against module-global decorators and global state.
+
+The lifecycle initializes contacts, authenticates all Google accounts, optionally prewarms conversations, optionally starts ambient listening, and optionally starts a scheduler loop (`inbox_server.py:1198`). This makes server startup a heavy ownership boundary: auth, data source setup, ML/audio, and background jobs all meet there.
+
+### Layer 5: HTTP Client and TUI
+
+`inbox_client.py` is a synchronous HTTP client. It derives its base URL from `INBOX_SERVER_URL` or `INBOX_SERVER_PORT` (`inbox_client.py:16`), attaches `INBOX_SERVER_TOKEN` as a bearer token (`inbox_client.py:21`), and can auto-start `inbox_server.py` with the current Python executable (`inbox_client.py:48`).
+
+`inbox.py` declares itself as a thin HTTP client that auto-starts the server (`inbox.py:1`). That is mostly true: `InboxApp.boot()` loads favorites, calls `self.client.ensure_server()`, then refreshes and starts polling (`inbox.py:2082`). Refreshes collect conversations, calendar, notes, reminders, GitHub notifications, and indexed views through `InboxClient` (`inbox.py:2295`, `inbox.py:2363`, `inbox.py:2389`).
+
+The TUI still leaks through the HTTP boundary in a few places:
+
+- It directly imports `services.llm_is_loaded` for command palette behavior (`inbox.py:1957`).
+- It directly imports `services.load_favorites` on boot (`inbox.py:2090`).
+- It directly imports `services.save_favorites` when toggling favorites (`inbox.py:4060`).
+- It imports `agents.runner.Supervisor` for the local assistant action (`inbox.py:4131`), but no tracked `agents/` package exists in this worktree.
+
+Those are the main places where the "thin client" boundary is porous.
+
+### Layer 6: Operational Index
+
+`message_index_store.py` owns the local `.inbox_index.sqlite3` schema (`message_index_store.py:12`). It creates `sync_state`, `items`, `threads`, and `sender_stats` tables with indexes (`message_index_store.py:80`). `message_sync.py` owns Gmail and iMessage bootstrap/incremental sync into that store (`message_sync.py:181`, `message_sync.py:422`, `message_sync.py:498`, `message_sync.py:541`).
+
+The API exposes index endpoints for threads, status, health, named views, bootstrap sync, and incremental sync (`inbox_server.py:3805`, `inbox_server.py:3820`, `inbox_server.py:3829`, `inbox_server.py:3834`, `inbox_server.py:3844`, `inbox_server.py:3850`).
+
+This layer matches the roadmap in `PLAN.md`, and tests cover many of the intended guarantees. `tests/test_api_contract.py` verifies client/server shape for index status and health (`tests/test_api_contract.py:91`, `tests/test_api_contract.py:109`).
+
+### Layer 7: MCP Surfaces
+
+The MCP architecture has three layers:
+
+- `mcp_backend.py` is an async HTTP adapter to the private FastAPI server. It reads `INBOX_SERVER_URL`, `INBOX_SERVER_TOKEN`, and defaults to `http://127.0.0.1:9849` (`mcp_backend.py:9`). All calls flow through `_request()` (`mcp_backend.py:29`).
+- `mcp_gateway.py` builds the Starlette public app, health endpoint, memory store, and bearer-token middleware for `INBOX_MCP_TOKEN` (`mcp_gateway.py:18`, `mcp_gateway.py:48`, `mcp_gateway.py:87`).
+- `mcp_server.py`, `inbox_mcp_readonly.py`, `inbox_mcp_stdio.py`, and `inbox_mcp_readonly_stdio.py` choose full vs read-only and HTTP vs stdio transport (`mcp_server.py:34`, `mcp_server.py:142`, `mcp_server.py:145`, `inbox_mcp_readonly.py:30`, `inbox_mcp_readonly.py:77`, `inbox_mcp_stdio.py:16`, `inbox_mcp_readonly_stdio.py:10`).
+
+`tools_registry.py` is the strongest anti-drift mechanism in the MCP layer. It says one table drives full and read-only servers (`tools_registry.py:1`) and dynamically creates FastMCP handlers from `Tool` definitions (`tools_registry.py:52`, `tools_registry.py:110`). Mutating tools can require a `confirm` parameter (`tools_registry.py:55`, `tools_registry.py:73`).
+
+There is explicit contract coverage: `tests/test_api_contract.py` checks that every MCP registry path maps to a FastAPI route (`tests/test_api_contract.py:75`), and `tests/test_tools_registry.py` checks confirmation gating and readonly registration behavior.
+
+## Entrypoints
+
+Main local entrypoints:
+
+- `uv run python inbox.py`: Textual TUI; calls `InboxClient.ensure_server()` (`inbox.py:4277`, `inbox.py:2082`, `inbox_client.py:60`).
+- `uv run python inbox_server.py`: FastAPI backend on `127.0.0.1`, port from `INBOX_SERVER_PORT` or 9849 (`inbox_server.py:3936`).
+- `uv run python mcp_server.py`: full HTTP MCP gateway on `127.0.0.1:8000` (`mcp_server.py:148`).
+- `uv run python inbox_mcp_readonly.py`: read-only HTTP MCP gateway on `127.0.0.1:8001` by default (`inbox_mcp_readonly.py:83`).
+- `uv run python inbox_mcp_stdio.py`: full local stdio MCP (`inbox_mcp_stdio.py:16`).
+- `uv run python inbox_mcp_readonly_stdio.py`: read-only local stdio MCP (`inbox_mcp_readonly_stdio.py:10`).
+- `uv run python message_sync.py`: index bootstrap/incremental CLI (`message_sync.py:638`).
+- `uv run python ambient_daemon.py`: ambient audio daemon (`ambient_daemon.py:91`).
+- `./dev.sh`: worktree launcher that defaults to port 9850 (`dev.sh:1`).
+- `scripts/run_inbox_backend.sh` and MCP runner scripts: service-friendly wrappers that set `UV_CACHE_DIR` and run the relevant Python entrypoint.
+
+## Ownership Map
+
+Current practical owners by file:
+
+| Area | Files | Notes |
+| --- | --- | --- |
+| Provider APIs and local integrations | `services.py`, `contacts.py`, `ambient_notes.py` | `services.py` owns almost every provider-specific implementation. |
+| API runtime | `inbox_server.py`, `google_account_resolution.py` | API owns global state, lifecycle, auth middleware, route models, and route handlers. |
+| Human UI | `inbox.py`, `tui_tabs.py`, `command_palette.py` | UI is mostly HTTP-backed but has direct service imports for favorites/LLM status and a missing assistant import. |
+| HTTP client | `inbox_client.py` | Synchronous client for TUI and scripts. |
+| MCP | `mcp_backend.py`, `mcp_gateway.py`, `mcp_server.py`, `inbox_mcp_readonly.py`, stdio wrappers, `tools_registry.py` | Best defined external boundary, with confirmation-gated writes. |
+| Operational index | `message_index_store.py`, `message_sync.py`, `thread_classifier.py`, `gmail_triage.py` | Close to the roadmap; still top-level rather than packaged. |
+| Local persistence | `memory_store.py`, `scheduler.py`, `.inbox_*.sqlite3` | SQLite stores live at repo root by default and are gitignored. |
+| Deployment/config | `scripts/`, `deploy/`, `config/`, `.env.mcp.example` | Config examples are present; real tokens are ignored. |
+| Validation | `tests/`, `docs/TESTING_FOR_AGENTS.md`, `pyproject.toml` | Broad suite exists, but safe marker coverage is small. |
+
+## Boundary Risks and Stale Assumptions
+
+1. `services.py` is the main architecture bottleneck.
+
+Evidence: it is 6,467 lines and owns unrelated domains from Gmail to WhatsApp, ML, Drive, Docs, Sheets, local SQLite, AppleScript, and notifications. Adding a new provider or changing a policy can touch the same file as unrelated audio or LLM code.
+
+Safe next direction: extract by stable domain seams only when making real changes. Start with the already coherent clusters: Google Workspace, Apple local stores, audio/LLM, and search/triage. Avoid a broad mechanical split without behavior tests.
+
+2. `inbox_server.py` is both router and application composition root.
+
+Evidence: route decorators are global (`inbox_server.py:1310` onward), `create_app()` copies existing global routes into a new app (`inbox_server.py:1297`), and `ServerState` initializes every major runtime service (`inbox_server.py:802`). This is workable but makes it hard to reason about route ownership and startup side effects.
+
+Safe next direction: for new API groups, prefer routers or small registration functions before adding more global route blocks. Existing routes do not need to move all at once.
+
+3. The TUI is not fully thin.
+
+Evidence: `inbox.py` calls the HTTP client for most work, but imports `services.llm_is_loaded`, `services.load_favorites`, and `services.save_favorites` directly (`inbox.py:1957`, `inbox.py:2090`, `inbox.py:4060`). It also imports `agents.runner.Supervisor` at runtime (`inbox.py:4131`) while `rg --files | rg "^agents/"` returned no tracked `agents/` files.
+
+Safe next direction: either route favorites and LLM status through existing API endpoints consistently, or document these as intentional local-only UI affordances. The assistant action should be guarded by an importability test or moved behind an optional plugin boundary.
+
+4. Source adapters are partial.
+
+Evidence: `SourceAdapters` covers Gmail search and Calendar event reads only (`inbox_server.py:795`). Most other provider calls still go straight from route handlers to `services.py`.
+
+Safe next direction: do not rename this to a general adapter layer until it actually covers more integrations. If the next work targets testability of a provider, extend `SourceAdapters` one provider at a time.
+
+5. Roadmap and implementation have diverged around memory and agent platform scope.
+
+Evidence: `PLAN.md` says this phase does not solve full personal memory or a general-purpose personal agent platform. The repo now has `memory_store.py`, MCP memory tools in `mcp_server.py`, a `/memory/extract` endpoint in `inbox_server.py:3621`, and a TUI assistant action that expects `agents.runner.Supervisor`.
+
+Safe next direction: update `PLAN.md` or split "inbox operational index" from "personal assistant memory" explicitly so future agents do not treat these as accidental scope creep or as mandatory Phase 1 surface.
+
+6. Runtime docs have at least one stale environment claim.
+
+Evidence: `README.md` says Python 3.10+ is required, while `pyproject.toml` requires `>=3.12,<3.15` (`pyproject.toml:5`).
+
+Safe next direction: correct the README requirement to match packaging before any onboarding or CI work.
+
+7. MCP V1 plan is behind the current tool surface.
+
+Evidence: `MCP_V1_PLAN.md` lists a narrow v1 and says Calendar stays on the built-in ChatGPT connector for now. `tools_registry.py` now includes tools beyond that v1, including Sheets, Tasks, Maps/departure, scheduled messages, followups, Drive, Docs, GitHub, and memory extraction paths.
+
+Safe next direction: mark `MCP_V1_PLAN.md` historical or replace it with the current source-of-truth rule: `tools_registry.py` plus `tests/test_api_contract.py`.
+
+8. Safe validation policy exists, but marker coverage is not yet broad.
+
+Evidence: `docs/TESTING_FOR_AGENTS.md` says default agent verification should be `INBOX_TEST_MODE=1 uv run pytest -m safe`, `ruff`, and `pyright`. Only `tests/test_inbox_test_mode.py` and `tests/test_mcp_gateway.py` currently set `pytestmark = pytest.mark.safe`.
+
+Safe next direction: classify more deterministic tests with `safe`, or change the recommended safe command to focused tests that actually cover the touched area.
+
+9. Optional external project dependency is embedded in the main server surface.
+
+Evidence: `/query` imports `gemma4_hackathon` from an external editable path and returns 503 when unavailable (`inbox_server.py:3896`). This is gracefully handled, but the endpoint lives in the main API module and adds another reason for server route churn.
+
+Safe next direction: keep optional hackathon/cross-silo routes isolated behind their own route registration or explicit experimental section.
+
+## Existing Guardrails
+
+The repo already has useful guardrails:
+
+- `.gitignore` excludes credentials, token files, env files, server logs, `.inbox_memory.sqlite3`, `.inbox_scheduler.sqlite3`, and `.inbox_index.sqlite3`.
+- `inbox_test_mode.py` blocks live writes when `INBOX_TEST_MODE` is enabled (`inbox_test_mode.py:22`), and `services.py` calls `_assert_live_write_allowed()` across many write operations (`services.py:114`).
+- `tests/conftest.py` stubs heavy ML/hardware modules (`tests/conftest.py:15`).
+- `tests/test_api_contract.py` catches MCP registry route drift (`tests/test_api_contract.py:75`).
+- `tests/test_tools_registry.py` catches MCP confirmation-gating drift.
+- `InboxServerRuntime` lets tests skip scheduler and ambient startup (`inbox_server.py:826`).
+- `MCP_SETUP.md` clearly separates private backend token auth from public MCP token auth.
+
+## Missing Validation
+
+I did not run the full test suite, linter, type checker, server, TUI, or MCP gateways because this queue item only asked for an architecture-map report and the required validation command is `git status --short`.
+
+Additional validation worth running before code changes in this repo:
+
+```bash
+INBOX_TEST_MODE=1 uv run pytest -m safe
+uv run ruff check .
+uv run pyright
+```
+
+For route/MCP boundary changes, the cheapest focused tests are:
+
+```bash
+INBOX_TEST_MODE=1 uv run pytest tests/test_api_contract.py tests/test_tools_registry.py tests/test_mcp_gateway.py -q
+```
+
+For index changes:
+
+```bash
+INBOX_TEST_MODE=1 uv run pytest tests/test_message_index_store.py tests/test_message_sync.py tests/test_server.py -q
+```
+
+## Next Safe Work
+
+1. Make the thin-client boundary explicit.
+
+Acceptance criteria:
+
+- Decide whether favorites and LLM status are allowed direct TUI service calls.
+- If not, add API/client methods and move the TUI to `InboxClient`.
+- Add a focused regression test around the changed TUI path.
+
+Validation:
+
+```bash
+INBOX_TEST_MODE=1 uv run pytest tests/test_inbox_app.py tests/test_client.py tests/test_server.py -q
+uv run ruff check .
+```
+
+2. Stabilize the optional local assistant action.
+
+Acceptance criteria:
+
+- Either add the missing `agents.runner` package, remove the TUI action, or feature-gate it with a clear unavailable state.
+- Document where the assistant control-plane code lives.
+- Add a test that the command palette action fails gracefully when the optional dependency is missing.
+
+Validation:
+
+```bash
+INBOX_TEST_MODE=1 uv run pytest tests/test_command_palette.py tests/test_inbox_app.py -q
+uv run ruff check .
+```
+
+3. Reconcile docs with current runtime boundaries.
+
+Acceptance criteria:
+
+- README Python version matches `pyproject.toml`.
+- `MCP_V1_PLAN.md` is marked historical or updated to point to `tools_registry.py`.
+- `PLAN.md` explains how `memory_store.py`, `/memory/extract`, and MCP memory tools relate to Phase 1.
+- `docs/TESTING_FOR_AGENTS.md` safe command matches actual marker coverage or marker coverage is broadened.
+
+Validation:
+
+```bash
+INBOX_TEST_MODE=1 uv run pytest tests/test_inbox_test_mode.py tests/test_api_contract.py tests/test_tools_registry.py -q
+uv run ruff check .
+```
+
+4. Prepare a future services split only around tested seams.
+
+Acceptance criteria:
+
+- Choose one domain cluster, such as Google Workspace or Apple local stores.
+- Move only that cluster behind a small module while preserving public imports or updating callers deliberately.
+- Add/keep focused tests for the moved cluster.
+
+Validation:
+
+```bash
+INBOX_TEST_MODE=1 uv run pytest tests/test_services.py tests/test_gmail_actions.py tests/test_drive.py tests/test_calendar.py -q
+uv run ruff check .
+uv run pyright
+```
+
+## Final Validation
+
+Required command:
+
+```bash
+git status --short
+```
+
+Result: command completed successfully and reported only this required docs-only artifact:
+
+```text
+?? docs/overnight/
+```

--- a/docs/overnight/inbox-sym-30-dependency-surface.md
+++ b/docs/overnight/inbox-sym-30-dependency-surface.md
@@ -1,0 +1,214 @@
+# inbox-sym-30 dependency surface audit
+
+Queue item: `inbox-sym-30-dependency-surface`
+Focus area: dependency-surface
+Audited: 2026-05-07
+Repo path: `/Users/jwalinshah/projects/agent-stack/.agent-stack-worktrees/2026-05-07-overnight-marathon/inbox-sym-30-dependency-surface`
+
+## Summary
+
+`inbox-sym-30` is a local-first Python inbox application: a Textual TUI and agent-facing MCP tools talk to a local FastAPI server that reads and mutates iMessage, Gmail, Google Calendar, Drive, Sheets, Docs, Tasks, Apple Notes, Apple Reminders, GitHub notifications, local ML/audio services, and local SQLite-backed state. The dependency surface is intentionally broad and very Mac-specific.
+
+The repo has a locked `uv` environment, but running `uv` under this worker exposed a handoff risk: plain `uv tree --locked --depth 2` tried to initialize `/Users/jwalinshah/.cache/uv` and failed with `Operation not permitted`. The project launch scripts already work around this with `UV_CACHE_DIR=/tmp/uv-cache`; agent-facing validation docs do not consistently mention that override.
+
+No product code was changed. This report is the only intended tracked output.
+
+## Branch and dirty state
+
+- Current branch: `codex/goal-inbox-sym-30-dependency-surface`.
+- Starting HEAD: `2805b8400519da188ca7d3f6e39b19a8ca42b05a` (`2805b84 Merge pull request #34 from jwalin-shah/codex/SYM-9-indexed-defaults`).
+- Starting dirty state: `git status --short --branch` printed only `## codex/goal-inbox-sym-30-dependency-surface`.
+- Ignored local state observed: `git status --ignored --short` produced no output, so this worktree did not currently contain ignored token files, sqlite stores, logs, caches, or batch state.
+- Runtime tool observation: `python` was not on PATH, while `python3 --version` returned `Python 3.12.8` and `UV_CACHE_DIR=/tmp/uv-cache uv tree --locked --depth 2` selected `CPython 3.12.12`.
+
+## Repo purpose and entrypoints
+
+Local evidence:
+
+- `README.md` describes the app as a "privacy-first terminal UI" for iMessage, Gmail, Calendar, Sheets, Notes, Reminders, GitHub, and Drive.
+- `CLAUDE.md` documents the core split: `services.py` for data access, `inbox_server.py` for FastAPI, `inbox_client.py` for the sync HTTP client, `mcp_backend.py`/`mcp_server.py` for MCP, and `inbox.py` for the Textual TUI.
+- `inbox_server.py:1288-1310` constructs the FastAPI app with docs under `/api-docs`, `/api-redoc`, and `/api-openapi.json`.
+- `inbox_server.py:3937-3940` runs `uvicorn` on `127.0.0.1` using `INBOX_SERVER_PORT` or default `9849`.
+- `inbox_client.py:16-25` derives `INBOX_SERVER_URL` from `INBOX_SERVER_PORT` and attaches `Authorization: Bearer $INBOX_SERVER_TOKEN` if present.
+- `inbox_client.py:48-75` can auto-start `inbox_server.py` as a subprocess and writes `server.log` in the repo root.
+- `mcp_backend.py:18-27` wraps the private HTTP API for MCP clients and reads `INBOX_SERVER_URL` plus `INBOX_SERVER_TOKEN`.
+- `mcp_gateway.py:18-45` adds public MCP auth through `INBOX_MCP_TOKEN`; an empty token disables auth.
+- `mcp_gateway.py:87-94` exposes Starlette routes `/health` and `/mcp`.
+- `scripts/run_inbox_backend.sh`, `scripts/run_inbox_mcp_http.sh`, `scripts/run_inbox_mcp_stdio.sh`, and their read-only variants all set `UV_CACHE_DIR="${UV_CACHE_DIR:-/tmp/uv-cache}"` before `uv run`.
+- `dev.sh` starts worktree development on `INBOX_SERVER_PORT=9850` by default, deriving `INBOX_SERVER_URL` from the chosen port.
+- `batch/batch-runner.sh` is a live Gmail label mutation helper, with generated state in `batch/archive-state.tsv` and logs under `batch/logs/`.
+
+## Declared Python dependency surface
+
+Local evidence:
+
+- `pyproject.toml` declares project name `inbox`, version `0.1.0`, and Python `>=3.12,<3.15`; `.python-version` says `3.12`.
+- `pyproject.toml` runtime dependencies include FastAPI/Uvicorn, Google API clients, `httpx`, `loguru`, `mcp[cli]`, `mlx-lm`, `mlx-whisper`, `numpy`, `outlines`, `pydantic`, PyObjC frameworks, `python-multipart`, `rich`, `sounddevice`, and `textual`.
+- `pyproject.toml` dev dependencies include `bandit`, `hypothesis`, `pre-commit`, `pyright`, `pytest`, `pytest-cov`, `python-dotenv`, and `ruff`.
+- `uv.lock` contains 149 locked packages (`rg -c "^\[\[package\]\]" uv.lock` returned `149`).
+- `UV_CACHE_DIR=/tmp/uv-cache uv tree --locked --depth 2` resolved successfully and showed `fastapi 0.135.3`, `mcp 1.27.0`, `mlx-lm 0.31.2`, `mlx-whisper 0.4.3`, `numpy 2.4.4`, `outlines 1.2.12`, `textual 8.2.3`, `uvicorn 0.44.0`, and dev tools including `ruff 0.15.10`, `pyright 1.1.408`, and `pytest 9.0.3`.
+- Plain `uv tree --locked --depth 2` failed before dependency inspection because the sandbox could not open `/Users/jwalinshah/.cache/uv/sdists-v9/.git`.
+- `.pre-commit-config.yaml` separately pins `ruff-pre-commit v0.15.10`, `pre-commit-hooks v5.0.0`, and `bandit 1.9.4`.
+
+Dependency notes:
+
+- Direct Starlette imports appear in `mcp_gateway.py`, `inbox_server.py`, `tests/test_api_contract.py`, and `tests/test_mcp_gateway.py`, but `starlette` is not declared as a direct dependency. It currently arrives transitively through FastAPI/MCP.
+- `python-multipart` is declared and used by the FastAPI upload routes through `File`/`UploadFile`.
+- `python-dotenv` is declared in the dev dependency group and also comes from `mcp[cli]`, but the application does not call `load_dotenv`; launchd/systemd examples source or load `config/inbox.env` externally.
+- ML/audio dependencies are partly Python package dependencies (`mlx-lm`, `mlx-whisper`, `sounddevice`, `pyobjc`) and partly external binaries/models (`/opt/homebrew/bin/whisper-stream` and a Homebrew Cellar `whisper-cpp` model path).
+
+## System and platform dependency surface
+
+Local evidence:
+
+- `README.md` and `CLAUDE.md` both state that macOS is required for iMessage, Notes, Reminders, Dictation, and platform APIs.
+- `services.py:67-80` defaults iMessage to `~/Library/Messages/chat.db`, Notes to `~/Library/Group Containers/group.com.apple.notes/NoteStore.sqlite`, and Reminders to `~/Library/Group Containers/group.com.apple.reminders/Container_v1/Stores`.
+- `contacts.py` reads macOS AddressBook SQLite stores, documented in `README.md` and `CLAUDE.md`.
+- `services.py:215-309` manages read-only SQLite connections with `file:{db_path}?mode=ro`, lock retry handling, and per-thread connection caching.
+- `services.py:622`, `services.py:1937`, `services.py:2822`, and `services.py:5548` use `osascript` for iMessage, Notes, Reminders, and notification fallback paths.
+- `services.py:2311`, `services.py:2326`, and `services.py:4704` import `Quartz` for keyboard and desktop integrations.
+- `services.py:4525-4548` hard-codes MLX Whisper model `mlx-community/whisper-base.en-mlx`, `WHISPER_STREAM_BIN=/opt/homebrew/bin/whisper-stream`, and `WHISPER_STREAM_MODEL=/opt/homebrew/Cellar/whisper-cpp/1.8.4/share/whisper-cpp/ggml-base.en-q8_0.bin`.
+- `ambient_daemon.py` documents launchd usage through `launchctl load ~/Library/LaunchAgents/com.jwalin.ambient.plist`.
+- `scripts/setup_inbox_mcp.sh` installs launchd agents, writes `config/inbox.env` from the template, and loads three services with `launchctl`.
+- `deploy/*.service.example` assume Linux/systemd paths under `/Users/jwalinshah/projects/inbox`, which is useful as a template but not portable as-is.
+- `deploy/Caddyfile.example` exposes MCP HTTP and read-only MCP HTTP on ports `8000` and `8001`.
+
+## Environment variables and secrets
+
+Observed env vars from code, configs, and docs:
+
+- `INBOX_SERVER_PORT`: private FastAPI server port, default `9849`.
+- `INBOX_SERVER_URL`: client/MCP target URL, default `http://127.0.0.1:9849`.
+- `INBOX_SERVER_TOKEN`: optional bearer token for the private server.
+- `INBOX_MCP_TOKEN`: optional bearer token for the public MCP gateway; empty means unauthenticated.
+- `INBOX_MEMORY_DB`: optional override for `MemoryStore`.
+- `INBOX_TEST_MODE`, `INBOX_TEST_DATA_DIR`, `INBOX_TEST_NOW`: test-mode and deterministic test-data controls.
+- `INBOX_DEFAULT_GOOGLE_ACCOUNT`: write-routing override in `google_account_resolution.py`, mentioned in `CONNECTOR_ROADMAP.md` but absent from `config/inbox.env.example`.
+- `INBOX_POLL_INTERVAL`: TUI poll interval in `inbox.py`, absent from `config/inbox.env.example`.
+- `INBOX_PRE_WARM_CONVERSATIONS`: optional startup conversation prewarm in `inbox_server.py`, absent from `config/inbox.env.example`.
+- `INBOX_DISABLE_AMBIENT`: disables ambient autostart in `inbox_server.py`, absent from `config/inbox.env.example`.
+- `INBOX_HOME_ADDRESS`: fallback origin for travel-time/departure calculations, absent from `config/inbox.env.example`.
+- `INBOX_LLM_LARGE`: override for the larger MLX model, absent from `config/inbox.env.example`.
+- `GEMINI_API_KEY`: env override for Gemini; fallback file is `gemini_api_key.txt`.
+- `GOOGLE_CLOUD_API_KEY` and `GOOGLE_MAPS_API_KEY`: env overrides for map/travel features; fallback file is `google_maps_key.txt`.
+- `UV_CACHE_DIR`: used in service launch scripts but not in agent validation docs.
+
+Credential and local-secret files:
+
+- `services.py:57-66` defines `credentials.json`, legacy `token.json`, and per-account `tokens/`.
+- `services.py:84-86` defines `github_token.txt`, `google_maps_key.txt`, and `gemini_api_key.txt`.
+- `services.py:88-98` requests broad Google scopes: Gmail read/modify/send/settings, Calendar, Drive, Sheets, Docs, and Tasks.
+- `services.py:330-430` creates `tokens/`, migrates legacy `token.json`, renames token files by account email, refreshes credentials, and can run a local OAuth browser flow.
+- `.gitignore` ignores `credentials.json`, `token.json`, `token.json.lock`, `tokens/`, `github_token.txt`, `google_maps_key.txt`, `gemini_api_key.txt`, `config/inbox.env`, `.env*`, `*.key`, and `*.secret`.
+- `.mcp.json`, `.env.mcp.example`, `config/codex.inbox.example.toml`, and `config/gemini-settings.inbox.example.json` all model MCP client env wiring, but the Gemini example uses literal placeholder token strings rather than `${INBOX_SERVER_TOKEN}`.
+
+## Persistent and generated local state
+
+Local evidence:
+
+- `memory_store.py:9-39` defaults MCP memory to `.inbox_memory.sqlite3` in the repo root unless `INBOX_MEMORY_DB` is provided.
+- `message_index_store.py:12-84` defaults the message index to `.inbox_index.sqlite3` in the repo root and enables SQLite WAL.
+- `scheduler.py:15-67` defaults scheduler persistence to `.inbox_scheduler.sqlite3` in the repo root.
+- `ambient_notes.py:14-25` writes daily and ambient notes under `~/vault/daily` and `~/vault/ambient`.
+- `services.py:5429-5480` writes notification config under `~/.config/inbox/notifications.json` unless test mode redirects it.
+- `services.py:5560-5584` writes favorites under `~/.config/inbox/favorites.json` unless test mode redirects it.
+- `services.py:6090-6118` writes voice config under `~/.config/inbox/voice.json` and defaults `vault_dir` to `~/vault`.
+- `inbox_client.py:51-52` writes `server.log` in the repo root when auto-starting the server.
+- `batch/batch-runner.sh` creates `batch/archive-state.tsv` and `batch/logs/*.log`.
+- `.gitignore` ignores `.coverage`, `htmlcov/`, `*.log`, `.tldr/`, `.inbox_memory.sqlite3`, `.inbox_scheduler.sqlite3`, `.inbox_index.sqlite3`, `batch/triage-output.tsv`, `batch/archive-state.tsv`, `batch/logs/`, and `batch/.batch-state.lock`.
+- `.tldrignore` also excludes common Python caches, `.pytest_cache`, `.ruff_cache`, binary artifacts, env files, and credentials.
+- `.factory/` is tracked and contains service commands, skills, library notes, and validation JSON. It is not generated in this worktree; `git ls-files .factory ...` shows it is part of the repo history.
+
+## Validation surface
+
+Authoritative validation for this queue item:
+
+- Required command: `git status --short`.
+- Expected status after writing this report but before any commit: one untracked/added report path under `docs/overnight/`.
+- Expected status if a local handoff commit is made: clean worktree.
+
+Repo-declared validation candidates:
+
+- `UV_CACHE_DIR=/tmp/uv-cache INBOX_TEST_MODE=1 uv run pytest -m safe`
+  - Expected: pass for the small safe subset. Risk: only `tests/test_inbox_test_mode.py` and `tests/test_mcp_gateway.py` are marked `safe`, so this does not prove most server/TUI behavior.
+- `UV_CACHE_DIR=/tmp/uv-cache INBOX_TEST_MODE=1 uv run pytest tests/test_inbox_test_mode.py -q`
+  - Expected: pass and prove test-mode path redirection plus live-write blocking helper behavior.
+- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check .`
+  - Expected: pass according to `docs/TESTING_FOR_AGENTS.md` and `.factory/services.yaml`; not run during this read-only audit.
+- `UV_CACHE_DIR=/tmp/uv-cache uv run pyright`
+  - Expected: pass according to `docs/TESTING_FOR_AGENTS.md` and `.factory/services.yaml`; not run during this read-only audit.
+- `UV_CACHE_DIR=/tmp/uv-cache uv tree --locked --depth 2`
+  - Observed: pass; useful cheap proof for lockfile and dependency resolution.
+- `uv tree --locked --depth 2`
+  - Observed: fail in this worker due sandbox denial on `/Users/jwalinshah/.cache/uv`; use only after setting `UV_CACHE_DIR` or granting cache access.
+
+Testing details:
+
+- `docs/TESTING_FOR_AGENTS.md` says default agent runs must be deterministic, local, and safe, and recommends `INBOX_TEST_MODE=1 uv run pytest -m safe`, `uv run ruff check .`, and `uv run pyright`.
+- `pyproject.toml` registers markers `safe`, `integration`, `local_data`, `slow`, and `live_write`.
+- `rg` found only two files with module-level `pytestmark = pytest.mark.safe`: `tests/test_inbox_test_mode.py` and `tests/test_mcp_gateway.py`.
+- `tests/conftest.py` stubs heavy deps (`mlx_lm`, `mlx_whisper`, `sounddevice`, `outlines`, `Quartz`) when not importable, so unit tests can run without the full ML/hardware stack.
+- `services.py` has `_assert_live_write_allowed`; `rg` found guard calls for representative writes including Google auth, iMessage, Gmail, Calendar, Reminders, Tasks, GitHub notifications, Drive, Sheets, Docs, desktop notifications, WhatsApp, and calendar attendees.
+
+## Risks and stale assumptions
+
+1. `uv` cache handling is inconsistent. Service scripts set `UV_CACHE_DIR=/tmp/uv-cache`, but docs and `.factory/services.yaml` commands omit it. This worker proved plain `uv tree --locked --depth 2` can fail before reading the lockfile.
+2. `python` is absent on PATH in this worker; `python3` exists. The repo mainly uses `uv run python`, which is fine, but shell snippets or agents that call bare `python` outside `uv` may fail.
+3. Several runtime env vars are implemented but not represented in `config/inbox.env.example`: `INBOX_DEFAULT_GOOGLE_ACCOUNT`, `INBOX_POLL_INTERVAL`, `INBOX_PRE_WARM_CONVERSATIONS`, `INBOX_DISABLE_AMBIENT`, `INBOX_HOME_ADDRESS`, `INBOX_LLM_LARGE`, `GEMINI_API_KEY`, `GOOGLE_CLOUD_API_KEY`, and `GOOGLE_MAPS_API_KEY`.
+4. `INBOX_MCP_TOKEN` and `INBOX_SERVER_TOKEN` default to empty in code paths, which disables auth for the public MCP gateway and private API respectively. This is intentional for localhost, but dangerous if Caddy or launch configs are exposed before env is filled.
+5. Starlette is imported directly but only guaranteed transitively. FastAPI/MCP currently pull it in, but dependency cleanup or package extras changes could break MCP gateway imports without a pyproject diff.
+6. OAuth scope breadth is very large. One token directory unlocks Gmail read/modify/send/settings, Calendar, Drive, Sheets, Docs, and Tasks. Worktree docs explicitly mention copying `tokens/` from the primary checkout, which is convenient but easy to misuse.
+7. Ambient autostart can touch microphone/model resources on server startup when voice config enables it. `INBOX_DISABLE_AMBIENT` exists, but it is not in the env template or agent testing doc.
+8. Three SQLite stores default to the repo root: `.inbox_memory.sqlite3`, `.inbox_index.sqlite3`, and `.inbox_scheduler.sqlite3`. Only memory has an env override observed in code; scheduler and index are harder to isolate per worktree.
+9. Homebrew whisper paths are hard-coded to one installed `whisper-cpp` version. A brew upgrade can silently make dictation unavailable even if Python dependencies are valid.
+10. `.factory/init.sh` and `.factory/services.yaml` target `/Users/jwalinshah/projects/inbox` and port `9849`, not this isolated worktree. They are useful portfolio artifacts but unsafe as generic worker commands without path/port review.
+11. `batch/batch-runner.sh` performs live Gmail label mutations and maintains a TSV state file while allowing parallel workers. It should be treated as live-write infrastructure, not a validation helper.
+12. Launchd and systemd examples have absolute paths under `/Users/jwalinshah/projects/inbox`. They are local templates rather than portable deployment manifests.
+
+## Decisions from this audit
+
+- Treat `UV_CACHE_DIR=/tmp/uv-cache` as part of the reliable local command contract for sandboxed workers.
+- Treat `git status --short` as the only validation command required by this queue item; broader pytest/lint/typecheck candidates are documented rather than executed here.
+- Treat hidden tracked `.factory/` content as part of the repo dependency surface because it contains commands, validation evidence, and service assumptions.
+- Treat all MCP HTTP exposure as auth-sensitive because empty `INBOX_MCP_TOKEN` means the public middleware permits requests.
+- Treat local personal-data stores and OAuth files as external dependencies, not fixtures. Safe agent work should use `INBOX_TEST_MODE=1` and `INBOX_TEST_DATA_DIR`.
+
+## Next safe work
+
+1. Normalize agent-safe command docs around `UV_CACHE_DIR`.
+   - Acceptance criteria: `docs/TESTING_FOR_AGENTS.md`, `.factory/services.yaml`, and relevant setup docs show `UV_CACHE_DIR=/tmp/uv-cache` for `uv` commands intended for sandboxed workers.
+   - Validation: `UV_CACHE_DIR=/tmp/uv-cache uv tree --locked --depth 2`; `git diff -- docs/TESTING_FOR_AGENTS.md .factory/services.yaml`.
+
+2. Build a complete env-var inventory and update templates.
+   - Acceptance criteria: `config/inbox.env.example` documents every runtime env var observed in code, with safe defaults and notes for live-write/external-service vars; docs distinguish localhost-only empty tokens from exposed MCP/server deployments.
+   - Validation: `rg -n "INBOX_|GEMINI_API_KEY|GOOGLE_.*API_KEY|UV_CACHE_DIR" .`; `UV_CACHE_DIR=/tmp/uv-cache INBOX_TEST_MODE=1 uv run pytest tests/test_inbox_test_mode.py -q`.
+
+3. Make direct dependency imports explicit.
+   - Acceptance criteria: either add `starlette` as a declared direct dependency or remove direct Starlette imports from first-party modules/tests; `uv.lock` remains in sync.
+   - Validation: `UV_CACHE_DIR=/tmp/uv-cache uv tree --locked --depth 2`; `UV_CACHE_DIR=/tmp/uv-cache INBOX_TEST_MODE=1 uv run pytest tests/test_mcp_gateway.py -q`.
+
+4. Add path overrides for local stores that currently default to repo root or home.
+   - Acceptance criteria: index, scheduler, server log, and vault paths have explicit env/config overrides comparable to `INBOX_MEMORY_DB`; tests prove test-mode or env redirection avoids primary data stores.
+   - Validation: `UV_CACHE_DIR=/tmp/uv-cache INBOX_TEST_MODE=1 uv run pytest tests/test_inbox_test_mode.py tests/test_message_index_store.py tests/test_memory_store.py -q`.
+
+5. Add a live-write safety pass for batch and setup scripts.
+   - Acceptance criteria: `batch/batch-runner.sh` clearly requires an explicit live-write flag or defaults to dry run, and `scripts/setup_inbox_mcp.sh` documents/guards launchd writes; parallel state updates use a lock or are single-writer.
+   - Validation: `bash -n batch/batch-runner.sh scripts/setup_inbox_mcp.sh`; dry-run invocation against a temp copy of `batch/archive-input.tsv` does not call the live server.
+
+## Non-goals
+
+- No product code changes.
+- No credential reads, token validation, OAuth flows, or external service calls.
+- No server startup, MCP exposure, Caddy launch, launchd/systemd install, or deploy.
+- No live Gmail, Calendar, Drive, Docs, Sheets, Tasks, GitHub, Reminders, Notes, iMessage, WhatsApp, notification, audio, or keyboard-injection writes.
+- No PR creation or external tracker updates.
+- No attempt to prove README feature claims beyond local dependency-surface evidence.
+
+## Unknowns
+
+- Whether the primary checkout at `/Users/jwalinshah/projects/inbox` currently has live tokens, service state, or a running server.
+- Whether `credentials.json`, `tokens/`, `github_token.txt`, `google_maps_key.txt`, or `gemini_api_key.txt` exist in the primary checkout; they were not present in this clean worktree and were intentionally not inspected elsewhere.
+- Whether Homebrew currently has the exact `whisper-cpp` model path referenced by `services.py`.
+- Whether MLX model caches are already populated; first use may download or compile/cache outside the repo.
+- Whether full `uv run pytest`, `uv run pyright`, and `uv run ruff check .` are green on this branch; this queue item only required `git status --short`.
+- Whether `.factory/validation/*` reports are current relative to HEAD `2805b84`; they are tracked artifacts but not independently revalidated here.

--- a/docs/overnight/inbox-sym-30-validation-map.md
+++ b/docs/overnight/inbox-sym-30-validation-map.md
@@ -1,0 +1,173 @@
+# inbox-sym-30 validation-map audit
+
+Date: 2026-05-07
+Queue item: `inbox-sym-30-validation-map`
+Repo path: `/Users/jwalinshah/projects/agent-stack/.agent-stack-worktrees/2026-05-07-overnight-marathon/inbox-sym-30-validation-map`
+Branch: `codex/goal-inbox-sym-30-validation-map`
+HEAD at audit start: `2805b8400519da188ca7d3f6e39b19a8ca42b05a`
+
+## Scope
+
+This audit maps the validation surface for the local `inbox-sym-30` worktree. It is read-only with respect to product code. The only intended tracked change is this report.
+
+Non-goals:
+- No product code changes.
+- No live inbox server startup.
+- No Gmail, Calendar, Drive, Sheets, Docs, GitHub, iMessage, Notes, Reminders, microphone, notification, OAuth, deploy, or MCP live-service exercise.
+- No live-write tests or `local_data` tests.
+- No external pushes, PR creation, tracker updates, or repo cleanup.
+
+## Repo Purpose And State
+
+Purpose: `README.md` and `CLAUDE.md` describe a local-first Python inbox/TUI that uses a FastAPI backend for iMessage, Gmail, Google Calendar, Google Sheets, Apple Notes, Apple Reminders, GitHub notifications, Google Drive, ambient audio, dictation, and MCP access. The repository is validation-sensitive because its normal runtime reads local personal data stores and can perform external writes through OAuth-backed services.
+
+Observed state:
+- `git status --short --branch` returned only `## codex/goal-inbox-sym-30-validation-map` before report creation.
+- Required validation command `git status --short` returned no output before report creation and exited 0.
+- Required validation command `git status --short` after report creation exited 0 and returned `?? docs/overnight/`.
+- `git status --short --ignored` after validation probes showed ignored local artifacts: `.pytest_cache/`, `.ruff_cache/`, and `.venv/`.
+- The `.venv/` directory was created by the attempted `uv run` validation after the default uv cache path was blocked by sandbox permissions.
+- Expected final tracked dirty state is this report at `docs/overnight/inbox-sym-30-validation-map.md`.
+
+## Validation Surface
+
+Documented developer commands:
+- `README.md` documents `uv run ruff check --fix .`, `uv run pyright`, and `uv run pytest`.
+- `CLAUDE.md` repeats the same dev commands and explains the worktree development workflow.
+- `DOCS_INDEX.md` claims `uv run pytest` has "736 pass" and later says "All 736 tests pass".
+
+Documented agent-safe commands:
+- `docs/TESTING_FOR_AGENTS.md` defines the default safe loop as `INBOX_TEST_MODE=1 uv run pytest -m safe`, `uv run ruff check .`, and `uv run pyright`.
+- The same file says `INBOX_TEST_MODE=1 uv run pytest tests/test_inbox_test_mode.py -q` is the focused safe test.
+- It explicitly says not to run `live_write`, `local_data`, or live provider-specific tests unless requested by name.
+
+Configured tools:
+- `pyproject.toml` requires Python `>=3.12,<3.15`, which conflicts with the `README.md` quick-start claim of Python 3.10+.
+- `pyproject.toml` configures `ruff` with `E`, `F`, `I`, `UP`, `B`, and `SIM`, ignores `E501`, and targets Python 3.12.
+- `pyproject.toml` configures `pyright` in basic mode with `reportMissingImports = true`.
+- `pyproject.toml` configures pytest to use `testpaths = ["tests"]` and global `addopts = "--cov=. --cov-report=term-missing"`.
+- `pyproject.toml` registers markers: `safe`, `integration`, `local_data`, `slow`, and `live_write`.
+- `.pre-commit-config.yaml` includes ruff with `--fix`, `ruff-format`, standard pre-commit hygiene hooks, and Bandit. It does not run pytest or pyright.
+- `scripts/run_inbox_backend.sh`, `scripts/run_inbox_mcp_http.sh`, and `scripts/run_inbox_mcp_http_readonly.sh` set `UV_CACHE_DIR="${UV_CACHE_DIR:-/tmp/uv-cache}"`, but `dev.sh`, `README.md`, `CLAUDE.md`, and `docs/TESTING_FOR_AGENTS.md` do not set a sandbox-safe uv cache path.
+
+Test inventory:
+- `llm-tldr tree .` found 29 files under `tests/`, plus a top-level `test_autocomplete_dev.py` development script.
+- `rg -l "^def test_|^class Test" tests | wc -l` returned `29`.
+- `rg -n "^def test_|^class Test" tests | wc -l` returned `393` test/class declarations. This is not the same measurement as pytest-collected test cases, but it shows the current docs claim of "736 tests" needs revalidation.
+- `rg -n "pytestmark = pytest.mark.safe|@pytest.mark.safe|..." tests` found only `tests/test_inbox_test_mode.py` and `tests/test_mcp_gateway.py` marked safe at module scope.
+- `tests/conftest.py` stubs heavy/hardware modules (`mlx_lm`, `mlx_whisper`, `sounddevice`, `outlines`, `Quartz`) but does not stub normal package dependencies like `google_auth_oauthlib`, `loguru`, or `textual`.
+- `tests/test_inbox_test_mode.py` verifies `INBOX_TEST_MODE`, marker registration, and testing docs. Two tests import `services.py`.
+- `tests/test_mcp_gateway.py` uses `pytest.mark.anyio`; without `trio` installed, default AnyIO parametrization produces trio-backend failures.
+
+## Commands Run
+
+Repo discovery and state:
+- `llm-tldr tree .` passed and showed a flat Python app with `services.py`, `inbox_server.py`, `inbox.py`, MCP modules, scripts, deploy examples, docs, and 29 test files.
+- `git rev-parse HEAD` returned `2805b8400519da188ca7d3f6e39b19a8ca42b05a`.
+- `git status --short --branch` passed and reported branch `codex/goal-inbox-sym-30-validation-map`.
+- `git status --short` passed with empty output before report creation.
+- `git status --short` passed after report creation and showed `?? docs/overnight/`.
+
+Tool availability:
+- `uv --version` passed: `uv 0.11.5`.
+- `pytest --version` passed: `pytest 9.0.2`.
+- `ruff --version` passed: `ruff 0.15.8`.
+- `pyright --version` passed: `pyright 1.1.408`.
+- `bandit --version` passed: `bandit 1.9.4`.
+- `pre-commit --version` passed: `pre-commit 4.5.1`.
+
+Validation probes:
+- `UV_CACHE_DIR=/private/tmp/uv-cache-inbox-sym-30-validation-map INBOX_TEST_MODE=1 uv run pytest tests/test_inbox_test_mode.py -q` failed before tests ran because `uv` needed to download `pyobjc-core==12.1` and network/DNS was unavailable. This created ignored `.venv/` state.
+- `python -m pytest tests/test_inbox_test_mode.py -q` failed because `python` is not on PATH.
+- `python3 -m pytest tests/test_inbox_test_mode.py -q` failed because global pytest loaded `pyproject.toml` addopts but global `pytest-cov` was unavailable: unrecognized `--cov=. --cov-report=term-missing`.
+- `python3 -m pytest tests/test_inbox_test_mode.py -q -o addopts=''` ran and produced `4 passed, 2 failed`; failures were `ModuleNotFoundError: No module named 'google_auth_oauthlib'` when importing `services.py`.
+- `python3 -m pytest tests/test_mcp_gateway.py tests/test_inbox_test_mode.py -q -o addopts=''` ran and produced `9 passed, 4 failed`; failures were missing `trio` for AnyIO's trio backend and missing `google_auth_oauthlib` for `services.py` imports.
+- `python3 -m pytest tests/test_mcp_gateway.py -q -o addopts='' -k 'not trio'` passed: `5 passed, 2 deselected`.
+- `python3 -m pytest tests/test_inbox_test_mode.py::test_test_mode_blocks_live_writes tests/test_inbox_test_mode.py::test_test_mode_uses_configured_test_data_dir tests/test_inbox_test_mode.py::test_agent_safe_pytest_markers_are_registered tests/test_inbox_test_mode.py::test_agent_testing_docs_define_safe_commands_and_opt_in_warnings -q -o addopts=''` passed: `4 passed`.
+- `ruff check .` passed: `All checks passed!`.
+- `pyright` failed with 116 errors. Major buckets were missing imports (`textual`, `loguru`, `google_auth_oauthlib`, `ApplicationServices`, `Quartz`, `mlx_lm`, `mlx_whisper`, `outlines`, and `gemma4_hackathon.silos.*`) plus real type issues in `inbox_server.py`, `services.py`, `memory_store.py`, `organize_inbox.py`, tests, and unsubscribe scripts.
+- `pre-commit validate-config` passed.
+- `bandit -c pyproject.toml -r .` passed with no issues identified after scanning 18,343 lines of code; 10 potential issues were skipped due to configured skips or `#nosec` handling.
+
+## Validation Command Candidates
+
+Use these as candidate proof commands, with current expected status in this worktree:
+
+| Command | Expected status | Notes |
+|---|---:|---|
+| `git status --short` | Pass | Required queue validation; before report it was empty. After report it should show only this report as tracked dirty state. |
+| `ruff check .` | Pass | Passed from PATH with ruff 0.15.8. Pyproject dev dependency asks for ruff >=0.15.10, so canonical `uv run ruff check .` still needs a provisioned uv env. |
+| `bandit -c pyproject.toml -r .` | Pass | Passed from PATH with Bandit 1.9.4. Mirrors pre-commit Bandit intent without hook environment setup. |
+| `pre-commit validate-config` | Pass | Config syntax is valid. Does not prove hook execution. |
+| `python3 -m pytest tests/test_mcp_gateway.py -q -o addopts='' -k 'not trio'` | Pass | Cheap local proof for non-trio MCP gateway safe tests when uv env is unavailable. |
+| Selected four `tests/test_inbox_test_mode.py` tests with `-o addopts=''` | Pass | Proves test-mode helper and docs/marker checks that do not import `services.py`. |
+| `python3 -m pytest tests/test_inbox_test_mode.py -q -o addopts=''` | Fail | Fails on missing `google_auth_oauthlib` when importing `services.py`. |
+| `python3 -m pytest tests/test_mcp_gateway.py tests/test_inbox_test_mode.py -q -o addopts=''` | Fail | Fails on missing `trio` and `google_auth_oauthlib`. |
+| `INBOX_TEST_MODE=1 uv run pytest tests/test_inbox_test_mode.py -q` | Blocked/fail locally | With `UV_CACHE_DIR` moved to `/private/tmp`, uv still needed network to fetch `pyobjc-core==12.1`. Without moved cache, uv cannot access `~/.cache/uv` under sandbox. |
+| `INBOX_TEST_MODE=1 uv run pytest -m safe` | Expected blocked/fail locally | Same uv provisioning blocker; additionally safe coverage is currently only two files. |
+| `uv run pytest` | Not run; expected blocked/fail locally | Out of scope for this audit because it is broader than the agent-safe loop and uv provisioning is already blocked. |
+| `pyright` | Fail | 116 errors from PATH. `uv run pyright` may remove some missing imports after env provisioning, but current type gate is red. |
+| `pre-commit run --all-files` | Not run | Hook setup may need network/cache and ruff hook is configured with `--fix`, so it is not a non-mutating validation command. |
+
+## Risks And Stale Assumptions
+
+1. Python version docs are stale. `README.md` says Python 3.10+, while `pyproject.toml` requires Python `>=3.12,<3.15`.
+
+2. Test-count claims are stale or at least unsupported. `DOCS_INDEX.md` claims "736 pass"; local static inventory found 393 test/class declarations across 29 test files, and the current worktree could not run pytest under the canonical uv environment.
+
+3. Canonical agent-safe validation is not actually offline/sandbox safe. `docs/TESTING_FOR_AGENTS.md` tells agents to use `uv run`, but the default uv cache is outside this sandbox and moving the cache to `/private/tmp` still requires network for `pyobjc-core`.
+
+4. Pytest's global addopts make fallback testing brittle. Without the uv dev environment, global pytest fails immediately because `pytest-cov` is not installed but `--cov=. --cov-report=term-missing` is forced by `pyproject.toml`.
+
+5. Safe marker coverage is too narrow. Only `tests/test_inbox_test_mode.py` and `tests/test_mcp_gateway.py` are marked `safe`, so `pytest -m safe` is more of a smoke test than a representative deterministic suite.
+
+6. AnyIO async tests assume optional backend dependencies. `tests/test_mcp_gateway.py` uses `pytest.mark.anyio`, and global pytest tries a trio backend even though `trio` is not available in the observed environment.
+
+7. `pyright` is documented as a normal validation command but currently fails hard. Some errors are missing import/environment problems, but others are local type-contract issues that should be triaged separately.
+
+8. Pre-commit is not an adequate non-mutating validation gate. It omits pytest and pyright, and its ruff hook uses `--fix`, so `pre-commit run --all-files` can mutate files while validating.
+
+9. Runtime scripts and validation docs disagree on uv cache handling. Service wrapper scripts set `UV_CACHE_DIR=/tmp/uv-cache`; `dev.sh` and testing docs do not.
+
+10. Personal-data safety relies on convention rather than a single enforced test harness. `INBOX_TEST_MODE=1` blocks live writes through `assert_live_writes_allowed`, but default README/CLAUDE pytest commands omit it.
+
+## Next Safe Work
+
+1. Add an agent-safe validation wrapper.
+   - Work: create a small script such as `scripts/validate_agent_safe.sh` that exports `INBOX_TEST_MODE=1`, uses a workspace or `/tmp` uv cache, runs non-mutating lint, runs a deterministic safe pytest subset, and prints clear guidance if dependencies are not locally provisioned.
+   - Acceptance criteria: the script never touches live providers, never uses `--fix`, and exits with a clear message when uv cannot run offline.
+   - Validation command: `scripts/validate_agent_safe.sh`.
+
+2. Normalize pytest markers and safe suite coverage.
+   - Work: classify deterministic tests across `tests/` as `safe` or explicitly mark them otherwise; add a collection check that fails when a test file lacks an intentional validation category.
+   - Acceptance criteria: `INBOX_TEST_MODE=1 uv run pytest -m safe --collect-only -q` collects more than the current two safe files, and intentionally unsafe tests are marked `local_data`, `live_write`, `slow`, or `integration`.
+   - Validation commands: `INBOX_TEST_MODE=1 uv run pytest -m safe --collect-only -q`; `rg -n "pytestmark = pytest.mark.safe|@pytest.mark.safe" tests`.
+
+3. Fix the current agent-safe pytest blockers.
+   - Work: either make `trio` an explicit dev dependency or constrain AnyIO tests to asyncio; ensure the uv/dev environment contains `google-auth-oauthlib` and `pytest-cov`, or make the focused safe tests not require full service imports.
+   - Acceptance criteria: `INBOX_TEST_MODE=1 uv run pytest tests/test_inbox_test_mode.py tests/test_mcp_gateway.py -q` passes in a clean worktree with no live credentials.
+   - Validation command: `UV_CACHE_DIR=/tmp/uv-cache INBOX_TEST_MODE=1 uv run pytest tests/test_inbox_test_mode.py tests/test_mcp_gateway.py -q`.
+
+4. Make Pyright actionable instead of aspirational.
+   - Work: separate missing-dependency noise from real type errors, add local stubs or excludes for optional platform modules, and either fix or baseline the remaining real errors.
+   - Acceptance criteria: `uv run pyright` has an agreed target, ideally zero errors or a checked-in baseline with owner and date.
+   - Validation command: `uv run pyright`.
+
+5. Update validation docs to match reality.
+   - Work: update `README.md`, `CLAUDE.md`, `DOCS_INDEX.md`, and `docs/TESTING_FOR_AGENTS.md` so Python version, test-count claims, safe commands, cache expectations, and pass/fail status are current.
+   - Acceptance criteria: no doc claims "736 pass" unless freshly verified; docs consistently prefer `INBOX_TEST_MODE=1`; docs warn that full pytest requires a provisioned uv environment.
+   - Validation command: `rg -n "Python 3.10|736 pass|uv run pytest" README.md CLAUDE.md DOCS_INDEX.md docs/TESTING_FOR_AGENTS.md`.
+
+6. Split mutating format/fix commands from validation commands.
+   - Work: make docs distinguish `ruff check .` from `ruff check --fix .`, and consider adding a non-mutating pre-commit/manual validation path.
+   - Acceptance criteria: an agent can run a no-write validation command without surprise formatting edits.
+   - Validation commands: `ruff check .`; `pre-commit validate-config`.
+
+## Unknowns
+
+- Whether the primary non-sandbox developer machine has all uv dependencies cached and can run `uv run pytest` successfully.
+- Whether the historical "736 pass" claim was based on pytest-collected cases rather than static test declarations.
+- Whether a CI workflow exists outside this worktree; no `.github/workflows/*` file was found by `rg --files`.
+- Whether `pyright` failures are accepted debt or should block future work.
+- Whether the intended agent-safe suite should include server/client/service unit tests that mock all provider surfaces, or remain a narrow safety harness.
+- Whether generated `.venv/`, `.pytest_cache/`, and `.ruff_cache/` should be left for later workers or cleaned by the runner; they are ignored by `.gitignore`.

--- a/docs/overnight/inbox-validation-map.md
+++ b/docs/overnight/inbox-validation-map.md
@@ -1,0 +1,161 @@
+# inbox-validation-map
+
+## Scope
+
+Queue item: deep validation-map audit for `inbox`.
+
+This report is intentionally read-only for product code. It records the repo's validation surfaces, observed command behavior, validation gaps, and safe follow-up work. The only tracked file added by this worker is this report.
+
+## Repo State
+
+- Repo purpose: `inbox` is a local-first Python/TUI personal communication hub. The README describes a FastAPI backend plus Textual TUI that unifies iMessage, Gmail, Calendar, Sheets, Notes, Reminders, GitHub, Drive, ambient audio, dictation, and local ML.
+- Worktree: `/Users/jwalinshah/projects/agent-stack/.agent-stack-worktrees/2026-05-07-overnight-marathon/inbox-validation-map`
+- Branch: `codex/goal-inbox-validation-map`
+- Starting HEAD: `2805b8400519da188ca7d3f6e39b19a8ca42b05a`
+- Starting dirty state: `git status --short --branch` showed only `## codex/goal-inbox-validation-map`.
+- Local validation side effects: `uv run --no-sync python --version` created an ignored `.venv/`; pytest runs created ignored `.coverage` and `.pytest_cache/`. `git status --short --ignored .venv .pytest_cache .coverage` showed all three as ignored (`!!`).
+
+## Validation Inventory
+
+Primary validation files and claims:
+
+- `pyproject.toml` defines Python `>=3.12,<3.15`, runtime dependencies, dev dependencies, `ruff`, `pyright`, `pytest`, `pytest-cov`, and `bandit`.
+- `pyproject.toml` sets `pytest` `testpaths = ["tests"]` and default `addopts = "--cov=. --cov-report=term-missing"`.
+- `pyproject.toml` registers five markers: `safe`, `integration`, `local_data`, `slow`, and `live_write`.
+- `docs/TESTING_FOR_AGENTS.md` says default agent verification is `INBOX_TEST_MODE=1 uv run pytest -m safe`, `uv run ruff check .`, and `uv run pyright`.
+- `docs/TESTING_FOR_AGENTS.md` says `INBOX_TEST_MODE=1` blocks live writes and warns not to run `local_data`, `live_write`, or live provider-specific integration tests unless explicitly requested.
+- `README.md` and `CLAUDE.md` list developer commands as `uv run ruff check --fix .`, `uv run pyright`, and `uv run pytest`.
+- `DOCS_INDEX.md` claims `uv run pytest` has "Tests (736 pass)" and "All 736 tests pass"; this is stale against the current collected suite and observed results.
+- `.pre-commit-config.yaml` runs `ruff --fix`, `ruff-format`, basic pre-commit hooks, and `bandit -c pyproject.toml`.
+- No CI or central runner was found by `fd -H -t f '(^Makefile$|tox\.ini$|noxfile\.py$|pytest\.ini$|setup\.cfg$|\.github/|github/workflows|requirements.*\.txt$)' .`.
+
+## Commands Run
+
+Required queue validation:
+
+- `git status --short --branch`
+  - Result: pass. Initial output was only `## codex/goal-inbox-validation-map`.
+
+Exploration and validation-map discovery:
+
+- `llm-tldr tree .`
+  - Result: pass. Observed a flat Python app with `tests/`, `scripts/`, `deploy/`, `config/`, and docs, including `docs/TESTING_FOR_AGENTS.md`.
+- `rtk read pyproject.toml`
+  - Result: pass. Confirmed `pytest`, coverage addopts, `ruff`, `pyright`, `bandit`, and marker config.
+- `rtk read docs/TESTING_FOR_AGENTS.md`
+  - Result: pass. Confirmed agent-safe validation policy and opt-in warnings.
+- `rtk grep "pytest|ruff|pyright|bandit|INBOX_TEST_MODE|safe|local_data|live_write|pre-commit|coverage|uv run" .`
+  - Result: pass. Found validation claims in README, CLAUDE, DOCS_INDEX, pyproject, test files, and service write guards.
+- `rg -n "pytestmark|@pytest\.mark" tests --glob '*.py'`
+  - Result: pass. Found only four marker lines: safe module marks in `tests/test_inbox_test_mode.py` and `tests/test_mcp_gateway.py`, plus two `anyio` marks.
+- `rg -n "^def test_|^async def test_" tests test_autocomplete_dev.py | wc -l`
+  - Result: pass. Found 250 test function definitions before parametrization.
+
+Executable validation commands:
+
+- `uv run ruff check .`
+  - Result: pass. Output: `All checks passed!`
+- `INBOX_TEST_MODE=1 uv run pytest -m safe -q`
+  - First result: fail before collection due sandboxed home cache: `Failed to initialize cache at /Users/jwalinshah/.cache/uv`.
+  - Retried as `UV_CACHE_DIR=/private/tmp/inbox-validation-map-uv-cache INBOX_TEST_MODE=1 uv run pytest -m safe -q`.
+  - Retry result: pass. Output summary: `11 passed, 855 deselected in 9.95s`; total coverage in that narrow lane was 15%.
+- `UV_CACHE_DIR=/private/tmp/inbox-validation-map-uv-cache INBOX_TEST_MODE=1 uv run pytest -q`
+  - Result: fail. Output summary: `53 failed, 813 passed in 126.51s`.
+  - Failure class: tests expecting mocked write helpers to execute now raise `inbox_test_mode.LiveWriteBlocked` because `INBOX_TEST_MODE=1` blocks service write paths.
+- `uv run pyright`
+  - Result: fail. Output summary: `108 errors, 0 warnings, 0 informations`.
+  - Failure classes: unresolved optional/local imports, dynamic Textual widget APIs, dynamic Google/Quartz APIs, object-typed API services, test fake type mismatches, and optional subscripting in unsubscribe scripts.
+- `UV_CACHE_DIR=/private/tmp/inbox-validation-map-uv-cache uv run bandit -c pyproject.toml -r . -q`
+  - Result: pass with warning noise. Warnings included malformed `nosec` comments such as ignored words in comments and `nosec encountered ... but no failed test` on SQL-related files.
+
+## Key Evidence
+
+- `docs/TESTING_FOR_AGENTS.md` is the current best source for safe local validation. It correctly distinguishes safe agent runs from live/local-data tests.
+- `inbox_test_mode.py` defines `INBOX_TEST_MODE`, `LiveWriteBlocked`, `assert_live_writes_allowed`, and `test_data_dir`.
+- `services.py` centralizes live-write blocking through `_assert_live_write_allowed`, with guarded calls for Gmail, iMessage, Calendar, Reminders, Tasks, GitHub notifications, Drive, Sheets, Docs, desktop notifications, WhatsApp, and account auth.
+- `tests/test_inbox_test_mode.py` proves `INBOX_TEST_MODE` blocks live writes, redirects data paths, registers pytest markers, and documents safe commands.
+- `tests/test_mcp_gateway.py` is also marked safe; together with `tests/test_inbox_test_mode.py`, it accounts for the 11 selected safe tests.
+- `tests/test_drive.py`, `tests/test_github.py`, `tests/test_gmail_actions.py`, `tests/test_notifications.py`, `tests/test_reminders.py`, and `tests/test_services.py` contain mocked write-behavior tests that fail when the full suite is run under `INBOX_TEST_MODE=1`.
+- `.pre-commit-config.yaml` uses mutating `ruff --fix` and `ruff-format`; this is fine as a pre-commit hook but not a read-only audit command.
+- `scripts/run_inbox_backend.sh` sets `UV_CACHE_DIR="${UV_CACHE_DIR:-/tmp/uv-cache}"`, but `dev.sh` and the docs validation commands do not, which matters inside sandboxed worktrees where `~/.cache/uv` can be blocked.
+- `DOCS_INDEX.md` says all 736 tests pass, while current full pytest collection observed 866 parametrized tests with 53 failures under `INBOX_TEST_MODE=1`.
+
+## Risks And Stale Assumptions
+
+1. The documented agent-safe lane is healthy but too small to protect most of the product. `pytest -m safe` selected 11 tests and deselected 855, so most regression coverage is outside the default safe proof.
+2. Full pytest and safe test mode currently conflict. Running the full suite with `INBOX_TEST_MODE=1` blocks mocked write tests in Drive, GitHub, Gmail, Notifications, Reminders, and service AppleScript/Gmail paths.
+3. `pyright` is listed as a default agent command, but it currently fails with 108 errors. That makes the documented validation contract non-green even before product behavior is considered.
+4. `DOCS_INDEX.md` has stale validation claims: "736 pass" and "All 736 tests pass" do not match the current observed suite.
+5. Validation commands are sensitive to the UV cache location. In this sandbox, `INBOX_TEST_MODE=1 uv run pytest -m safe -q` failed until `UV_CACHE_DIR` was moved to `/private/tmp/...`.
+6. Pre-commit is not a safe read-only audit command as configured because `ruff --fix` and `ruff-format` may modify files.
+7. There is no discovered CI workflow, Makefile, tox, nox, or single non-mutating validation wrapper. Agents must piece together validation from docs and pyproject.
+8. Bandit passes but emits warning noise about malformed/ineffective `nosec` comments, which can hide whether security validation is meaningful.
+
+## Validation Command Candidates
+
+Use these as the current validation map:
+
+| Command | Expected Status | Notes |
+| --- | --- | --- |
+| `git status --short` | pass | Queue-required validation. Should show only the intended report change before commit, or clean after commit. |
+| `UV_CACHE_DIR=/private/tmp/inbox-validation-map-uv-cache INBOX_TEST_MODE=1 uv run pytest -m safe -q` | pass | Observed `11 passed, 855 deselected`. Cheap and agent-safe, but narrow. |
+| `uv run ruff check .` | pass | Observed `All checks passed!`; non-mutating form. |
+| `uv run ruff check --fix .` | not read-only | Listed in README/CLAUDE and pre-commit, but may modify files. Avoid for audits. |
+| `uv run pyright` | fail | Observed 108 errors. Do not use as a merge gate until triaged or scoped. |
+| `UV_CACHE_DIR=/private/tmp/inbox-validation-map-uv-cache INBOX_TEST_MODE=1 uv run pytest -q` | fail | Observed 53 failures and 813 passes because test mode blocks mocked write tests. |
+| `UV_CACHE_DIR=/private/tmp/inbox-validation-map-uv-cache uv run pytest -q` | unknown / risky | Not run. It may execute mocked write tests without `INBOX_TEST_MODE`; needs a human decision on whether mocks are sufficient guardrails. |
+| `UV_CACHE_DIR=/private/tmp/inbox-validation-map-uv-cache uv run bandit -c pyproject.toml -r . -q` | pass with warning noise | Observed exit 0 plus `nosec` warning noise. |
+| `uv run pre-commit run --all-files` | not read-only | Not run because configured hooks include format/fix actions. |
+
+## Next Safe Work
+
+1. Expand the safe test lane without weakening live-write protection.
+   - Acceptance criteria: Tests that only use mocked services and temp paths are marked `safe`; tests that intentionally verify `LiveWriteBlocked` stay safe; true local-data/live-write tests are explicitly marked otherwise.
+   - Suggested validation: `UV_CACHE_DIR=/private/tmp/inbox-validation-map-uv-cache INBOX_TEST_MODE=1 uv run pytest -m safe -q` selects materially more than 11 tests and passes.
+
+2. Split write-helper unit tests from live-write-blocking policy.
+   - Acceptance criteria: Mocked Drive/GitHub/Gmail/Notification/Reminder tests can run in an agent-safe mode without hitting external services, while separate tests prove `INBOX_TEST_MODE` blocks real write entrypoints.
+   - Suggested validation: `UV_CACHE_DIR=/private/tmp/inbox-validation-map-uv-cache INBOX_TEST_MODE=1 uv run pytest tests/test_drive.py tests/test_github.py tests/test_gmail_actions.py tests/test_notifications.py tests/test_reminders.py tests/test_services.py -q` no longer fails because of `LiveWriteBlocked`.
+
+3. Make `pyright` actionable.
+   - Acceptance criteria: Either `uv run pyright` passes, or `pyproject.toml` scopes/ignores known dynamic integration surfaces and docs state the expected residual errors.
+   - Suggested validation: `uv run pyright`.
+
+4. Add a non-mutating validation wrapper.
+   - Acceptance criteria: A documented command or script runs the intended read-only checks with a sandbox-safe `UV_CACHE_DIR`, no `ruff --fix`, no formatter writes, and no live external writes.
+   - Suggested validation: new wrapper exits 0 for `ruff` plus safe pytest, and explicitly reports `pyright` as pass/fail according to the chosen contract.
+
+5. Update stale validation docs.
+   - Acceptance criteria: `DOCS_INDEX.md`, `README.md`, `CLAUDE.md`, and `docs/TESTING_FOR_AGENTS.md` agree on the current pass/fail status and avoid claiming "736 pass" unless revalidated.
+   - Suggested validation: `rg -n "736|All .* tests pass|uv run pytest|pyright|ruff" README.md CLAUDE.md DOCS_INDEX.md docs/TESTING_FOR_AGENTS.md`.
+
+## Non-Goals
+
+- No product code changes.
+- No credential, token, OAuth, inbox data, Calendar, Gmail, Drive, GitHub, Notes, Reminders, or external-service access.
+- No live server startup, no localhost browser QA, no deploys, no pushes, no PR creation, and no external tracker updates.
+- No mutation of `.pre-commit-config.yaml`, test markers, pyproject config, or docs beyond this audit report.
+
+## Unknowns
+
+- Whether the desired release gate should be narrow safe pytest only, full pytest without `INBOX_TEST_MODE`, full pytest with a mock-write bypass, or a staged combination.
+- Whether any existing external CI exists outside this worktree; none was found locally.
+- Whether `pyright` was ever green or intentionally allowed to fail for dynamic integrations.
+- Whether the 53 full-suite failures under `INBOX_TEST_MODE=1` should be fixed by test marker changes, a mock-write context manager, service-layer dependency injection, or adjusted docs.
+- Whether bandit's `nosec` warning noise is acceptable or should be cleaned into a stricter security gate.
+
+## Decision Notes
+
+- I treated `docs/TESTING_FOR_AGENTS.md` as the safest validation policy because this repo handles personal data and live external write surfaces.
+- I used `UV_CACHE_DIR=/private/tmp/inbox-validation-map-uv-cache` for repeatable validation after observing the default `~/.cache/uv` failure.
+- I did not run pre-commit because the configured hooks can modify files.
+- I did run full pytest under `INBOX_TEST_MODE=1` to map the current conflict between broad regression coverage and live-write blocking; the result is not a recommended merge gate yet.
+
+## Handoff
+
+- Changed tracked-intent file: `docs/overnight/inbox-validation-map.md`.
+- Final required validation: `git status --short` exited 0 and showed `?? docs/overnight/`.
+- Commit status: not committed. `git add docs/overnight/inbox-validation-map.md` failed because the worktree git metadata points at `/Users/jwalinshah/projects/inbox/.git/worktrees/inbox-validation-map/index.lock`, which is outside the writable sandbox.
+- Commit SHA for current HEAD: `2805b8400519da188ca7d3f6e39b19a8ca42b05a`.
+- PR URL: none; PR creation and pushing were out of scope.
+- Blockers: only the sandboxed git metadata write blocker prevented creating a local commit.


### PR DESCRIPTION
## Summary

Adds generated overnight Codex review reports from the May 7 Goal Pack runs.

This PR is docs-only: it copies successful `docs/overnight` reports from isolated Goal Pack worktrees into a normal review branch.

## Included work

- Registered repo IDs: inbox, inbox-sym-115, inbox-sym-116, inbox-sym-117, inbox-sym-118, inbox-sym-119, inbox-sym-120, inbox-sym-214, inbox-sym-30
- Report files: 30
- Source goal runs: 30 successful report outputs

## Validation

- Secret-like scan over copied reports found no live token/API-key patterns.
- Placeholder secret examples such as `*_API_KEY=...` were redacted in copied report text.
- `git status --short` showed only `docs/overnight` report additions before commit.
- No product code, deploys, external tracker updates, or generated runtime logs are included.

## Review notes

This is opened as a draft because the reports are generated audit output and should be skimmed before merge.