### PR TITLE
[codex] Add whole-portfolio review reports

### DIFF
--- a/docs/overnight/2026-05-07-whole-portfolio-review/inbox-implementation-readiness.md
+++ b/docs/overnight/2026-05-07-whole-portfolio-review/inbox-implementation-readiness.md
@@ -1,0 +1,205 @@
+# Inbox implementation-readiness review
+
+Queue item: `inbox-implementation-readiness`
+Branch: `codex/goal-inbox-implementation-readiness`
+Review date: 2026-05-07
+Scope: read-only repo review plus this report. No product code changed.
+
+## Current state
+
+- Starting HEAD: `2805b8400519da188ca7d3f6e39b19a8ca42b05a`.
+- Initial validation command `git status --short` returned no output before this report was written.
+- No `.github/workflows` files were present (`rg --files -g '.github/**'` returned no matches).
+- No previous overnight outputs were available in this worktree: `rg --files docs runs` found only `docs/TESTING_FOR_AGENTS.md` and reported `runs: No such file or directory`.
+- Recent history is already moving in the right direction: latest commits include `a821b5a Make indexed inbox views the default`, `05fc249 Add index sync health endpoint`, and `44be0c8 Avoid large thread cleanup expressions`.
+
+## Concrete observations
+
+1. `PLAN.md` defines the immediate product as Gmail, iMessage/SMS, calendar context, local FastAPI server, local SQLite index, and Textual TUI. It explicitly says incomplete areas are resumable bootstrap sync, stronger incremental checkpoints, noisy classification, indexed default TUI views, waiting-on views, and calendar context.
+
+2. `message_sync.py` has a real sync implementation, not just scaffolding: Gmail bootstrap persists `bootstrap_page_token`, tracks `internalDateMs`, records a Gmail `historyId` when available, has timestamp fallback, and rebuilds only changed `(source, account)` scopes after bootstrap/incremental sync.
+
+3. `tests/test_message_sync.py` is a strong readiness signal. It covers Gmail bootstrap resume after interruption, history cursor recording, no double-counting on resume, history-based incremental sync, timestamp fallback, skipped iMessage rows advancing checkpoints, and scoped thread rebuilds.
+
+4. `message_index_store.py` owns the operational index schema: `sync_state`, `items`, `threads`, and `sender_stats`. `list_threads()` already supports actionable, recent, action set, needs-reply, open-loop, latest-sender, and priority/recent sort filters, so more index views can be added without provider calls.
+
+5. `thread_classifier.py` is deterministic and small enough for implementation work. The current classifier distinguishes OTP, newsletter, appointment, survey, receipt, security, opportunity, health-admin, housing, and general threads, but `tests/test_thread_classifier.py` currently has only one focused assertion for OTP ignore behavior.
+
+6. `inbox_server.py` exposes index-first API surfaces: `/index/threads`, `/index/status`, `/index/health`, `/index/views/{view_name}`, `/index/sync/bootstrap`, `/index/sync/incremental`, and `/inbox/needs-action`. The sync POST routes call `index_bootstrap_sync` and `index_incremental_sync` directly in a thread without an obvious server-level concurrency guard.
+
+7. `tests/test_server.py` validates the index health and read-model contract: stale checkpoints, missing checkpoints, sync errors, no sync state, index views, and `/inbox/needs-action` avoiding live Gmail fallback when the index is empty.
+
+8. `inbox_client.py` includes compact index helpers for recent, actionable, waiting-on-me, and waiting-on-others views. The client can already consume more granular waiting views than the current TUI presents.
+
+9. `tui_tabs.py` declares `Now`, `Actionable`, and `Waiting On` as primary tabs before raw sources, matching the product plan. `inbox.py` binds these to `ctrl+1`, `ctrl+9`, and `ctrl+0`, refreshes `recent`, `actionable`, and `waiting-on` index views, and renders indexed thread summaries without raw body fetches.
+
+10. `inbox.py`'s `_show_index_thread()` renders summary, action items, and brief text from the index only. That keeps the default view compact, but there is not yet an obvious "open raw source thread from this indexed row" flow in the inspected slice.
+
+11. `google_account_resolution.py` centralizes Google service resolution and honors `INBOX_DEFAULT_GOOGLE_ACCOUNT` when the preferred account exists in the service map. It also implements `preflight_google_write_payload()` for docs/sheets/Drive folders, Tasks, and Calendar events.
+
+12. `CONNECTOR_ROADMAP.md` says write routing and preflight should be encoded in code, not prompts. The backend partially implements that, but `tools_registry.py` currently has no MCP tool entries for `preflight_google_write`, `index_health`, index views, or `/inbox/needs-action` (`rg -n "preflight|index_|needs_action|workflow" tools_registry.py ...` returned only tests around client index status/health).
+
+13. `tools_registry.py` and `tests/test_tools_registry.py` provide a good safety base for MCP work: every mutating tool must be confirmation-gated, readonly registration is separately tested, handler signatures are checked, and path params are URL-encoded.
+
+14. `docs/TESTING_FOR_AGENTS.md`, `inbox_test_mode.py`, and `services.py` provide an agent-safe test mode. `INBOX_TEST_MODE=1` blocks representative live writes and redirects local data paths, and `tests/test_inbox_test_mode.py` asserts the docs and marker registration. However, `rg -n "@pytest.mark|live_write|local_data|safe" tests pyproject.toml` shows only `tests/test_inbox_test_mode.py` and `tests/test_mcp_gateway.py` carry module-level `pytest.mark.safe`, so the documented `pytest -m safe` loop currently exercises only a small slice.
+
+15. `config/codex.inbox.example.toml` and `config/gemini-settings.inbox.example.json` both pass `INBOX_SERVER_TOKEN` to MCP clients. `deploy/com.inbox.backend.plist.example` and `deploy/inbox-backend.service.example` source `config/inbox.env` and run `scripts/run_inbox_backend.sh`, while `dev.sh` defaults worktrees to port 9850. Runtime routing is reasonably documented and implementable.
+
+## Risks and blockers
+
+- There is no CI workflow in this worktree, so local validation discipline is the only visible enforcement surface.
+- The documented safe pytest command appears too narrow because most deterministic tests are not marked `safe`.
+- Live provider behavior still depends on local macOS data stores, OAuth tokens, Google account services, GitHub token files, microphone/accessibility permissions, and server routing. Implementation slices should stay in `INBOX_TEST_MODE=1` unless explicitly approved.
+- Index sync endpoints appear callable concurrently. A double bootstrap or bootstrap plus incremental run could make status and checkpoint evidence harder to trust.
+- Preflight exists as an HTTP endpoint but is not exposed through the MCP tool registry, so agents can confirm writes without first having a first-class preflight step.
+- Previous overnight reports and `runs/*` artifacts were not available locally, so this pass cannot compare against prior overnight findings.
+
+## Exact validation commands
+
+Required queue validation:
+
+```bash
+git status --short
+```
+
+Useful local implementation validation commands for future slices:
+
+```bash
+INBOX_TEST_MODE=1 uv run pytest tests/test_message_sync.py -q
+INBOX_TEST_MODE=1 uv run pytest tests/test_server.py -q
+INBOX_TEST_MODE=1 uv run pytest tests/test_client.py tests/test_api_contract.py -q
+INBOX_TEST_MODE=1 uv run pytest tests/test_thread_classifier.py -q
+INBOX_TEST_MODE=1 uv run pytest tests/test_tools_registry.py tests/test_mcp_gateway.py -q
+uv run ruff check .
+uv run pyright
+```
+
+## Implementation-ready follow-up tasks
+
+### 1. Expose index and preflight tools on the MCP registry
+
+Owned files:
+- `tools_registry.py`
+- `tests/test_tools_registry.py`
+- `tests/test_api_contract.py`
+
+Change:
+- Add readonly MCP tools for `index_health`, `index_status`, `list_index_view`, `list_needs_action`, and `preflight_google_write`.
+- Keep preflight readonly even though it describes writes.
+- Ensure registry route tests prove each tool maps to an existing FastAPI endpoint.
+
+Acceptance criteria:
+- `readonly_only=True` registration includes the new index/preflight tools.
+- `test_mcp_tool_paths_route_to_fastapi_endpoints` stays green.
+- No new mutating tool is added without `confirm=True`.
+
+Smallest useful validation:
+
+```bash
+INBOX_TEST_MODE=1 uv run pytest tests/test_tools_registry.py tests/test_api_contract.py -q
+```
+
+### 2. Split Waiting On into "Waiting on me" and "Waiting on others" surfaces
+
+Owned files:
+- `tui_tabs.py`
+- `inbox.py`
+- `inbox_client.py`
+- `tests/test_client.py`
+- `tests/test_inbox_app.py`
+
+Change:
+- Use the existing client helpers for `waiting-on-me` and `waiting-on-others`.
+- Add clear TUI navigation and state preservation for the two views, or add a small toggle inside the existing Waiting On tab if a new tab is too much UI surface.
+- Keep both views index-only and avoid raw provider fallback.
+
+Acceptance criteria:
+- Waiting-on-me calls `/index/views/waiting-on-me`.
+- Waiting-on-others calls `/index/views/waiting-on-others`.
+- Sidebar status makes the selected waiting mode visible.
+- Existing source tabs still preserve selection state.
+
+Smallest useful validation:
+
+```bash
+INBOX_TEST_MODE=1 uv run pytest tests/test_client.py tests/test_inbox_app.py -q
+```
+
+### 3. Add representative classifier fixtures before tuning actionability
+
+Owned files:
+- `thread_classifier.py`
+- `tests/test_thread_classifier.py`
+- optionally `message_index_store.py` if the fix needs sender-stat behavior
+
+Change:
+- Add tests for recruiter/interview, newsletter, receipt, appointment, security alert, health-admin, housing, and latest-sender-is-me cases.
+- Then tune the smallest classifier rules needed to satisfy those fixtures.
+
+Acceptance criteria:
+- Automated/newsletter/receipt/OTP examples do not become reply-worthy.
+- Recruiter or direct opportunity examples become `review` or `reply`.
+- Health/security examples become `track` with an open loop.
+- Last sender `Me` does not set `needs_reply`.
+
+Smallest useful validation:
+
+```bash
+INBOX_TEST_MODE=1 uv run pytest tests/test_thread_classifier.py tests/test_message_sync.py -q
+```
+
+### 4. Add an index sync concurrency guard and status evidence
+
+Owned files:
+- `inbox_server.py`
+- `tests/test_server.py`
+- optionally `message_index_store.py` if a persistent lock/status field is needed
+
+Change:
+- Prevent `/index/sync/bootstrap` and `/index/sync/incremental` from running concurrently in the same server process.
+- Return a clear 409 or structured failure when another sync is running.
+- Preserve `sync_state.status`, `last_run_started_at`, and `last_error` semantics.
+
+Acceptance criteria:
+- A second sync request while one is running does not start another sync.
+- The response identifies the active mode or at least reports that sync is already running.
+- Existing index health tests still pass.
+
+Smallest useful validation:
+
+```bash
+INBOX_TEST_MODE=1 uv run pytest tests/test_server.py -q
+```
+
+### 5. Make the agent-safe validation lane enforceable
+
+Owned files:
+- `.github/workflows/agent-safe.yml`
+- `docs/TESTING_FOR_AGENTS.md`
+- `pyproject.toml`
+- targeted test files chosen for `safe` coverage
+
+Change:
+- Add a CI workflow or equivalent local validation script for `INBOX_TEST_MODE=1`, safe pytest, ruff, and pyright.
+- Expand `safe` markers for deterministic tests that do not touch live personal data, or adjust docs to name focused safe files instead of implying broad coverage.
+
+Acceptance criteria:
+- The documented safe command runs a meaningful subset of deterministic backend/client/MCP/index tests.
+- Live-write, local-data, and slow tests remain opt-in.
+- CI or the local script fails on lint/type/test regressions.
+
+Smallest useful validation:
+
+```bash
+INBOX_TEST_MODE=1 uv run pytest -m safe -q
+uv run ruff check .
+uv run pyright
+```
+
+## Handoff
+
+- Files changed by this queue item: `docs/overnight/2026-05-07-whole-portfolio-review/inbox-implementation-readiness.md`
+- Product code changed: no
+- PR URL: not created; external pushes and PR creation are out of scope for this queue item.
+- Blockers: no local blocker for the required report. Previous overnight artifacts and CI workflows were not present in this worktree. A local commit was attempted but blocked because Git could not create `/Users/jwalinshah/projects/inbox/.git/worktrees/inbox-implementation-readiness/index.lock` from this sandboxed worktree.
+- Required validation result: `git status --short` exits 0 and reports this new `docs/overnight/` report path as the only worktree change.

--- a/docs/overnight/2026-05-07-whole-portfolio-review/inbox-risk-and-validation-review.md
+++ b/docs/overnight/2026-05-07-whole-portfolio-review/inbox-risk-and-validation-review.md
@@ -1,0 +1,175 @@
+# Inbox Risk And Validation Review
+
+Queue item: `inbox-risk-and-validation-review`
+Branch: `codex/goal-inbox-risk-and-validation-review`
+Review date: 2026-05-07
+Pass: risk-and-validation-review
+
+## Scope
+
+This review covered the local `inbox` worktree only. It used repo-local evidence from docs, package metadata, scripts, deployment examples, tests, recent git history, and current git state. Product code was not edited.
+
+No prior overnight outputs were present in this worktree: `fd -a 'overnight|handoff|result.json|runs' .` returned no paths before this report was added.
+
+## Validation Commands Run
+
+| Command | Result |
+| --- | --- |
+| `git status --short --branch` | Passed before report creation; branch was `codex/goal-inbox-risk-and-validation-review` with no tracked changes. |
+| `llm-tldr tree .` | Passed; used to inventory repo structure. |
+| `rg --files docs .github scripts deploy config tests \| sort` | Returned expected docs/scripts/tests and reported `.github` missing. |
+| `INBOX_TEST_MODE=1 uv run pytest -m safe -q` | Blocked before collection: sandbox denied `uv` cache access under `~/.cache/uv`. |
+| `UV_CACHE_DIR=/tmp/uv-cache INBOX_TEST_MODE=1 uv run pytest -m safe -q` | Blocked by restricted network while `uv` tried to download `numba==0.65.0`, pulled by `mlx-whisper`. |
+| `git status --short` | Required queue validation; it reported only the new `docs/overnight/` report path. Staging/commit was blocked by git metadata permissions and is recorded in the worker handoff. |
+
+## Concrete Observations
+
+1. `README.md` says the requirement is Python 3.10+, while `pyproject.toml` requires `>=3.12,<3.15` and `.python-version` pins `3.12`. This is a stale setup claim that can send new agents down the wrong environment path.
+2. `docs/TESTING_FOR_AGENTS.md` defines the intended safe loop as `INBOX_TEST_MODE=1 uv run pytest -m safe`, `uv run ruff check .`, and `uv run pyright`, with explicit warnings not to run `local_data` or `live_write` tests without opt-in.
+3. `pyproject.toml` has pytest coverage enabled by default with `--cov=. --cov-report=term-missing` and declares markers for `safe`, `integration`, `local_data`, `slow`, and `live_write`.
+4. `tests/conftest.py` stubs heavy or hardware-bound modules such as `mlx_lm`, `mlx_whisper`, `sounddevice`, `outlines`, and `Quartz`, but dependency installation still tries to fetch `mlx-whisper` transitive dependencies before tests can collect.
+5. `pyproject.toml` depends directly on `mlx-lm`, `mlx-whisper`, `pyobjc-framework-applicationservices`, `pyobjc-framework-Quartz`, and `sounddevice`; `uv.lock` pins `numba==0.65.0` through `mlx-whisper`, which caused the offline validation failure.
+6. Only `tests/test_inbox_test_mode.py` and `tests/test_mcp_gateway.py` are marked `pytest.mark.safe`. Representative write-blocking regressions in `tests/test_services.py` are not included in the documented `-m safe` loop.
+7. `inbox_test_mode.py` provides `assert_live_writes_allowed`, and `services.py` calls `_assert_live_write_allowed` across many mutating operations: Gmail sends/archive/delete/labels, calendar CRUD, Apple Reminders, Google Tasks, Drive, Sheets, Docs, GitHub notification mutation, WhatsApp send, desktop notifications, and attendee modification.
+8. `tests/test_services.py` verifies representative and extended live-write blockers, including Gmail reply, calendar event creation, Apple Reminder completion, Google Task creation, Drive folder creation, Sheet update, Doc creation, GitHub notification mutation, desktop notification, and WhatsApp send.
+9. `tools_registry.py` centralizes MCP tool registration and marks mutating tools as `confirm=True`; `tests/test_tools_registry.py` asserts all non-read-only tools are confirmation-gated and that read-only registration excludes write tools.
+10. `mcp_gateway.py` allows `/health` without `INBOX_MCP_TOKEN` but protects other MCP routes when the token is set. `inbox_server.py` also makes `INBOX_SERVER_TOKEN` optional, returning open local access when the token is unset.
+11. `MCP_SETUP.md` and `deploy/Caddyfile.example` correctly recommend exposing only `/health` and `/mcp`, keeping the private backend on `127.0.0.1:9849`, and exposing the read-only MCP endpoint first.
+12. `scripts/run_inbox_backend.sh`, `scripts/run_inbox_mcp_http.sh`, and `scripts/run_inbox_mcp_http_readonly.sh` set `UV_CACHE_DIR=/tmp/uv-cache`, but `README.md`, `CLAUDE.md`, and `docs/TESTING_FOR_AGENTS.md` do not mention this for validation commands.
+13. `.pre-commit-config.yaml` configures ruff, ruff-format, generic pre-commit hooks, and bandit, but there is no `.github/workflows` directory in the local worktree, so CI parity cannot be verified from repo evidence.
+14. `message_index_store.py` stores `sync_state`, `items`, `threads`, and `sender_stats` with WAL enabled and idempotent item/thread upserts, giving the index a clear local validation surface.
+15. `message_index_store.py` updates `last_success_at` inside `set_sync_state` for all statuses, including `mark_sync_started` and `update_sync_progress`. `inbox_server.py` index health treats `last_success_at` as freshness evidence, so a running or interrupted sync could look fresher than the last completed success unless tests pin that behavior.
+16. `message_sync.py` has tests for resumable Gmail bootstrap, Gmail history-cursor incremental sync, timestamp fallback, skipped iMessage row checkpoint advancement, and scoped thread rebuilds in `tests/test_message_sync.py`.
+17. `thread_classifier.py` is intentionally heuristic and simple. `tests/test_thread_classifier.py` directly covers only OTP ignore behavior, while richer classifier behavior is covered indirectly through `tests/test_message_index_store.py`.
+18. `inbox_server.py` exposes index-first views and `/inbox/needs-action`; `tests/test_server.py` asserts `raw_provider_fetch` is false for indexed views and that `/inbox/needs-action` does not fall back to live Gmail when the index is empty.
+
+## Risks And Blockers
+
+1. Safe validation is not self-contained in the current sandbox. Even with `UV_CACHE_DIR=/tmp/uv-cache`, `uv run pytest -m safe -q` attempted to download `numba==0.65.0`; this blocks offline or restricted-network agents before tests collect.
+2. The documented safe marker does not include several high-value live-write guard tests. A future agent following `docs/TESTING_FOR_AGENTS.md` can pass `-m safe` while missing regressions in `tests/test_services.py`.
+3. Setup docs disagree on Python version. The repo will run agents on 3.12 through `.python-version` and `pyproject.toml`, but `README.md` still advertises 3.10+.
+4. CI status cannot be established from local evidence because `.github/workflows` is absent. Pre-commit exists, but there is no repo-local workflow proving ruff, pyright, and safe tests run automatically.
+5. Index health may overstate freshness because `last_success_at` is written during sync start/progress, not only after completed success.
+6. Classifier coverage is thin for the exact categories that drive product risk: newsletters, receipts, appointments, health-admin, security, housing, opportunity review, and frequent-human-sender promotion.
+7. HTTP write endpoints depend on optional local token auth plus service-layer test-mode guards. MCP writes are confirmation-gated, but direct REST access is not confirmation-gated by the server when the backend is reachable with a valid or absent `INBOX_SERVER_TOKEN`.
+8. Validation docs omit the `UV_CACHE_DIR=/tmp/uv-cache` workaround already used by runtime scripts, so agents in restricted environments hit avoidable cache permission failures.
+
+## Implementation-Ready Follow-Up Tasks
+
+### 1. Make Agent-Safe Tests Collect Without Network
+
+Owned files:
+- `pyproject.toml`
+- `uv.lock`
+- `docs/TESTING_FOR_AGENTS.md`
+- `tests/conftest.py`
+
+Work:
+- Split hardware/ML/audio dependencies into an optional dependency group or extra that is not required for the safe test loop.
+- Keep stubs in `tests/conftest.py`, but make dependency sync for `-m safe` avoid downloading `mlx-whisper` transitive packages.
+- Document the exact restricted-environment command with `UV_CACHE_DIR=/tmp/uv-cache`.
+
+Acceptance criteria:
+- A clean checkout can run the safe test command without contacting PyPI after the base Python/dev environment is available.
+- Runtime scripts still install/run full app dependencies when requested.
+- Docs distinguish safe validation from full local app dependency sync.
+
+Smallest useful validation:
+```bash
+UV_CACHE_DIR=/tmp/uv-cache INBOX_TEST_MODE=1 uv run pytest -m safe -q
+```
+
+### 2. Put Live-Write Guard Regressions In The Safe Test Lane
+
+Owned files:
+- `tests/test_services.py`
+- `tests/test_inbox_test_mode.py`
+- `docs/TESTING_FOR_AGENTS.md`
+
+Work:
+- Mark the representative `INBOX_TEST_MODE` live-write blocker tests as `safe`.
+- If needed, split live-write guard tests into a dedicated safe file so they are run by the documented command.
+- Add a doc sentence that safe tests include guard tests but still do not touch providers.
+
+Acceptance criteria:
+- `pytest -m safe` includes service-level write blocker regressions for Gmail, Calendar, Reminders, Tasks, Drive, Sheets, Docs, GitHub, notifications, and WhatsApp.
+- No test marked `safe` reaches a real provider, local personal DB, microphone, or notification mutation path.
+
+Smallest useful validation:
+```bash
+UV_CACHE_DIR=/tmp/uv-cache INBOX_TEST_MODE=1 uv run pytest -m safe tests/test_inbox_test_mode.py tests/test_services.py -q
+```
+
+### 3. Tighten Index Freshness Semantics
+
+Owned files:
+- `message_index_store.py`
+- `inbox_server.py`
+- `tests/test_message_index_store.py`
+- `tests/test_server.py`
+
+Work:
+- Preserve `last_success_at` for the last completed idle sync only.
+- Track running progress through `status`, `last_run_started_at`, `checkpoint_value`, and metadata without making health look successful.
+- Add health reasons for long-running or interrupted syncs if needed.
+
+Acceptance criteria:
+- Starting or progressing a sync does not make `/index/health` healthy unless a completed sync exists.
+- An error after progress keeps the last successful timestamp separate from current failure state.
+- Existing status and metadata tests still pass.
+
+Smallest useful validation:
+```bash
+UV_CACHE_DIR=/tmp/uv-cache INBOX_TEST_MODE=1 uv run pytest tests/test_message_index_store.py tests/test_server.py -k "sync_state or index_health" -q
+```
+
+### 4. Expand Classifier Fixtures For Actionable Views
+
+Owned files:
+- `thread_classifier.py`
+- `tests/test_thread_classifier.py`
+- `tests/test_message_index_store.py`
+
+Work:
+- Add table-driven fixtures for newsletter, receipt, appointment, health-admin, security alert, opportunity, housing, frequent human sender, and no-reply cases.
+- Pin `topic`, `noise_class`, `urgency`, `actionability`, `needs_reply`, and `open_loop`.
+- Only adjust classifier logic where tests expose a wrong or unstable classification.
+
+Acceptance criteria:
+- The categories used by indexed actionability views are directly tested.
+- Low-value automated mail remains `archive` or `ignore`.
+- Human/opportunity/security/health-admin examples produce stable `reply`, `review`, or `track` outputs.
+
+Smallest useful validation:
+```bash
+UV_CACHE_DIR=/tmp/uv-cache INBOX_TEST_MODE=1 uv run pytest tests/test_thread_classifier.py tests/test_message_index_store.py -q
+```
+
+### 5. Add Repo-Local CI Parity For Validation
+
+Owned files:
+- `.github/workflows/ci.yml`
+- `docs/TESTING_FOR_AGENTS.md`
+- `README.md`
+
+Work:
+- Add a GitHub Actions workflow that runs the same safe validation surface documented for agents.
+- Include `ruff check .`, `pyright`, and `INBOX_TEST_MODE=1 pytest -m safe`.
+- Update setup docs to align Python version and validation commands.
+
+Acceptance criteria:
+- Local docs and CI agree on Python 3.12.
+- Pull requests get automated feedback for lint, type check, and safe tests.
+- The workflow does not require personal tokens, local macOS databases, microphone access, or live providers.
+
+Smallest useful validation:
+```bash
+git ls-files .github/workflows/ci.yml && UV_CACHE_DIR=/tmp/uv-cache INBOX_TEST_MODE=1 uv run pytest -m safe -q
+```
+
+## Suggested Morning Review Focus
+
+- Check whether other queue items also hit `uv` network/dependency blockers; if yes, split heavy optional dependencies once instead of patching each report.
+- Inspect any runner-created PRs for CI evidence, because this local worktree has no `.github/workflows` evidence.
+- Prioritize follow-up task 1 before broad implementation, because it unblocks every future safe validation pass.
+- Prioritize follow-up task 3 before relying on `/index/health` as a go/no-go signal for indexed-default work.

--- a/docs/overnight/2026-05-07-whole-portfolio-review/inbox-sym-115-implementation-readiness.md
+++ b/docs/overnight/2026-05-07-whole-portfolio-review/inbox-sym-115-implementation-readiness.md
@@ -1,0 +1,338 @@
+# inbox-sym-115 implementation-readiness review
+
+Date: 2026-05-07
+Branch: `codex/goal-inbox-sym-115-implementation-readiness`
+Repo: `inbox-sym-115`
+Review type: implementation-readiness
+Starting HEAD: `2805b84`
+
+## Scope
+
+This pass was read-only against product code. The only intended repository change
+is this report under `docs/overnight/2026-05-07-whole-portfolio-review/`.
+
+External services, deploys, pushes, PR creation, live writes, and tracker updates
+were out of scope. Live provider behavior was inferred only from repo-local docs,
+tests, scripts, and code.
+
+## Evidence Reviewed
+
+- `llm-tldr tree .`
+- `git status --short --branch`
+- `git rev-parse --short HEAD`
+- `git log --oneline -8`
+- `rg --files -g 'docs/**' -g 'runs/**' -g 'items/**' -g '.github/**'`
+- `rtk read AGENTS.md`
+- `rtk read CLAUDE.md`
+- `rtk read README.md`
+- `rtk read pyproject.toml`
+- `rtk read docs/TESTING_FOR_AGENTS.md`
+- `rtk read PLAN.md`
+- `rtk read CONNECTOR_ROADMAP.md`
+- `rtk read MCP_V1_PLAN.md`
+- Targeted `rg` and `nl -ba ... | sed -n ...` reads across index, sync, MCP,
+  TUI, account routing, tests, scripts, and config.
+
+No `runs/`, `.github/`, `items/`, or prior `docs/overnight/` artifacts were
+present in this worktree. The only pre-existing file under `docs/` was
+`docs/TESTING_FOR_AGENTS.md`.
+
+## Current State
+
+The repo is ready for tightly scoped local implementation slices. The strongest
+next work is around making the index-driven inbox surface operationally reliable:
+safe validation coverage, index health visibility, MCP exposure of index-first
+reads, and write-account/preflight enforcement.
+
+The repo is not ready for unattended live-write validation. Several important
+surfaces intentionally depend on local credentials, macOS data stores, OAuth
+tokens, microphone/accessibility permissions, and personal data providers.
+
+## File-Path Observations
+
+1. `pyproject.toml` defines Python `>=3.12,<3.15`, first-class dev dependencies
+   for `pytest`, `ruff`, `pyright`, `bandit`, `hypothesis`, and `pre-commit`,
+   and pytest markers for `safe`, `integration`, `local_data`, `slow`, and
+   `live_write`. Pytest always runs coverage through
+   `addopts = "--cov=. --cov-report=term-missing"`.
+
+2. `docs/TESTING_FOR_AGENTS.md` defines the intended safe loop:
+   `INBOX_TEST_MODE=1 uv run pytest -m safe`, `uv run ruff check .`, and
+   `uv run pyright`. It also says not to run `local_data`, `live_write`, or
+   live provider-specific tests without explicit opt-in.
+
+3. `tests/conftest.py` stubs heavyweight or host-specific modules including
+   `mlx_lm`, `mlx_whisper`, `sounddevice`, `outlines`, and `Quartz`, which makes
+   deterministic unit tests practical without the full macOS/ML runtime.
+
+4. `tests/test_inbox_test_mode.py` and `tests/test_mcp_gateway.py` are the only
+   modules currently marked with `pytestmark = pytest.mark.safe`. That means the
+   documented agent-safe command does not yet exercise most deterministic index,
+   sync, server, client, or write-guard behavior.
+
+5. `inbox_test_mode.py` centralizes `INBOX_TEST_MODE`,
+   `INBOX_TEST_DATA_DIR`, and live-write blocking through
+   `assert_live_writes_allowed`. `tests/test_services.py` has deterministic
+   checks proving representative Gmail, Calendar, Reminders, Tasks, Drive,
+   Sheets, Docs, GitHub notification, desktop notification, and WhatsApp writes
+   are blocked under test mode, but that module is not in the safe marker lane.
+
+6. `message_index_store.py` has a concrete operational index schema for
+   `items`, `threads`, `sync_state`, and `sender_stats`. The `threads` table
+   includes `urgency`, `actionability`, `needs_reply`, `summary`, and
+   `open_loop`, and `list_threads` supports actionable, recent, reply-needed,
+   open-loop, sender, and priority/recent sort modes.
+
+7. `message_sync.py` implements resumable Gmail bootstrap with
+   `bootstrap_page_token`, Gmail history cursor incremental sync, timestamp
+   fallback metadata, iMessage sync, scoped thread rebuilds, and CLI modes for
+   `bootstrap`, `incremental`, `rebuild`, and `summary`.
+
+8. `tests/test_message_sync.py` already validates key implementation-readiness
+   behaviors: Gmail bootstrap resumes from saved page token, history cursors are
+   recorded, interrupted bootstrap does not double-count, iMessage checkpoints
+   advance across skipped rows, and incremental rebuild touches only changed
+   Gmail or iMessage scopes.
+
+9. `inbox_server.py` exposes index-first endpoints:
+   `/index/threads`, `/index/status`, `/index/health`,
+   `/index/views/{view_name}`, `/index/sync/bootstrap`, and
+   `/index/sync/incremental`. The `/inbox/needs-action` endpoint prefers
+   `state.index_store.list_threads` and sets `thread_read_model = "index"` and
+   `raw_thread_provider_fetch = False`.
+
+10. `tests/test_server.py` covers `/index/status`, `/index/health`, stale and
+    missing checkpoints, sync errors, index view routing, and
+    `/inbox/needs-action` behavior that does not fall back to live Gmail when
+    the index is empty.
+
+11. `inbox_client.py` has compact helpers for `index_threads`,
+    `index_status`, `index_health`, `index_view`,
+    `indexed_recent_threads`, `indexed_actionable_threads`,
+    `indexed_waiting_on_me_threads`, and `indexed_waiting_on_others_threads`.
+    `tests/test_client.py` covers the index helper request shapes.
+
+12. `tui_tabs.py` makes `Now`, `Actionable`, and `Waiting On` the first three
+    TUI tabs. `inbox.py` initializes the active filter to `all`, uses
+    `IndexedThreadItem`, fetches `recent`, `actionable`, and `waiting-on` index
+    views during refresh, and can render indexed thread summaries without raw
+    thread bodies.
+
+13. `google_account_resolution.py` centralizes Google account resolution around
+    `INBOX_DEFAULT_GOOGLE_ACCOUNT`, message/thread owner lookup, and a
+    `preflight_google_write_payload` helper for Docs, Sheets, Drive folders,
+    Tasks, and Calendar events. `tests/test_server.py` already validates default
+    account resolution and preflight result payloads.
+
+14. `inbox_server.py` exposes `/preflight/google-write`, but create/write
+    endpoints such as `/docs`, `/calendar/events`, `/drive/folder`, Sheets
+    range writes, and task creation still need an explicit pass to ensure the
+    same preflight policy is enforced before mutation rather than only being
+    available for manual inspection.
+
+15. `tools_registry.py` is a strong MCP readiness foundation: one `TOOLS` table
+    drives full and readonly MCP registration, path parameters are encoded, and
+    confirm-gated tools require `confirm=True`. However, `rg` found no indexed
+    inbox, index health, or needs-action tools in the MCP registry.
+
+16. `tests/test_api_contract.py` protects registry-to-FastAPI route drift and
+    verifies `InboxClient.index_status()` and `InboxClient.index_health()` match
+    server response shape. It does not yet assert MCP exposure for index-first
+    inbox reads because those tools do not exist.
+
+17. `mcp_server.py`, `mcp_backend.py`, `mcp_gateway.py`,
+    `inbox_mcp_readonly.py`, and `tests/test_mcp_gateway.py` show a clear
+    public/private token split: `INBOX_MCP_TOKEN` protects the public MCP layer,
+    and `INBOX_SERVER_TOKEN` protects the private local REST backend.
+
+18. `MCP_SETUP.md`, `config/inbox.env.example`,
+    `config/codex.inbox.example.toml`, and
+    `config/gemini-settings.inbox.example.json` document the backend URL/token
+    split and dev-vs-primary routing, including the warning not to reuse the
+    public MCP token as the private server token.
+
+19. `scripts/run_inbox_backend.sh` and
+    `scripts/run_inbox_mcp_http_readonly.sh` set `UV_CACHE_DIR=/tmp/uv-cache`
+    before launching backend/MCP processes. `dev.sh` defaults dev worktrees to
+    port `9850`, separate from the primary `9849` instance.
+
+20. `.gitignore` excludes credentials, OAuth tokens, local env files, logs,
+    `.claude/`, `.inbox_memory.sqlite3`, `.inbox_scheduler.sqlite3`,
+    `.inbox_index.sqlite3`, coverage output, batch state, and batch logs.
+
+## Risks And Blockers
+
+- The documented safe validation lane is too narrow. Because only two test
+  modules are marked `safe`, the default command can pass while index/sync/server
+  behavior is untested.
+
+- The index can be stale, missing, or in error, but `inbox.py` does not currently
+  appear to consume `InboxClient.index_health()`. A stale empty index could look
+  like an empty Now/Actionable/Waiting surface instead of an operational problem.
+
+- MCP users cannot yet ask for index-first views through the registry, even
+  though the FastAPI server and client have index endpoints. That can push agents
+  back toward raw provider reads.
+
+- Write preflight exists as an endpoint and helper, but implementation work is
+  still needed to make preflight policy part of the write path for each Google
+  mutation family.
+
+- Live provider validation needs credentials and explicit approval. This review
+  did not run live Gmail, Calendar, Drive, Docs, Sheets, Tasks, iMessage,
+  Reminders, Notes, GitHub, audio, dictation, notification, or MCP public
+  exposure flows.
+
+- No repo-local `.github/` workflow files were present, so CI behavior could not
+  be inspected from this worktree.
+
+- No prior `runs/*/result.json` or `runs/*/handoff.md` artifacts were present in
+  this repo checkout, so this pass could not reconcile earlier runner outputs.
+
+## Validation Commands
+
+Required queue validation:
+
+```bash
+git status --short
+```
+
+Agent-safe repo validation documented by the project:
+
+```bash
+INBOX_TEST_MODE=1 uv run pytest -m safe
+uv run ruff check .
+uv run pyright
+```
+
+Focused validations recommended for the follow-up slices below:
+
+```bash
+INBOX_TEST_MODE=1 uv run pytest tests/test_message_sync.py tests/test_message_index_store.py tests/test_server.py tests/test_client.py tests/test_api_contract.py -q
+INBOX_TEST_MODE=1 uv run pytest tests/test_inbox_app.py tests/test_tui_tabs.py tests/test_client.py -q
+INBOX_TEST_MODE=1 uv run pytest tests/test_api_contract.py tests/test_mcp_gateway.py -q
+INBOX_TEST_MODE=1 uv run pytest tests/test_server.py -k "preflight or create_doc or create_spreadsheet or create_drive_folder or create_event or create_task" -q
+bash -n batch/batch-runner.sh
+```
+
+## Implementation-Ready Follow-Up Tasks
+
+### 1. Promote deterministic index and write-guard tests into the safe lane
+
+Owned files:
+- `tests/test_message_sync.py`
+- `tests/test_message_index_store.py`
+- `tests/test_server.py`
+- `tests/test_client.py`
+- `tests/test_api_contract.py`
+- `tests/test_services.py`
+- `docs/TESTING_FOR_AGENTS.md`
+
+Acceptance criteria:
+- Deterministic tests for index status/health, index view routing, sync resume,
+  scoped rebuild, client index helpers, API contract, and test-mode write guards
+  are marked `safe`.
+- No tests requiring real local data or provider writes are marked `safe`.
+- `docs/TESTING_FOR_AGENTS.md` names a focused safe command for index/sync work.
+
+Smallest useful validation:
+
+```bash
+INBOX_TEST_MODE=1 uv run pytest -m safe -q
+```
+
+### 2. Surface index health in the TUI Now, Actionable, and Waiting On views
+
+Owned files:
+- `inbox.py`
+- `inbox_client.py` if a small helper or response normalization is needed
+- `tests/test_inbox_app.py`
+- `tests/test_client.py`
+
+Acceptance criteria:
+- Refresh fetches `/index/health` once and stores the health payload.
+- Now, Actionable, and Waiting On empty or stale states distinguish "no indexed
+  work" from `no_sync_state`, `missing_checkpoint`, `stale_checkpoint`, and
+  `sync_error`.
+- Existing indexed thread rendering still works when the health response is
+  healthy.
+- No raw provider thread fetch is added to these index-first views.
+
+Smallest useful validation:
+
+```bash
+INBOX_TEST_MODE=1 uv run pytest tests/test_inbox_app.py tests/test_client.py -q
+```
+
+### 3. Expose index-first inbox reads through the MCP tool registry
+
+Owned files:
+- `tools_registry.py`
+- `tests/test_api_contract.py`
+- `tests/test_mcp_gateway.py`
+- `MCP_V1_PLAN.md` or `MCP_SETUP.md` if docs need the new tool names
+
+Acceptance criteria:
+- Add readonly registry tools for index status, index health, a selected index
+  view, and needs-action rollup.
+- Full and readonly MCP servers both register these readonly tools.
+- Route-contract tests prove every new tool maps to an existing FastAPI route.
+- Returned thread payloads stay compact and do not expose `body_text`.
+
+Smallest useful validation:
+
+```bash
+INBOX_TEST_MODE=1 uv run pytest tests/test_api_contract.py tests/test_mcp_gateway.py -q
+```
+
+### 4. Enforce Google write preflight policy on initial mutation paths
+
+Owned files:
+- `google_account_resolution.py`
+- `inbox_server.py`
+- `tests/test_server.py`
+
+Acceptance criteria:
+- Docs, Sheets, Drive folder, Google Task, and Calendar create paths resolve the
+  same account and destination that `/preflight/google-write` would report.
+- Invalid folder, task list, or missing-account preflight failures return a
+  client error before calling provider write functions.
+- Explicit `account` overrides continue to work when the account exists.
+- Tests use mocks only and do not require live Google credentials.
+
+Smallest useful validation:
+
+```bash
+INBOX_TEST_MODE=1 uv run pytest tests/test_server.py -k "preflight or create_doc or create_spreadsheet or create_drive_folder or create_event or create_task" -q
+```
+
+### 5. Add deterministic safety tests for the batch archive runner
+
+Owned files:
+- `batch/batch-runner.sh`
+- `tests/test_batch_runner.py`
+- `batch/archive-input.tsv` only if a tiny fixture input is needed
+
+Acceptance criteria:
+- `bash -n batch/batch-runner.sh` passes.
+- A new deterministic test runs `--dry-run` against a temp-copied batch
+  directory and proves no curl/write call is executed.
+- Thread IDs and JSON payload construction are shell-safe for ordinary Gmail
+  IDs and fail closed for unsupported sources.
+- The runner keeps `archive-state.tsv` and `batch/logs/` out of git, consistent
+  with `.gitignore`.
+
+Smallest useful validation:
+
+```bash
+bash -n batch/batch-runner.sh
+INBOX_TEST_MODE=1 uv run pytest tests/test_batch_runner.py -q
+```
+
+## Handoff Notes
+
+- Product code was not edited.
+- No external services were called.
+- No PR was created.
+- No tracker state was changed.
+- The required validation for this queue item is `git status --short`.

--- a/docs/overnight/2026-05-07-whole-portfolio-review/inbox-sym-115-risk-and-validation-review.md
+++ b/docs/overnight/2026-05-07-whole-portfolio-review/inbox-sym-115-risk-and-validation-review.md
@@ -1,0 +1,185 @@
+# inbox-sym-115 risk and validation review
+
+Queue item: `inbox-sym-115-risk-and-validation-review`
+Branch: `codex/goal-inbox-sym-115-risk-and-validation-review`
+Review date: 2026-05-07
+Starting HEAD: `2805b8400519da188ca7d3f6e39b19a8ca42b05a`
+
+## Scope and validation
+
+This was a repo-local, read-only risk and validation review. Product code was not edited. External services, deploys, pushes, PRs, and tracker updates were not used.
+
+Required validation command:
+
+```bash
+git status --short
+```
+
+Agent-safe validation commands documented by the repo:
+
+```bash
+INBOX_TEST_MODE=1 uv run pytest -m safe
+uv run ruff check .
+uv run pyright
+```
+
+Prior overnight and CI artifacts checked:
+
+```bash
+rg --files -g '.github/**' -g 'docs/overnight/**' -g 'runs/**' -g 'items/**' -g '*handoff*' -g '*result.json'
+rg --files docs runs .github items
+```
+
+Result: no previous `docs/overnight`, `runs`, `items`, or `.github` artifacts were present in this worktree. The second command reported missing `runs`, `.github`, and `items` directories and only found `docs/TESTING_FOR_AGENTS.md`.
+
+## Concrete observations
+
+1. `README.md:31-34` says Python 3.10+ is required, but `pyproject.toml:5` requires `>=3.12,<3.15`. This can send agents or setup scripts down the wrong interpreter path.
+
+2. `pyproject.toml:53-61` configures pytest with coverage and registers `safe`, `integration`, `local_data`, `slow`, and `live_write` markers, while `docs/TESTING_FOR_AGENTS.md:9-13` tells agents to run `INBOX_TEST_MODE=1 uv run pytest -m safe`, ruff, and pyright.
+
+3. Only `tests/test_mcp_gateway.py:18` and `tests/test_inbox_test_mode.py:8` are marked `pytest.mark.safe`, while `rg --files tests | wc -l` reports 31 test files. Many deterministic mocked tests are outside the documented safe loop.
+
+4. `tests/conftest.py` stubs heavy ML and hardware modules such as `mlx_lm`, `mlx_whisper`, `sounddevice`, `Quartz`, and `outlines`, making broader local tests viable without real devices or ML installs.
+
+5. `inbox_test_mode.py:22-24` blocks live writes when `INBOX_TEST_MODE` is enabled, and `services.py:114-119` centralizes the service-level hook. Write guards are present across many service functions, including Google Tasks at `services.py:3172-3221`.
+
+6. `tests/test_services.py:934-950` verifies `INBOX_TEST_MODE` blocks extended live writes for Google Tasks, Drive, Sheets, Docs, GitHub notifications, desktop notifications, and WhatsApp. That coverage is useful but is not in the current `-m safe` loop.
+
+7. `inbox_server.py:1313-1340` implements optional private API token auth. If `INBOX_SERVER_TOKEN` is unset, `_is_authorized` returns true for all paths, including write endpoints. Many endpoint fixtures explicitly clear the token, for example `tests/test_server.py:52-55` and `tests/test_gmail_actions.py:18-21`.
+
+8. `.mcp.json:10-24` points both full and read-only local MCP entries at `http://127.0.0.1:9849`. `CLAUDE.md:73-76` and `MCP_SETUP.md:94-103` warn that dev worktrees must verify both `cwd` and `INBOX_SERVER_URL` or they can silently hit the primary instance.
+
+9. `mcp_backend.py:19-27` correctly forwards `INBOX_SERVER_TOKEN` to the private backend when it is configured, and `mcp_gateway.py:36-58` protects public MCP routes with `INBOX_MCP_TOKEN` while leaving `/health` open.
+
+10. `tools_registry.py:52-101` adds `confirm=True` gating at the MCP handler layer before dispatching to the backend. This protects MCP calls, but direct FastAPI clients can still call write endpoints with only API auth.
+
+11. `tools_registry.py:415-480` exposes Google Task create/update/delete as confirmation-gated MCP tools, and `inbox_server.py:2028-2055` exposes the corresponding HTTP write endpoints. There is no visible server-side preflight requirement on these direct endpoints.
+
+12. `inbox_server.py:2906-3020` provides a `GET /preflight/google-write` endpoint, and `tests/test_server.py:1521-1612` covers default account resolution plus valid/invalid folder and task-list destinations. The preflight layer exists, but write endpoints do not appear to require a recent preflight result.
+
+13. `message_index_store.py:80-120` creates the local index with WAL mode, `sync_state`, and unique `(source, account, external_id)` items. `message_sync.py:181-269` records Gmail bootstrap progress, page tokens, errors, and final history/timestamp checkpoints.
+
+14. `tests/test_message_sync.py:143-232` covers resumable Gmail bootstrap and history cursor recording. `tests/test_message_index_store.py:269-298` covers sync-state status and metadata persistence. These are high-value risk tests but are currently unmarked for the safe loop.
+
+15. `inbox_server.py:3739-3853` has index-first needs-action and index sync/status endpoints. `tests/test_server.py:1816-1935` asserts `/inbox/needs-action` does not fall back to live Gmail when the index is empty, but task and calendar failures are swallowed at `inbox_server.py:3773-3793`, making operational failures easy to miss.
+
+16. `DOCS_INDEX.md` states `uv run pytest` has "736 pass" and "All 736 tests pass", but the review did not find a current CI artifact or prior overnight report proving that claim in this checkout.
+
+## Primary risks and blockers
+
+1. The documented safe validation loop is too narrow. It currently exercises only two safe-marked test files, leaving mocked server, service, sync, and index tests outside the command agents are told to run.
+
+2. Token/auth behavior is under-specified for test and deployment. The private API intentionally becomes open when `INBOX_SERVER_TOKEN` is unset, but write endpoints are large in number and endpoint fixtures often clear the token. That is acceptable for local development only if deployment scripts and tests make the boundary explicit.
+
+3. Write safety is split across MCP confirmation, optional API auth, service-level test-mode guards, and an advisory preflight endpoint. There is no single server-side contract proving that direct HTTP writes are preflighted or mapped to clear blocked-write errors under `INBOX_TEST_MODE`.
+
+4. Dev worktree routing can hit the primary inbox. The docs call this out, but `.mcp.json` hardcodes port 9849 and there is no automated check that the MCP backend URL matches the active worktree intent.
+
+5. Documentation has stale or conflicting claims: Python 3.10+ vs `pyproject.toml` requiring 3.12+, a test-count pass claim without current local evidence, and an older MCP v1 plan that no longer matches the broader registry write surface.
+
+6. CI evidence is missing in this worktree. No `.github` workflow or prior `runs/*/result.json` / `handoff.md` files were available locally, so the next work wave should not assume remote validation exists.
+
+No stop condition was hit. The main blocker is evidence quality: before launching broad implementation work, make the agent-safe validation lane representative enough to catch regressions.
+
+## Implementation-ready follow-up tasks
+
+### 1. Expand the safe test marker set
+
+Owned files:
+- `tests/test_server.py`
+- `tests/test_server_endpoints.py`
+- `tests/test_services.py`
+- `tests/test_message_sync.py`
+- `tests/test_message_index_store.py`
+- `tests/test_api_contract.py`
+- `tests/test_conversations_latency.py`
+- `pyproject.toml` only if marker descriptions need tightening
+
+Acceptance criteria:
+- Deterministic, mocked tests that do not touch live local data or external writes are marked `safe`.
+- Tests requiring local macOS data, live provider data, or externally visible writes are explicitly marked `local_data`, `integration`, or `live_write`.
+- `INBOX_TEST_MODE=1 uv run pytest -m safe --collect-only -q` includes server, service write-guard, sync, index, and API contract tests, not only MCP/test-mode tests.
+
+Smallest useful validation:
+
+```bash
+INBOX_TEST_MODE=1 uv run pytest -m safe --collect-only -q
+INBOX_TEST_MODE=1 uv run pytest -m safe tests/test_inbox_test_mode.py tests/test_mcp_gateway.py tests/test_api_contract.py -q
+```
+
+### 2. Add private API auth contract tests
+
+Owned files:
+- `tests/test_server_auth.py` or `tests/test_server.py`
+- `inbox_server.py` only if behavior needs correction
+
+Acceptance criteria:
+- With `INBOX_SERVER_TOKEN` set, missing and invalid credentials return 401 for at least one read endpoint and one write endpoint.
+- Valid `Authorization: Bearer ...` and `x-api-key` both work.
+- The test documents whether `/health` should require the private token when auth is enabled, then locks that behavior.
+
+Smallest useful validation:
+
+```bash
+INBOX_TEST_MODE=1 uv run pytest tests/test_server_auth.py -q
+```
+
+### 3. Make direct HTTP write blocking explicit under test mode
+
+Owned files:
+- `tests/test_server_write_guards.py` or `tests/test_server.py`
+- `inbox_server.py`
+- `services.py` only if a missing guard is found
+
+Acceptance criteria:
+- Representative direct HTTP writes for Gmail, Reminders, Google Tasks, Drive, Docs, Sheets, GitHub notification read, and desktop notification are covered with `INBOX_TEST_MODE=1`.
+- A blocked write returns a clear 4xx response instead of an unstructured 500.
+- The tests use fake services that would fail if the service-level guard did not run.
+
+Smallest useful validation:
+
+```bash
+INBOX_TEST_MODE=1 uv run pytest tests/test_server_write_guards.py -q
+```
+
+### 4. Reconcile stale docs and validation claims
+
+Owned files:
+- `README.md`
+- `DOCS_INDEX.md`
+- `MCP_V1_PLAN.md`
+- `docs/TESTING_FOR_AGENTS.md`
+
+Acceptance criteria:
+- README Python requirement matches `pyproject.toml`.
+- Unverified fixed test-count claims are removed or replaced with the exact command used to generate them.
+- MCP docs distinguish current registry behavior from historical v1 scope.
+- Agent testing docs explain that `-m safe` is the default deterministic lane and that live provider tests require opt-in.
+
+Smallest useful validation:
+
+```bash
+rg "Python 3.10|736 pass|All 736 tests pass|deletes stay out of scope" README.md DOCS_INDEX.md MCP_V1_PLAN.md docs/TESTING_FOR_AGENTS.md
+git diff --check
+```
+
+### 5. Add a worktree routing self-check for MCP/dev use
+
+Owned files:
+- `mcp_backend.py`
+- `mcp_gateway.py`
+- `MCP_SETUP.md`
+- `.mcp.json` or `config/codex.inbox.example.toml` if examples are updated
+- `tests/test_mcp_gateway.py`
+
+Acceptance criteria:
+- A local health or diagnostic path reports the effective backend URL and whether backend auth is enabled without exposing tokens.
+- Tests cover `INBOX_SERVER_URL` override behavior so worktree clients can prove they are not hitting primary port 9849 by accident.
+- Docs tell agents to run the self-check before exercising a dev worktree.
+
+Smallest useful validation:
+
+```bash
+INBOX_TEST_MODE=1 uv run pytest tests/test_mcp_gateway.py -q
+```

--- a/docs/overnight/2026-05-07-whole-portfolio-review/inbox-sym-116-implementation-readiness.md
+++ b/docs/overnight/2026-05-07-whole-portfolio-review/inbox-sym-116-implementation-readiness.md
@@ -1,0 +1,151 @@
+# inbox-sym-116 Implementation Readiness Review
+
+Date: 2026-05-07
+Branch: `codex/goal-inbox-sym-116-implementation-readiness`
+Starting HEAD: `2805b8400519da188ca7d3f6e39b19a8ca42b05a`
+Scope: read-only review plus this report only.
+
+## Summary
+
+`inbox-sym-116` is implementation-ready for small vertical slices around the indexed inbox, MCP/tool surfacing, account-routing policy, and validation hygiene. The highest-leverage next work is not a broad rewrite: it is wiring already-built index and policy primitives into the surfaces agents actually use, then tightening the safe validation lane so future workers can prove changes without touching live personal data.
+
+No repo-local `docs/overnight/` report, `runs/*/result.json`, or `runs/*/handoff.md` was present before this pass. No `.github` workflow directory was present in this worktree, so local validation commands are the only repo-local validation evidence available.
+
+## Concrete Observations
+
+1. [PLAN.md](../../../PLAN.md) defines the product direction as an operational indexed inbox, with raw providers relegated to drill-down, and names `message_sync.py`, `message_index_store.py`, `inbox_server.py`, and tests as Milestone 1 ownership.
+2. [message_index_store.py](../../../message_index_store.py) already has persistent `sync_state`, `items`, `threads`, and `sender_stats` tables, including `status`, `last_run_started_at`, `metadata_json`, and `last_error` fields for sync observability.
+3. [message_sync.py](../../../message_sync.py) already supports resumable Gmail bootstrap via `bootstrap_page_token`, records Gmail `historyId` cursors, falls back to timestamp cursors, and has scoped thread rebuild paths for changed accounts/sources.
+4. [inbox_server.py](../../../inbox_server.py) exposes index-first endpoints: `/index/threads`, `/index/status`, `/index/health`, `/index/views/{view_name}`, `/index/sync/bootstrap`, and `/index/sync/incremental`.
+5. [tests/test_message_sync.py](../../../tests/test_message_sync.py) covers bootstrap resume after interruption, duplicate avoidance on resume, Gmail history incremental sync, timestamp fallback, skipped iMessage checkpoint advancement, and scoped incremental thread rebuilds.
+6. [tests/test_server.py](../../../tests/test_server.py) covers index endpoint response shape, health reasons (`no_sync_state`, `missing_checkpoint`, `stale_checkpoint`, `sync_error`), and the current contract that `/inbox/needs-action` does not fall back to live Gmail when the index is empty.
+7. [inbox_client.py](../../../inbox_client.py) has client helpers for index status, health, and named indexed views, and [inbox.py](../../../inbox.py) already fetches `recent`, `actionable`, and `waiting-on` views for the TUI auxiliary data path.
+8. [tools_registry.py](../../../tools_registry.py) drives full and read-only MCP tool registration from one table and tests enforce confirm-gating, but the registry does not currently expose the index health/status/view endpoints or `/preflight/google-write`.
+9. [google_account_resolution.py](../../../google_account_resolution.py) centralizes Google account resolution and honors `INBOX_DEFAULT_GOOGLE_ACCOUNT`, but most returned API models still expose `account` rather than the roadmap's explicit `owning_account` field.
+10. [CONNECTOR_ROADMAP.md](../../../CONNECTOR_ROADMAP.md) says Google writes should default to `jshah1331@gmail.com` via `INBOX_DEFAULT_GOOGLE_ACCOUNT`, replies should route to object ownership, and the model should prefer intent-level tools over raw provider payloads.
+11. [docs/TESTING_FOR_AGENTS.md](../../TESTING_FOR_AGENTS.md) declares the default safe loop as `INBOX_TEST_MODE=1 uv run pytest -m safe`, `uv run ruff check .`, and `uv run pyright`; [pyproject.toml](../../../pyproject.toml) registers `safe`, `integration`, `local_data`, `slow`, and `live_write` markers.
+12. Only two test modules are currently marked safe: [tests/test_inbox_test_mode.py](../../../tests/test_inbox_test_mode.py) and [tests/test_mcp_gateway.py](../../../tests/test_mcp_gateway.py), while the repo has 31 test files. The documented safe lane is therefore too narrow for implementation handoffs.
+13. [DOCS_INDEX.md](../../../DOCS_INDEX.md) still claims `uv run pytest` is "Tests (736 pass)" and "All 736 tests pass"; this review did not run the full suite, so future work should treat that as stale until revalidated.
+14. [README.md](../../../README.md) says Python 3.10+ is required, while [pyproject.toml](../../../pyproject.toml) requires `>=3.12,<3.15`.
+15. [.mcp.json](../../../.mcp.json) and [.cursor/mcp.json](../../../.cursor/mcp.json) point assistants at `http://127.0.0.1:9849`; [MCP_SETUP.md](../../../MCP_SETUP.md) and [CLAUDE.md](../../../CLAUDE.md) correctly warn that dev worktrees must use a distinct `cwd` and `INBOX_SERVER_URL` to avoid silently exercising the primary instance.
+16. [batch/batch-runner.sh](../../../batch/batch-runner.sh) removes the `INBOX` label for Gmail archive operations, while [modes/batch-archive.md](../../../modes/batch-archive.md) documents adding an `ARCHIVED` label and refers to `thread_id` as the batch modify ID. This is likely to confuse the next automation slice.
+
+## Risks And Blockers
+
+- Live personal data and writes are a standing risk. Any implementation work should run with `INBOX_TEST_MODE=1` and avoid `local_data` or `live_write` tests unless explicitly approved.
+- CI evidence is absent in this worktree because no `.github` workflows are present. Workers should report local validation commands exactly.
+- The safe marker lane is underdeveloped relative to the documented agent workflow, so `pytest -m safe` can pass while leaving index, server, and MCP registry behavior untested.
+- The index-first backend exists, but agent-facing MCP tools and slash-mode docs still emphasize raw provider endpoints. That increases the chance that future agents bypass the operational index.
+- Primary/dev routing remains easy to misconfigure because repo-local MCP configs default to port 9849. Worktree testing needs explicit `INBOX_SERVER_URL=http://127.0.0.1:9850` or higher.
+- Some documentation is stale against package metadata and validation reality, notably the Python version and "736 pass" claims.
+
+## Validation Commands
+
+Queue-item validation run:
+
+```bash
+git status --short
+```
+
+Useful implementation validation commands for future slices:
+
+```bash
+INBOX_TEST_MODE=1 uv run pytest -m safe -q
+INBOX_TEST_MODE=1 uv run pytest tests/test_message_sync.py tests/test_message_index_store.py -q
+INBOX_TEST_MODE=1 uv run pytest tests/test_server.py tests/test_client.py tests/test_api_contract.py -q
+INBOX_TEST_MODE=1 uv run pytest tests/test_tools_registry.py tests/test_mcp_gateway.py -q
+uv run ruff check .
+uv run pyright
+bash -n batch/batch-runner.sh
+```
+
+Do not run live provider, local data, or live-write tests without explicit approval.
+
+## Implementation-Ready Follow-Up Tasks
+
+### 1. Expose Indexed Inbox Views Through MCP
+
+Owned files: [tools_registry.py](../../../tools_registry.py), [mcp_backend.py](../../../mcp_backend.py), [tests/test_tools_registry.py](../../../tests/test_tools_registry.py), [tests/test_api_contract.py](../../../tests/test_api_contract.py).
+
+Acceptance criteria:
+- Read-only MCP includes tools for `index_status`, `index_health`, and named `index_view`.
+- Full MCP includes the same read-only index tools.
+- Route contract tests prove every new MCP tool maps to an existing FastAPI endpoint.
+- Returned payloads preserve `read_model: "index"` and `raw_provider_fetch: false`.
+
+Smallest useful validation:
+
+```bash
+INBOX_TEST_MODE=1 uv run pytest tests/test_tools_registry.py tests/test_api_contract.py -q
+```
+
+### 2. Make The Safe Test Lane Cover Core Agent Work
+
+Owned files: [tests/test_message_sync.py](../../../tests/test_message_sync.py), [tests/test_message_index_store.py](../../../tests/test_message_index_store.py), [tests/test_server.py](../../../tests/test_server.py), [tests/test_client.py](../../../tests/test_client.py), [tests/test_tools_registry.py](../../../tests/test_tools_registry.py), [docs/TESTING_FOR_AGENTS.md](../../TESTING_FOR_AGENTS.md).
+
+Acceptance criteria:
+- Deterministic index, server-contract, client, and MCP-registry tests are marked `safe`.
+- Tests that can touch user data or live writes remain unmarked or explicitly marked `local_data` / `live_write`.
+- `docs/TESTING_FOR_AGENTS.md` states what the safe lane covers and what it deliberately excludes.
+
+Smallest useful validation:
+
+```bash
+INBOX_TEST_MODE=1 uv run pytest -m safe -q
+```
+
+### 3. Surface Index Health In The TUI And Client Workflow
+
+Owned files: [inbox_client.py](../../../inbox_client.py), [inbox.py](../../../inbox.py), [tests/test_client.py](../../../tests/test_client.py), [tests/test_inbox_app.py](../../../tests/test_inbox_app.py), [tests/test_server.py](../../../tests/test_server.py).
+
+Acceptance criteria:
+- Refresh/poll paths fetch `/index/health` alongside indexed views.
+- The TUI status bar distinguishes empty healthy views from stale/error/no-sync index states.
+- Tests cover fresh, stale, error, and no-sync health payloads without live provider access.
+
+Smallest useful validation:
+
+```bash
+INBOX_TEST_MODE=1 uv run pytest tests/test_client.py tests/test_inbox_app.py tests/test_server.py -q
+```
+
+### 4. Add Account Ownership Contract Tests For Google Writes
+
+Owned files: [google_account_resolution.py](../../../google_account_resolution.py), [inbox_server.py](../../../inbox_server.py), [service_models.py](../../../service_models.py), [tests/test_gmail_actions.py](../../../tests/test_gmail_actions.py), [tests/test_server_endpoints.py](../../../tests/test_server_endpoints.py).
+
+Acceptance criteria:
+- Tests prove `INBOX_DEFAULT_GOOGLE_ACCOUNT` is honored for Docs, Sheets, Drive folders, Tasks, Calendar events, and Gmail compose when no explicit account is supplied.
+- Gmail reply tests continue proving message/thread owner routing wins over the default when ownership can be resolved.
+- Returned Google objects expose an explicit ownership field, either by standardizing on `owning_account` or by documenting and testing `account` as the stable ownership field.
+
+Smallest useful validation:
+
+```bash
+INBOX_TEST_MODE=1 uv run pytest tests/test_gmail_actions.py tests/test_server_endpoints.py -q
+```
+
+### 5. Align Batch Archive Workflow With Actual Gmail Semantics
+
+Owned files: [batch/batch-runner.sh](../../../batch/batch-runner.sh), [modes/batch-archive.md](../../../modes/batch-archive.md), [tests/test_tools_registry.py](../../../tests/test_tools_registry.py) if MCP/tool semantics change.
+
+Acceptance criteria:
+- The mode doc and shell runner agree on whether inputs are Gmail message IDs or thread IDs.
+- The archive payload matches the real server contract and no longer documents a nonexistent `ARCHIVED` label requirement.
+- Dry-run behavior remains non-mutating and reports exactly what would be archived.
+- Any required ID resolution is implemented before mutating Gmail labels.
+
+Smallest useful validation:
+
+```bash
+bash -n batch/batch-runner.sh
+INBOX_TEST_MODE=1 uv run pytest tests/test_tools_registry.py -q
+```
+
+## Handoff Notes
+
+- Product code was not edited.
+- This report is the only intended file change.
+- External services, pushes, PR creation, tracker updates, and live provider checks were not performed.
+- Required validation command `git status --short` ran successfully; output showed `?? docs/overnight/` because this new report is uncommitted.
+- Local commit was attempted but blocked by sandbox permissions: Git tried to create `/Users/jwalinshah/projects/inbox/.git/worktrees/inbox-sym-116-implementation-readiness/index.lock`, which is outside the writable roots.
+- No PR was created.

--- a/docs/overnight/2026-05-07-whole-portfolio-review/inbox-sym-116-risk-and-validation-review.md
+++ b/docs/overnight/2026-05-07-whole-portfolio-review/inbox-sym-116-risk-and-validation-review.md
@@ -1,0 +1,231 @@
+# inbox-sym-116 Risk And Validation Review
+
+Queue item: `inbox-sym-116-risk-and-validation-review`
+Branch: `codex/goal-inbox-sym-116-risk-and-validation-review`
+Baseline HEAD inspected: `2805b8400519da188ca7d3f6e39b19a8ca42b05a`
+Review date: 2026-05-07
+
+## Scope
+
+This was a read-only risk and validation pass. I did not edit product code, call external services, deploy, push, create PRs, or update trackers. The only intended write is this report.
+
+Evidence inspected:
+
+- Repository structure via `llm-tldr tree .`
+- Current git state via `git status --short`, `git log --oneline -10`, and recent merge stats
+- Project docs: `README.md`, `CLAUDE.md`, `DOCS_INDEX.md`, `PLAN.md`, `CONNECTOR_ROADMAP.md`, `MCP_SETUP.md`, `docs/TESTING_FOR_AGENTS.md`
+- Package and validation config: `pyproject.toml`, `.pre-commit-config.yaml`, `.factory/services.yaml`
+- Runtime/config/deploy surfaces: `dev.sh`, `scripts/*.sh`, `config/*.example.*`, `deploy/*.example`, `.cursor/mcp.json`
+- Test and safety surfaces: `tests/`, `inbox_test_mode.py`, `tools_registry.py`, `mcp_gateway.py`, `inbox_server.py`, `google_account_resolution.py`
+- Prior generated validation evidence under `.factory/validation/**`
+
+Not present in this worktree:
+
+- No tracked `.github/` workflows.
+- No repo-local `runs/` directory with `result.json` or `handoff.md`.
+- No prior `docs/overnight/` reports.
+
+## Executive Summary
+
+The repo has stronger-than-average local guardrails for a personal-data application: token auth exists for the HTTP backend, MCP write tools are confirmation-gated, test mode blocks many live writes, and recent index/sync work has focused tests. The main risk is not absence of tests; it is validation drift. Different repo surfaces disagree about Python version, test counts, safe test scope, and whether the default test command is the full suite.
+
+The next executable work should make validation boring and unambiguous before expanding product behavior: align safe/full test commands, add CI or an equivalent local gate, expose the preflight write checker through the curated MCP surface, and add missing regression coverage around ambient note persistence and worktree-safe factory setup.
+
+## Concrete Observations
+
+1. `pyproject.toml` requires Python `>=3.12,<3.15`, while `README.md` still says Python 3.10+ is required. This can send new agents or CI jobs onto an unsupported interpreter.
+
+2. `docs/TESTING_FOR_AGENTS.md` makes `INBOX_TEST_MODE=1 uv run pytest -m safe` the default safe command, but `rg` found `pytest.mark.safe` only in `tests/test_inbox_test_mode.py` and `tests/test_mcp_gateway.py`. Most deterministic tests are unmarked and would be deselected by that command.
+
+3. `pyproject.toml` sets default pytest addopts to `--cov=. --cov-report=term-missing`, but there is no coverage threshold. The command reports coverage but does not prevent coverage erosion.
+
+4. `.factory/services.yaml` defines `test: uv run pytest --ignore=tests/test_audio.py --ignore=tests/test_llm.py -x -q`. Prior validation in `.factory/validation/fix-broken-state/user-testing/flows/cli-checks.json` says the restored full suite was `uv run pytest -x -q`, including `tests/test_audio.py` and `tests/test_llm.py`.
+
+5. `DOCS_INDEX.md` claims "Tests (736 pass)" and "All 736 tests pass", but the prior generated CLI validation reports `254 passed`. That stale claim is a high-confidence documentation drift issue.
+
+6. `.pre-commit-config.yaml` runs Ruff, formatting, YAML/large-file/private-key hooks, and Bandit. It does not run `pyright` or `pytest`, and there is no tracked `.github/workflows` CI fallback.
+
+7. `inbox_test_mode.py` centralizes live-write blocking with `assert_live_writes_allowed`, and `services.py` calls `_assert_live_write_allowed` across high-risk mutations including Gmail, Calendar, Reminders, Tasks, Drive, Sheets, Docs, GitHub notification writes, desktop notifications, and attendee modification.
+
+8. `tests/test_services.py` includes representative and extended test-mode blocking coverage, and `tests/test_inbox_test_mode.py` verifies marker registration and testing docs. This is good evidence, but because most service tests are not marked `safe`, the default safe command does not exercise much of that coverage.
+
+9. `inbox_server.py` protects the raw FastAPI backend with `INBOX_SERVER_TOKEN`, and `tests/test_server.py::TestAuth` covers unauthenticated 401 plus Bearer and `X-API-Key` success. `inbox_client.py` and `mcp_backend.py` both forward Bearer auth from the same env var.
+
+10. `tools_registry.py` drives the curated MCP surface and marks every mutating tool as `confirm=True`; `tests/test_tools_registry.py` asserts all non-readonly tools require confirmation and that readonly registration excludes write tools.
+
+11. `inbox_server.py` exposes `/preflight/google-write`, and `google_account_resolution.py` validates default account, Drive folder, Tasks list, and calendar destination. `tests/test_server.py` covers these cases. However, `tools_registry.py` does not expose a `preflight_google_write` MCP tool, even though `CONNECTOR_ROADMAP.md` names it as a target intent-level tool.
+
+12. Recent sync/index work is well covered: `tests/test_message_sync.py` covers resumable Gmail bootstrap, history-cursor incremental sync, timestamp fallback, skipped iMessage row checkpoints, and scoped thread rebuilds; `tests/test_server.py` covers `/index/health`, stale checkpoints, sync errors, and compact indexed views.
+
+13. `message_index_store.py`, `message_sync.py`, and `thread_classifier.py` now form the operational index path described in `PLAN.md`. This is implementation-ready, but the classifier remains heuristic and the plan explicitly calls classification noise a main phase risk.
+
+14. `services.py` is 6,467 lines, `inbox.py` is 4,279 lines, and `inbox_server.py` is 3,940 lines. The test suite is broad, but these large shared modules increase change risk because small edits often cross personal-data, UI, auth, and provider boundaries.
+
+15. `.factory/init.sh` has a bash shebang but file mode `-rw-r--r--`, matching prior generated warnings that direct execution fails with permission denied. It also `cd`s to `/Users/jwalinshah/projects/inbox` and kills port `9849`, which conflicts with the worktree isolation rules documented in `CLAUDE.md` and `MCP_SETUP.md`.
+
+16. `inbox_server.py` now initializes `AmbientService` with `on_note=lambda raw, summary: ambient_notes.save_note(raw, summary)`, and `tests/test_ambient_notes.py` covers note writing. The server endpoint test fixtures in `tests/test_voice_pipeline.py` replace the server ambient service with a no-op callback, so there is no server-level regression test proving default ambient capture persists notes.
+
+## Risks And Blockers
+
+- Validation drift: agent docs, factory automation, docs index, and prior generated outputs do not agree on the authoritative validation command or expected test count.
+- CI gap: there is no tracked GitHub Actions workflow or equivalent repo-local automated gate. Validation currently depends on local/manual convention.
+- Safe-test gap: the documented agent-safe command currently covers only a small marked subset, which can create false confidence for personal-data write guardrails.
+- MCP preflight gap: write preflight exists as an HTTP endpoint but is not available through the curated MCP tool registry, so agents may still need prompt-level routing decisions.
+- Worktree safety gap: `.factory/init.sh` is not executable and hard-codes the primary checkout and port, which can disrupt the daily-driver inbox if reused from a worktree.
+- Ambient persistence gap: the prior ambient no-op regression appears fixed, but there is no endpoint/runtime-level test tying `ServerState` default ambient callback to `ambient_notes.save_note`.
+- External/live validation is intentionally blocked for this queue item. No Gmail, Calendar, Drive, Docs, Reminders, GitHub, notification, audio, deployment, or MCP network exercise was run.
+
+## Exact Validation Commands
+
+Required queue validation:
+
+```bash
+git status --short
+```
+
+Repo-documented safe loop:
+
+```bash
+INBOX_TEST_MODE=1 uv run pytest -m safe
+uv run ruff check .
+uv run pyright
+```
+
+Current full local validation candidates from repo/factory evidence:
+
+```bash
+uv run pytest -x -q
+uv run ruff check .
+uv run pyright
+pre-commit run --all-files
+```
+
+Focused validation commands for the highest-risk follow-ups:
+
+```bash
+INBOX_TEST_MODE=1 uv run pytest tests/test_inbox_test_mode.py tests/test_mcp_gateway.py -q
+INBOX_TEST_MODE=1 uv run pytest tests/test_services.py::test_test_mode_blocks_representative_live_writes tests/test_services.py::test_test_mode_blocks_extended_live_writes -q
+uv run pytest tests/test_tools_registry.py tests/test_api_contract.py -q
+uv run pytest tests/test_message_sync.py tests/test_message_index_store.py -q
+uv run pytest tests/test_voice_pipeline.py tests/test_ambient_notes.py -q
+bash -n .factory/init.sh
+```
+
+## Implementation-Ready Follow-Up Tasks
+
+### 1. Make Agent-Safe Test Selection Honest
+
+Owned files:
+
+- `docs/TESTING_FOR_AGENTS.md`
+- `pyproject.toml`
+- `tests/test_inbox_test_mode.py`
+- deterministic test modules selected for `safe` coverage, starting with `tests/test_services.py`, `tests/test_tools_registry.py`, `tests/test_client.py`, `tests/test_api_contract.py`, and `tests/test_message_sync.py`
+
+Acceptance criteria:
+
+- The documented `INBOX_TEST_MODE=1 uv run pytest -m safe` command exercises all deterministic tests that do not touch live personal data or external write surfaces.
+- Tests that mock provider SDKs, use temp SQLite files, or exercise pure routing/contract logic are marked `safe`.
+- Tests that require local macOS data, real OAuth tokens, microphone/audio devices, or live provider writes remain unmarked or explicitly marked `local_data`, `integration`, or `live_write`.
+- `tests/test_inbox_test_mode.py` verifies the docs contain the final safe command and marker vocabulary.
+
+Smallest useful validation:
+
+```bash
+INBOX_TEST_MODE=1 uv run pytest -m safe -q
+uv run pytest tests/test_inbox_test_mode.py -q
+```
+
+### 2. Reconcile Validation Docs And Factory Commands
+
+Owned files:
+
+- `.factory/services.yaml`
+- `DOCS_INDEX.md`
+- `README.md`
+- `CLAUDE.md`
+- `docs/TESTING_FOR_AGENTS.md`
+
+Acceptance criteria:
+
+- Python requirement is consistent with `pyproject.toml` (`>=3.12,<3.15`) across setup docs.
+- Stale "736 tests pass" claims are removed or replaced with command-based guidance that does not hard-code a count.
+- `.factory/services.yaml` stops hiding `tests/test_audio.py` and `tests/test_llm.py` behind the default test command, or clearly names the command as a reduced smoke test and adds a separate full-suite command.
+- Docs name one authoritative safe loop and one authoritative full local loop.
+
+Smallest useful validation:
+
+```bash
+uv run pytest --collect-only -q
+uv run ruff check .
+```
+
+### 3. Add A Repo-Local CI Gate
+
+Owned files:
+
+- `.github/workflows/ci.yml`
+- `README.md` or `docs/TESTING_FOR_AGENTS.md` if command names need to be referenced
+
+Acceptance criteria:
+
+- A tracked workflow runs on pull requests and pushes.
+- The workflow installs with `uv` using a Python version allowed by `pyproject.toml`.
+- The workflow runs Ruff, Pyright, and the safest practical pytest command for this macOS/personal-data repo.
+- If the full suite requires macOS-only dependencies, the workflow uses a macOS runner or documents why a reduced safe suite is the CI gate and what local command covers the full suite.
+
+Smallest useful validation:
+
+```bash
+uv run ruff check .
+uv run pyright
+INBOX_TEST_MODE=1 uv run pytest -m safe -q
+```
+
+### 4. Expose Google Write Preflight Through MCP
+
+Owned files:
+
+- `tools_registry.py`
+- `tests/test_tools_registry.py`
+- `tests/test_api_contract.py`
+- `mcp_backend.py` only if a typed convenience wrapper is desired
+
+Acceptance criteria:
+
+- `preflight_google_write` is present in `TOOLS`, marked `readonly=True`, and routes to `GET /preflight/google-write`.
+- Tool parameters include `kind`, `account`, `folder_id`, `list_id`, `calendar_id`, and `title`.
+- The API contract test proves the tool route matches a FastAPI endpoint.
+- Readonly MCP registration includes the preflight tool; write confirmation is not required because it does not mutate state.
+
+Smallest useful validation:
+
+```bash
+uv run pytest tests/test_tools_registry.py tests/test_api_contract.py -q
+```
+
+### 5. Add Ambient Persistence Regression Coverage
+
+Owned files:
+
+- `tests/test_voice_pipeline.py`
+- `tests/test_server_endpoints.py` or `tests/test_server.py`
+- `inbox_server.py` only if tests reveal the default callback wiring needs a small seam
+
+Acceptance criteria:
+
+- A server/runtime test proves default `ServerState` ambient note callback calls `ambient_notes.save_note(raw, summary)`.
+- Existing endpoint tests can still replace ambient/dictation services with no-op test doubles without masking default wiring.
+- The test uses mocks and does not start real audio capture, microphone input, or ML inference.
+
+Smallest useful validation:
+
+```bash
+uv run pytest tests/test_voice_pipeline.py tests/test_ambient_notes.py -q
+```
+
+## Handoff Notes
+
+- Product code was intentionally left untouched.
+- This report is the only new repo artifact expected from this worker.
+- PR creation and external tracker updates were out of scope for this queue item.

--- a/docs/overnight/2026-05-07-whole-portfolio-review/inbox-sym-117-implementation-readiness.md
+++ b/docs/overnight/2026-05-07-whole-portfolio-review/inbox-sym-117-implementation-readiness.md
@@ -1,0 +1,277 @@
+# inbox-sym-117 Implementation Readiness Review
+
+Queue item: `inbox-sym-117-implementation-readiness`
+Branch: `codex/goal-inbox-sym-117-implementation-readiness`
+Reviewed HEAD: `2805b8400519da188ca7d3f6e39b19a8ca42b05a`
+Date: 2026-05-07
+
+## Scope
+
+This is a read-only implementation-readiness pass for the `inbox-sym-117`
+repo. I did not edit product code. I reviewed repo-local docs, scripts,
+tests, config, recent git state, and searched for previous overnight outputs.
+
+## Evidence Observations
+
+1. `PLAN.md` defines the implementation direction around a local operational
+   index: stabilize sync/index first, then make indexed reads default, then
+   add the TUI Now, Actionable, Waiting On, and Calendar Context surfaces.
+   This is already executable as vertical slices because the plan names owned
+   files such as `message_sync.py`, `message_index_store.py`, `inbox_server.py`,
+   `inbox_client.py`, and `inbox.py`.
+2. `message_index_store.py` already has the core index schema (`sync_state`,
+   `items`, `threads`, `sender_stats`) plus idempotent item upserts, thread
+   rebuilds, index counts, sync state listing, and view filters for actionable,
+   recent, waiting-on-me, waiting-on-others, and open-loop tracking queries.
+3. `message_sync.py` has resumable Gmail bootstrap using
+   `bootstrap_page_token`, Gmail history cursor support with timestamp fallback,
+   iMessage rowid checkpoints, and scoped thread rebuilds through
+   `rebuild_changed_threads()`. This means Phase 1 sync hardening work can be
+   tested mostly with fakes instead of live provider calls.
+4. `inbox_server.py` exposes index endpoints at `/index/threads`,
+   `/index/status`, `/index/health`, `/index/views/{view_name}`,
+   `/index/sync/bootstrap`, and `/index/sync/incremental`. The sync endpoints
+   call live sync functions in background threads, so endpoint tests should
+   patch those call targets and must not hit Gmail or Messages directly.
+5. `inbox_server.py` also has `/inbox/needs-action` returning
+   `thread_read_model="index"` and `raw_thread_provider_fetch=false`;
+   `tests/test_server.py` verifies that the route does not fall back to live
+   Gmail when the index is empty.
+6. `inbox_client.py` includes `index_status()`, `index_health()`,
+   `index_view()`, and helper methods for recent, actionable, waiting-on-me,
+   and waiting-on-others indexed threads. The server/client contract for status
+   and health is covered in `tests/test_api_contract.py`.
+7. `inbox.py` already loads indexed recent, actionable, and waiting-on views in
+   its auxiliary refresh path. The TUI metadata in `tui_tabs.py` now labels the
+   first tab as `Now`, but `inbox.py` key binding text and `tui_tabs.py`
+   command text still say `All` in places. This is a small naming drift that
+   can confuse agents and users.
+8. `tests/test_message_sync.py` covers Gmail bootstrap resume, history cursor
+   capture, timestamp fallback, skipped iMessage rows, changed-scope rebuilds,
+   and global rebuild repair. `tests/test_message_index_store.py` covers
+   idempotence, sender stats, high-volume automated sender behavior, waiting
+   filters, latest-sender filtering, and a 1100-thread rebuild case.
+9. `docs/TESTING_FOR_AGENTS.md` defines the agent-safe loop:
+   `INBOX_TEST_MODE=1 uv run pytest -m safe`, `uv run ruff check .`, and
+   `uv run pyright`. `pyproject.toml` registers `safe`, `integration`,
+   `local_data`, `slow`, and `live_write` markers.
+10. The safe marker is currently narrow: only `tests/test_inbox_test_mode.py`
+    and `tests/test_mcp_gateway.py` declare `pytestmark = pytest.mark.safe`.
+    Deterministic index, client, server, API-contract, and tool-registry tests
+    are not yet part of the documented safe agent loop.
+11. `services.py` has live-write guards via `_assert_live_write_allowed()` on
+    Gmail, iMessage, calendar, reminders, Google Tasks, Drive, Sheets, Docs,
+    GitHub notification mutation, notifications, and attendee modification.
+    `tests/test_services.py` has representative guard tests, and
+    `tests/test_inbox_test_mode.py` verifies test-mode path redirection.
+12. `tools_registry.py` centralizes the MCP tool surface and marks mutating
+    tools as `confirm=True`; `tests/test_tools_registry.py` verifies all
+    mutating tools require confirmation and readonly registration omits writes.
+    The current MCP default `list_inbox_threads` still reads raw Gmail
+    conversations, so indexed inbox views are not yet first-class MCP tools.
+13. `.pre-commit-config.yaml` configures Ruff, Ruff format, common pre-commit
+    hooks, large-file/key checks, and Bandit using `pyproject.toml`. No
+    `.github/` workflow files were present in this worktree, so local evidence
+    does not show CI running the documented agent-safe loop.
+14. `README.md` says Python 3.10+, while `pyproject.toml` requires
+    `>=3.12,<3.15`. `DOCS_INDEX.md` and `SHEETS_CHANGELOG.md` claim "736
+    tests pass"; that claim is stale unless revalidated because the current
+    review did not run the full suite and the test tree has changed.
+15. `dev.sh` supports isolated worktree development by defaulting to port
+    `9850`, while `config/codex.inbox.example.toml` shows how to point MCP
+    clients at the primary `9849` instance or a dev worktree. This reduces
+    implementation risk for UI/API work because agents can avoid disrupting
+    the daily-driver inbox.
+16. `config/inbox.env.example`, `scripts/run_inbox_backend.sh`,
+    `scripts/run_inbox_mcp_http.sh`, and `deploy/inbox-backend.service.example`
+    provide deployment/run surfaces, but they rely on local tokens and primary
+    machine paths. Implementation agents should keep validation provider-free
+    unless explicitly asked to test live integrations.
+17. Search for `runs/**`, `docs/overnight/**`, `*handoff*`, and
+    `*result.json` returned no prior overnight artifacts in this worktree.
+18. `git status --short --branch` was clean at the start of review on
+    `codex/goal-inbox-sym-117-implementation-readiness`.
+
+## Risks And Blockers
+
+- The documented safe validation loop is too small to prove most executable
+  work. Deterministic tests exist, but most are not marked `safe`.
+- Full sync and provider-backed behavior cannot be validated safely without
+  local credentials and live personal data. Work on sync should use fake
+  provider services and temp SQLite databases by default.
+- No local `.github/` workflows were present, so there is no repo-local proof
+  that every PR runs the safe test loop, lint, type checking, or Bandit.
+- The index is now the default read path for several flows, but MCP still
+  exposes raw Gmail inbox listing as the primary thread tool.
+- Product docs contain stale runtime and test-count claims, which can mislead
+  agents choosing validation commands or Python versions.
+
+## Exact Validation Commands
+
+Required queue validation:
+
+```bash
+git status --short
+```
+
+Agent-safe validation recommended for implementation slices:
+
+```bash
+INBOX_TEST_MODE=1 uv run pytest -m safe
+uv run ruff check .
+uv run pyright
+```
+
+Useful focused validations:
+
+```bash
+INBOX_TEST_MODE=1 uv run pytest tests/test_message_sync.py tests/test_message_index_store.py -q
+INBOX_TEST_MODE=1 uv run pytest tests/test_server.py tests/test_api_contract.py tests/test_client.py -q
+INBOX_TEST_MODE=1 uv run pytest tests/test_tools_registry.py tests/test_mcp_gateway.py -q
+```
+
+## Implementation-Ready Follow-Up Tasks
+
+### 1. Broaden the agent-safe test lane for deterministic index/API work
+
+Owned files:
+
+- `tests/test_message_sync.py`
+- `tests/test_message_index_store.py`
+- `tests/test_server.py`
+- `tests/test_client.py`
+- `tests/test_api_contract.py`
+- `tests/test_tools_registry.py`
+- `docs/TESTING_FOR_AGENTS.md`
+
+Acceptance criteria:
+
+- Deterministic tests for the index store, message sync fakes, index server
+  endpoints, API contract, client helpers, and tool registry are included in
+  `pytest -m safe`.
+- Tests that require local personal data, live providers, external writes, or
+  slow hardware/ML dependencies remain outside `safe`.
+- `docs/TESTING_FOR_AGENTS.md` names the broadened safe lane and explains what
+  is intentionally excluded.
+
+Smallest useful validation:
+
+```bash
+INBOX_TEST_MODE=1 uv run pytest -m safe -q
+```
+
+### 2. Add safe endpoint tests for index sync triggers
+
+Owned files:
+
+- `tests/test_server.py`
+- `inbox_server.py` only if the current error shape needs normalization
+
+Acceptance criteria:
+
+- `/index/sync/bootstrap` is tested with `index_bootstrap_sync` patched to
+  return fake stats and proves the response shape is `{"ok": true,
+  "mode": "bootstrap", "stats": ...}`.
+- `/index/sync/incremental` is tested with `index_incremental_sync` patched to
+  return fake stats and proves the response shape is `{"ok": true,
+  "mode": "incremental", "stats": ...}`.
+- Tests prove no live Gmail, iMessage, or token-loading path is invoked.
+
+Smallest useful validation:
+
+```bash
+INBOX_TEST_MODE=1 uv run pytest tests/test_server.py -k 'index_sync' -q
+```
+
+### 3. Make indexed inbox views first-class MCP readonly tools
+
+Owned files:
+
+- `tools_registry.py`
+- `tests/test_tools_registry.py`
+- `tests/test_api_contract.py`
+- `MCP_V1_PLAN.md`
+
+Acceptance criteria:
+
+- Add readonly tools for indexed recent, actionable, waiting-on-me, and
+  waiting-on-others threads, mapped to `/index/views/recent`,
+  `/index/views/actionable`, `/index/views/waiting-on-me`, and
+  `/index/views/waiting-on-others`.
+- Existing raw Gmail tools remain available for drill-down, but docs identify
+  indexed tools as the default inbox read path.
+- Contract tests prove every new tool path routes to a FastAPI endpoint and
+  readonly MCP registration includes the new tools.
+
+Smallest useful validation:
+
+```bash
+INBOX_TEST_MODE=1 uv run pytest tests/test_tools_registry.py tests/test_api_contract.py -q
+```
+
+### 4. Resolve TUI Now/Waiting naming drift and expose split waiting views
+
+Owned files:
+
+- `tui_tabs.py`
+- `command_palette.py`
+- `inbox.py`
+- `tests/test_tui_tabs.py`
+- `tests/test_command_palette.py`
+- `tests/test_inbox_app.py`
+
+Acceptance criteria:
+
+- The first tab, command palette entry, and key binding text consistently use
+  `Now` instead of mixing `Now` and `All`.
+- The TUI either exposes separate `Waiting On Me` and `Waiting On Others`
+  surfaces or clearly defines the existing `Waiting On` tab as the open-loop
+  tracking view.
+- Tests cover tab metadata, command registry labels, and the index view names
+  requested during auxiliary refresh.
+
+Smallest useful validation:
+
+```bash
+INBOX_TEST_MODE=1 uv run pytest tests/test_tui_tabs.py tests/test_command_palette.py tests/test_inbox_app.py -q
+```
+
+### 5. Add a local CI workflow for the safe implementation lane
+
+Owned files:
+
+- `.github/workflows/ci.yml`
+- `.pre-commit-config.yaml` only if workflow behavior needs alignment
+- `docs/TESTING_FOR_AGENTS.md`
+
+Acceptance criteria:
+
+- Pull requests run `uv sync --dev`, `INBOX_TEST_MODE=1 uv run pytest -m safe`,
+  `uv run ruff check .`, and `uv run pyright`.
+- The workflow does not require local personal data, Google tokens, Apple
+  databases, microphone input, or live external writes.
+- Testing docs link the local commands to the CI workflow so agents can
+  reproduce failures before handoff.
+
+Smallest useful validation:
+
+```bash
+INBOX_TEST_MODE=1 uv run pytest -m safe
+uv run ruff check .
+uv run pyright
+```
+
+## Handoff Notes
+
+- Report file written: `docs/overnight/2026-05-07-whole-portfolio-review/inbox-sym-117-implementation-readiness.md`
+- Product code changes: none.
+- Previous overnight artifacts: none found locally.
+- External services, deploys, pushes, PRs, and tracker updates: not attempted.
+- Required validation command run: `git status --short`.
+- Validation result: command completed successfully and reported the new
+  `docs/overnight/` report path as untracked.
+- Commit/PR blocker: local commit creation was blocked by sandbox permissions.
+  `git add docs/overnight/2026-05-07-whole-portfolio-review/inbox-sym-117-implementation-readiness.md`
+  failed because Git could not create
+  `/Users/jwalinshah/projects/inbox/.git/worktrees/inbox-sym-117-implementation-readiness/index.lock`
+  (`Operation not permitted`).

--- a/docs/overnight/2026-05-07-whole-portfolio-review/inbox-sym-117-risk-and-validation-review.md
+++ b/docs/overnight/2026-05-07-whole-portfolio-review/inbox-sym-117-risk-and-validation-review.md
@@ -1,0 +1,188 @@
+# inbox-sym-117 Risk And Validation Review
+
+Queue item: `inbox-sym-117-risk-and-validation-review`
+Branch: `codex/goal-inbox-sym-117-risk-and-validation-review`
+Review date: 2026-05-07
+HEAD reviewed: `2805b8400519da188ca7d3f6e39b19a8ca42b05a`
+
+## Scope
+
+This is a read-only risk and validation review for the `inbox-sym-117` repo. No product code was edited. External services, deploys, pushes, PR creation, destructive cleanup, and tracker updates were treated as out of scope.
+
+Repo-local previous overnight outputs were checked with `fd -H -t f 'overnight|handoff|result\.json|CODEX_WORKPAD|ISSUE|runs' .`; no prior overnight reports, handoffs, or run result files were present in this worktree before this report.
+
+Current git state at the start of review was clean on `codex/goal-inbox-sym-117-risk-and-validation-review`.
+
+## Concrete File Evidence
+
+1. `CLAUDE.md:3-13` defines Inbox as a local Python/Textual/FastAPI personal-data app and documents `INBOX_SERVER_PORT`/`INBOX_SERVER_URL`; this makes wrong-port validation a real risk because the daily driver defaults to port `9849`.
+2. `CLAUDE.md:53-76` explicitly warns that macOS data paths are shared across worktrees and that an MCP client pointed at `9849` can appear to work while reading primary data instead of a dev worktree.
+3. `docs/TESTING_FOR_AGENTS.md:7-13` declares the agent-safe loop as `INBOX_TEST_MODE=1 uv run pytest -m safe`, `uv run ruff check .`, and `uv run pyright`.
+4. `pyproject.toml:53-62` registers pytest markers and coverage defaults, but only `tests/test_inbox_test_mode.py:8` and `tests/test_mcp_gateway.py:18` currently apply the `safe` marker. A grep count found 864 test functions and only two `safe` marker sites.
+5. `tests/conftest.py:15-35` stubs ML and hardware dependencies such as `mlx_lm`, `mlx_whisper`, `sounddevice`, `outlines`, and `Quartz`, so many deterministic tests appear eligible for safe marking after review.
+6. `inbox_test_mode.py:18-24` implements `INBOX_TEST_MODE` and `assert_live_writes_allowed`; `services.py:114-119` wires service mutations through that helper.
+7. `services.py:420-4455`, `services.py:5511`, and `services.py:6270` show broad live-write guards for Google auth, Gmail, iMessage, Calendar, Reminders, Tasks, Drive, Sheets, Docs, GitHub notifications, desktop notifications, WhatsApp, and calendar attendee mutation.
+8. `services.py:5429-5480`, `services.py:5560-5584`, and `services.py:6090-6118` write notification, favorite, and voice config files under `~/.config/inbox` outside test mode; `tests/test_inbox_test_mode.py:29-46` verifies these paths move under `INBOX_TEST_DATA_DIR` only when services is imported in test mode.
+9. `inbox_server.py:1313-1340` requires `INBOX_SERVER_TOKEN` only when that env var is set; `tests/test_server.py:371-410` covers unset, bearer, and `X-API-Key` behavior.
+10. `mcp_gateway.py:32-45` and `mcp_gateway.py:48-58` allow all non-health HTTP MCP requests when `INBOX_MCP_TOKEN` is unset; `tests/test_mcp_gateway.py:36-53` tests rejection only when the token is configured.
+11. `MCP_SETUP.md:252-313` says the backend should never be internet-facing, MCP should be exposed instead of the raw API, and remote MCP should require `INBOX_MCP_TOKEN`; `scripts/run_inbox_mcp_http.sh:1-9` and `scripts/run_inbox_mcp_http_readonly.sh:1-9` start HTTP MCP without checking that token.
+12. `.pre-commit-config.yaml:1-23` covers Ruff, formatting, basic file hygiene, private-key detection, and Bandit; no `.github/workflows` directory or other CI workflow file exists in this worktree.
+13. `.factory/services.yaml:1-16` defines local install, test, typecheck, lint, format, and an inbox server healthcheck; its test command excludes audio and LLM tests but does not use `INBOX_TEST_MODE=1`.
+14. `README.md:31-34` claims Python `3.10+`, while `pyproject.toml:5` requires `>=3.12,<3.15`; this is a stale setup claim that can send workers into the wrong interpreter.
+15. `batch/batch-runner.sh:56-65` initializes state and auth headers, `batch/batch-runner.sh:74-80` constructs a JSON payload with shell interpolation, and `batch/batch-runner.sh:92-101` updates a shared state TSV without locking while `batch/batch-runner.sh:135-160` can run workers in parallel.
+16. `message_sync.py:638-655` exposes local index bootstrap, incremental, rebuild, and summary CLI modes; `inbox_server.py:3844-3853` exposes bootstrap and incremental sync as API POST endpoints.
+
+## Risks And Blockers
+
+1. Safe validation is too narrow. The documented agent-safe command currently covers only the safe-marked files, while high-value deterministic tests for server auth, preflight, index health, message sync, client routing, and live-write blocking are unmarked. This can let risky changes pass the default overnight loop.
+2. There is no repo CI workflow. Local commands are documented, pre-commit exists, and `.factory/services.yaml` has useful commands, but there is no checked-in workflow proving that the safe loop, lint, and typecheck run on PRs.
+3. HTTP MCP auth is fail-open when `INBOX_MCP_TOKEN` is absent. The server binds to loopback in `mcp_server.py` and `inbox_mcp_readonly.py`, and deployment docs say to use env files, but the runtime middleware and scripts do not fail closed. A misconfigured service can expose tools unauthenticated behind whatever reverse proxy is in front of it.
+4. Worktree routing remains fragile. The docs correctly warn about primary-vs-dev confusion, but there is no validation command that proves `cwd`, `INBOX_SERVER_URL`, server port, and MCP backend routing all point at the intended worktree before testing mutations.
+5. Batch archive parallelism can corrupt local state. Parallel workers update `batch/archive-state.tsv` with a read-rewrite-move sequence and no lock, even though `.gitignore:45-49` reserves a batch lock file path. The curl JSON is also shell-built from TSV values.
+6. Setup docs are stale around Python version and test safety. README's Python requirement and unqualified `uv run pytest` recommendation conflict with pyproject and agent-safe testing guidance.
+7. Index sync endpoints can read large live personal data sources and mutate the local `.inbox_index.sqlite3` state. They are valid product functionality, but they should not be part of default agent validation unless a test-data DB or explicit local-data opt-in is present.
+8. External/live validation is intentionally blocked for this review. Gmail, Calendar, Drive, Docs, Sheets, Tasks, iMessage, Notes, Reminders, GitHub, microphone, notification, and OAuth paths require credentials or local personal data and should stay mocked or explicitly opted in.
+
+## Exact Validation Commands
+
+Required queue validation:
+
+```bash
+git status --short
+```
+
+Agent-safe default loop from repo docs:
+
+```bash
+INBOX_TEST_MODE=1 uv run pytest -m safe
+uv run ruff check .
+uv run pyright
+```
+
+Useful focused validations for the follow-up tasks below:
+
+```bash
+INBOX_TEST_MODE=1 uv run pytest tests/test_inbox_test_mode.py tests/test_mcp_gateway.py -q
+INBOX_TEST_MODE=1 uv run pytest tests/test_server.py::TestAuth tests/test_server.py::TestPreflight -q
+INBOX_TEST_MODE=1 uv run pytest tests/test_message_sync.py tests/test_message_index_store.py -q
+bash -n batch/batch-runner.sh
+uv run ruff check .
+uv run pyright
+```
+
+## Implementation-Ready Follow-Up Tasks
+
+### 1. Expand The Safe Test Marker Set
+
+Owned files:
+- `tests/test_message_sync.py`
+- `tests/test_message_index_store.py`
+- `tests/test_server.py`
+- `tests/test_services.py`
+- `tests/test_client.py`
+- `docs/TESTING_FOR_AGENTS.md`
+
+Acceptance criteria:
+- Deterministic tests that use mocks/temp paths and do not touch live personal data are marked `safe`.
+- `INBOX_TEST_MODE=1 uv run pytest -m safe -q` exercises server auth, Google preflight, index health, message sync checkpointing, client auth headers, and representative live-write blocking.
+- Tests that require local user stores, OAuth, provider APIs, microphone input, or visible writes remain unmarked or explicitly marked `local_data`, `integration`, `slow`, or `live_write`.
+
+Smallest useful validation:
+
+```bash
+INBOX_TEST_MODE=1 uv run pytest -m safe tests/test_inbox_test_mode.py tests/test_mcp_gateway.py tests/test_server.py tests/test_message_sync.py tests/test_message_index_store.py tests/test_services.py tests/test_client.py -q
+```
+
+### 2. Add Checked-In CI For The Agent-Safe Loop
+
+Owned files:
+- `.github/workflows/ci.yml`
+- `.factory/services.yaml`
+- `docs/TESTING_FOR_AGENTS.md`
+
+Acceptance criteria:
+- CI installs with `uv sync --group dev` or the repo's accepted equivalent.
+- CI runs `INBOX_TEST_MODE=1 uv run pytest -m safe`, `uv run ruff check .`, and `uv run pyright`.
+- `.factory/services.yaml` uses the same safe test command as agent docs, or explicitly distinguishes "safe" from "broader local" test commands.
+
+Smallest useful validation:
+
+```bash
+INBOX_TEST_MODE=1 uv run pytest -m safe -q
+uv run ruff check .
+uv run pyright
+```
+
+### 3. Fail Closed For HTTP MCP When Token Is Missing
+
+Owned files:
+- `mcp_gateway.py`
+- `mcp_server.py`
+- `inbox_mcp_readonly.py`
+- `scripts/run_inbox_mcp_http.sh`
+- `scripts/run_inbox_mcp_http_readonly.sh`
+- `tests/test_mcp_gateway.py`
+- `MCP_SETUP.md`
+
+Acceptance criteria:
+- HTTP MCP startup fails or refuses `/mcp` when `INBOX_MCP_TOKEN` is unset, unless an explicit local-development override is set.
+- `/health` still reports whether auth is enabled without exposing protected tools.
+- Stdio MCP behavior remains unchanged for trusted local clients.
+- Tests cover missing token, invalid token, valid token, `/health`, and the local override path.
+
+Smallest useful validation:
+
+```bash
+INBOX_TEST_MODE=1 uv run pytest tests/test_mcp_gateway.py -q
+bash -n scripts/run_inbox_mcp_http.sh scripts/run_inbox_mcp_http_readonly.sh
+```
+
+### 4. Harden Batch Archive State And Payload Handling
+
+Owned files:
+- `batch/batch-runner.sh`
+- `tests/test_batch_runner.py` or a new focused shell-test wrapper under `tests/`
+- `.gitignore`
+
+Acceptance criteria:
+- Parallel batch workers serialize updates to `batch/archive-state.tsv` using `batch/.batch-state.lock` or an equivalent lock.
+- JSON request payloads are built with a proper encoder instead of raw shell interpolation.
+- Thread IDs and source values are validated before use in log filenames, TSV writes, and curl payloads.
+- `--dry-run` remains read-only and does not create or mutate state beyond any explicitly documented temp setup.
+
+Smallest useful validation:
+
+```bash
+bash -n batch/batch-runner.sh
+INBOX_TEST_MODE=1 uv run pytest tests/test_batch_runner.py -q
+```
+
+### 5. Align Setup Docs With Runtime And Safe Validation
+
+Owned files:
+- `README.md`
+- `CLAUDE.md`
+- `DOCS_INDEX.md`
+- `docs/TESTING_FOR_AGENTS.md`
+- `pyproject.toml`
+
+Acceptance criteria:
+- Python version guidance consistently says `>=3.12,<3.15` or the project intentionally lowers `pyproject.toml`.
+- README development commands distinguish safe agent validation from full local validation.
+- Docs consistently mention `INBOX_TEST_MODE=1` for agent-run tests and reserve live/local-data verification for explicit opt-in.
+- `pyproject.toml` project metadata no longer has placeholder description text.
+
+Smallest useful validation:
+
+```bash
+INBOX_TEST_MODE=1 uv run pytest tests/test_inbox_test_mode.py -q
+uv run ruff check README.md CLAUDE.md DOCS_INDEX.md docs/TESTING_FOR_AGENTS.md pyproject.toml
+```
+
+## Handoff Notes
+
+- Report file written: `docs/overnight/2026-05-07-whole-portfolio-review/inbox-sym-117-risk-and-validation-review.md`
+- Product code edited: no
+- External trackers updated: no
+- PR created: no
+- Known blockers: live/provider validation requires credentials, local personal data, or explicit approval; this review stayed inside repo-local evidence and the queue validation command.

--- a/docs/overnight/2026-05-07-whole-portfolio-review/inbox-sym-118-implementation-readiness.md
+++ b/docs/overnight/2026-05-07-whole-portfolio-review/inbox-sym-118-implementation-readiness.md
@@ -1,0 +1,206 @@
+# inbox-sym-118 Implementation Readiness Review
+
+Date: 2026-05-07
+Branch: `codex/goal-inbox-sym-118-implementation-readiness`
+Repo: `inbox-sym-118`
+HEAD at review start: `2805b8400519da188ca7d3f6e39b19a8ca42b05a`
+
+## Scope
+
+This pass reviewed the repo for executable follow-up work. It did not modify product code, call external services, push branches, create PRs, or update trackers.
+
+The queue item referenced `items/inbox-sym-118-implementation-readiness/ISSUE.md`, but that file is not present in this worktree. The full issue body was provided in the worker prompt, so the review continued from that contract.
+
+No prior `docs/overnight/2026-05-07-whole-portfolio-review/` reports or `runs/*` outputs were present in this repo at the time of review. The repo does contain older `.factory/validation/*` outputs, which were used only as local evidence.
+
+## Concrete Observations
+
+1. `PLAN.md` defines the current product direction as an index-first inbox: stabilize sync/index, improve thread intelligence, make indexed reads the default, then build the `Now`, `Actionable`, and `Waiting On` TUI surfaces. This gives implementation agents a clear priority order.
+
+2. `message_index_store.py` already has the core operational index tables: `sync_state`, `items`, `threads`, and `sender_stats`. It also supports status metadata, scoped thread rebuilds, recent/actionable/waiting filters, sender stats, and idempotent item upserts.
+
+3. `message_sync.py` implements resumable Gmail bootstrap, Gmail history-cursor incremental sync, timestamp fallback, iMessage bootstrap/incremental sync, and scoped thread rebuilds. The highest-readiness slice is hardening these behaviors rather than inventing new architecture.
+
+4. `tests/test_message_sync.py` covers concrete sync guarantees: saved Gmail page-token resume, history cursor recording, no double-count on resume, Gmail history incremental updates, timestamp fallback, skipped iMessage row checkpointing, and scoped rebuilds for changed Gmail/iMessage scopes.
+
+5. `tests/test_message_index_store.py` covers index-store behavior: replacement upserts, OTP/noise classification, frequent-human sender stats, high-volume automated sender suppression, sync-state metadata, waiting/recent list filters, idempotency, and large rebuilds without SQLite expression-depth failure.
+
+6. `inbox_server.py` exposes index endpoints that match the plan: `/index/status`, `/index/health`, `/index/views/{view_name}`, `/index/sync/bootstrap`, `/index/sync/incremental`, and `/inbox/needs-action`. The server also intentionally marks indexed outputs as `read_model=index` and `raw_provider_fetch=false`.
+
+7. `tests/test_server.py` verifies the index endpoints route to `state.index_store.list_threads` with explicit filters for `actionable`, `waiting-on`, `waiting-on-me`, and `waiting-on-others`, and verifies `/inbox/needs-action` does not fall back to live Gmail when the index is empty.
+
+8. `inbox_client.py` has helpers for `indexed_recent_threads`, `indexed_actionable_threads`, `indexed_waiting_on_me_threads`, and `indexed_waiting_on_others_threads`, but `inbox.py` currently fetches only `recent`, `actionable`, and `waiting-on` for the first-screen TUI. The API is ahead of the TUI controls for separating "waiting on me" from "waiting on others".
+
+9. `CONNECTOR_ROADMAP.md` calls out source-of-truth account routing and write preflight as the next connector milestones. `google_account_resolution.py` already centralizes default Google account selection via `INBOX_DEFAULT_GOOGLE_ACCOUNT` and includes a `preflight_google_write_payload` helper for Docs, Sheets, Drive folders, Tasks, and Calendar events.
+
+10. `tests/test_server.py` has preflight coverage for no-service failures, default account resolution, folder verification, task-list verification, calendar defaulting, and unknown write kinds. The backend preflight is implementation-ready enough to expose through client/MCP surfaces.
+
+11. `tools_registry.py` centralizes MCP tool exposure and `tests/test_tools_registry.py` verifies every mutating MCP tool is confirmation-gated, readonly registration excludes write tools, path parameters are URL encoded, and registered tool routes exist in FastAPI via `tests/test_api_contract.py`.
+
+12. `tools_registry.py` does not currently expose a `preflight_google_write` MCP tool, even though `inbox_server.py` exposes `/preflight/google-write`. This is a small, low-risk connector-readiness task with clear tests.
+
+13. `docs/TESTING_FOR_AGENTS.md` documents the safe default loop as `INBOX_TEST_MODE=1 uv run pytest -m safe`, `uv run ruff check .`, and `uv run pyright`. In practice, only `tests/test_inbox_test_mode.py` and `tests/test_mcp_gateway.py` are marked `pytest.mark.safe`, so many deterministic server/index tests are excluded from the documented agent-safe lane.
+
+14. Running `INBOX_TEST_MODE=1 uv run pytest -m safe -q` failed before dependency resolution because uv tried to initialize cache under `/Users/jwalinshah/.cache/uv`, which is outside this sandbox. Retrying with `UV_CACHE_DIR=/tmp/uv-cache` got past cache creation but failed on DNS while trying to download `networkx==3.6.1`. Agent validation needs either pre-seeded dependencies or commands that set `UV_CACHE_DIR`.
+
+15. `.factory/services.yaml` sets `test` to `uv run pytest --ignore=tests/test_audio.py --ignore=tests/test_llm.py -x -q`, while `test_all` runs the full suite. Older `.factory/validation/fix-broken-state/scrutiny/synthesis.json` also notes that audio/LLM exclusions are already documented. This is a real lane split, but it should be made explicit in agent-facing validation docs.
+
+16. `.pre-commit-config.yaml` includes Ruff, Ruff format, pre-commit hygiene hooks, and Bandit with `pyproject.toml`. `pyproject.toml` also defines pytest markers and Pyright basic type checking, but no `.github/` CI workflow was present in this worktree.
+
+17. `.mcp.json` points both `inbox` and `inbox-readonly` MCP servers at `http://127.0.0.1:9849`, while `CLAUDE.md` warns that dev worktrees should use alternate ports. There is clear local guidance, but a dev-specific MCP example would reduce primary-vs-dev routing mistakes.
+
+18. `.gitignore` protects credential and runtime files (`credentials.json`, `tokens/`, `github_token.txt`, `gemini_api_key.txt`, `.inbox_index.sqlite3`, `.inbox_memory.sqlite3`, `.inbox_scheduler.sqlite3`, generated batch state), so the report can safely recommend validation without risking secret commits.
+
+## Risks And Blockers
+
+- Missing local queue issue file: `items/inbox-sym-118-implementation-readiness/ISSUE.md` is absent. The prompt contained the issue body, so this did not block the review, but future workers should have a local `ISSUE.md` or workpad artifact.
+- Dependency bootstrap blocked in this sandbox: `uv run` created `.venv` only after `UV_CACHE_DIR=/tmp/uv-cache`, then failed because network access is restricted and dependencies were not already available.
+- Local commit creation is blocked in this sandbox: `git add docs/overnight/2026-05-07-whole-portfolio-review/inbox-sym-118-implementation-readiness.md` failed because git tried to create `.git/worktrees/inbox-sym-118-implementation-readiness/index.lock` under `/Users/jwalinshah/projects/inbox`, which is outside the writable roots.
+- The documented safe pytest lane is too narrow: only two test files are marked `safe`, excluding deterministic server/index/client tests that are highly relevant for agent implementation.
+- No `.github/` CI config was present. The repo relies on local commands and `.factory` validation metadata, which is workable locally but weak for PR-level enforcement.
+- MCP/dev routing remains easy to misconfigure: default repo MCP config points at port `9849`, the primary daily-driver server, while worktree dev should use `9850+`.
+
+## Validation Commands
+
+Commands run during this review:
+
+```bash
+git status --short
+```
+
+Result before report creation: passed with clean output.
+
+```bash
+INBOX_TEST_MODE=1 uv run pytest -m safe -q
+```
+
+Result: blocked by uv cache permission at `/Users/jwalinshah/.cache/uv`.
+
+```bash
+UV_CACHE_DIR=/tmp/uv-cache INBOX_TEST_MODE=1 uv run pytest -m safe -q
+```
+
+Result: blocked by restricted network while downloading `networkx==3.6.1`, pulled through `mlx-whisper -> torch -> networkx`.
+
+Queue validation after writing this report:
+
+```bash
+git status --short
+```
+
+Result: passed with output `?? docs/overnight/`, expected because the required report could not be staged or committed under the current sandbox permissions.
+
+Commit attempt:
+
+```bash
+git add docs/overnight/2026-05-07-whole-portfolio-review/inbox-sym-118-implementation-readiness.md
+```
+
+Result: blocked by sandbox write permissions on the external git worktree metadata path.
+
+## Implementation-Ready Follow-Up Tasks
+
+### 1. Broaden The Agent-Safe Test Lane
+
+Owned files:
+- `tests/test_message_sync.py`
+- `tests/test_message_index_store.py`
+- `tests/test_server.py`
+- `tests/test_client.py`
+- `tests/test_api_contract.py`
+- `docs/TESTING_FOR_AGENTS.md`
+
+Acceptance criteria:
+- Deterministic index/sync/server/client/API-contract tests that avoid live data and external writes are marked with `pytestmark = pytest.mark.safe` or targeted `@pytest.mark.safe`.
+- Tests that require local user data, live writes, heavy ML/audio, or external credentials remain outside `safe` and use the existing marker vocabulary.
+- `docs/TESTING_FOR_AGENTS.md` lists the updated safe command with `UV_CACHE_DIR=/tmp/uv-cache` for sandboxed agents.
+
+Smallest useful validation:
+
+```bash
+UV_CACHE_DIR=/tmp/uv-cache INBOX_TEST_MODE=1 uv run pytest -m safe -q
+```
+
+### 2. Expose Google Write Preflight Through Client And MCP
+
+Owned files:
+- `inbox_client.py`
+- `tools_registry.py`
+- `tests/test_client.py`
+- `tests/test_tools_registry.py`
+- `tests/test_api_contract.py`
+
+Acceptance criteria:
+- `InboxClient` exposes a `preflight_google_write(...)` helper for `/preflight/google-write`.
+- `tools_registry.py` exposes a readonly MCP tool for Google write preflight.
+- API-contract tests confirm the MCP tool path routes to FastAPI.
+- Registry tests confirm the tool is readonly and does not require `confirm`.
+
+Smallest useful validation:
+
+```bash
+UV_CACHE_DIR=/tmp/uv-cache INBOX_TEST_MODE=1 uv run pytest tests/test_client.py tests/test_tools_registry.py tests/test_api_contract.py -q
+```
+
+### 3. Split Waiting-On TUI Into "Me" And "Others" Views
+
+Owned files:
+- `inbox.py`
+- `inbox_client.py`
+- `tests/test_inbox_app.py`
+- `tests/test_client.py`
+
+Acceptance criteria:
+- The TUI can show `waiting-on-me` and `waiting-on-others` indexed views separately, using the existing client helpers.
+- Existing `waiting-on` behavior remains available or is replaced with an explicit combined view.
+- Status text and sidebar data make the selected waiting view unambiguous.
+- Tests cover data collection and sidebar rendering for both views without live server access.
+
+Smallest useful validation:
+
+```bash
+UV_CACHE_DIR=/tmp/uv-cache INBOX_TEST_MODE=1 uv run pytest tests/test_client.py tests/test_inbox_app.py -q
+```
+
+### 4. Add A Sandbox-Friendly Validation Script
+
+Owned files:
+- `scripts/validate_agent_safe.sh`
+- `docs/TESTING_FOR_AGENTS.md`
+- `.factory/services.yaml`
+
+Acceptance criteria:
+- A single script sets `UV_CACHE_DIR=/tmp/uv-cache` by default and runs the safe pytest lane, Ruff, and Pyright.
+- The script does not run live-write, local-data, slow, audio, or LLM-heavy tests unless explicitly asked.
+- Agent docs and `.factory/services.yaml` point to the same safe command to avoid command drift.
+
+Smallest useful validation:
+
+```bash
+bash scripts/validate_agent_safe.sh
+```
+
+### 5. Add Dev MCP Routing Example For Worktrees
+
+Owned files:
+- `.mcp.dev.example.json`
+- `CLAUDE.md`
+- `MCP_SETUP.md`
+- `tests/test_mcp_gateway.py`
+
+Acceptance criteria:
+- The repo includes a dev MCP example that points at `http://127.0.0.1:9850` and still passes `INBOX_SERVER_TOKEN`.
+- Docs clearly distinguish primary daily-driver MCP routing from dev worktree routing.
+- A lightweight test or static assertion verifies the example keeps the token env placeholder and does not point dev at `9849`.
+
+Smallest useful validation:
+
+```bash
+UV_CACHE_DIR=/tmp/uv-cache INBOX_TEST_MODE=1 uv run pytest tests/test_mcp_gateway.py -q
+```
+
+## Readiness Summary
+
+The safest next implementation work is not broad feature expansion. It is tightening the agent-safe validation lane, exposing already-built preflight/account-routing primitives through client/MCP surfaces, and finishing the index-first TUI split that the API already supports.
+
+The index/sync work is the most implementation-ready area because the desired behavior is documented in `PLAN.md`, represented in `message_sync.py` and `message_index_store.py`, and already covered by focused deterministic tests. The connector-policy work is also ready, but should be kept to small endpoint/client/MCP slices so it does not accidentally widen write behavior.

--- a/docs/overnight/2026-05-07-whole-portfolio-review/inbox-sym-118-risk-and-validation-review.md
+++ b/docs/overnight/2026-05-07-whole-portfolio-review/inbox-sym-118-risk-and-validation-review.md
@@ -1,0 +1,117 @@
+# inbox-sym-118 risk and validation review
+
+Date: 2026-05-07
+Branch: `codex/goal-inbox-sym-118-risk-and-validation-review`
+HEAD: `2805b8400519da188ca7d3f6e39b19a8ca42b05a`
+Queue item: `inbox-sym-118-risk-and-validation-review`
+
+## Scope
+
+This is a repo-local risk and validation pass for `inbox-sym-118`. I reviewed local docs, package metadata, tests, scripts, deployment examples, factory validation outputs, and git state. I did not edit product code, call external services, push, open a PR, or update trackers.
+
+The queue item referenced `items/inbox-sym-118-risk-and-validation-review/ISSUE.md`, but that file is absent in this worktree. I used the Goal Pack issue text supplied in the worker prompt as the task contract.
+
+## Concrete observations
+
+1. `README.md` describes a privacy-first local TUI/API spanning iMessage, Gmail, Calendar, Sheets, Notes, Reminders, GitHub, Drive, ambient audio, dictation, and autocomplete; the stated runtime surface is much broader than a normal web app and includes personal data plus live write integrations.
+2. `pyproject.toml:5` requires Python `>=3.12,<3.15`, while `README.md` says Python 3.10+. That mismatch can send agents or CI to the wrong interpreter before any tests run.
+3. `pyproject.toml:53-62` registers pytest markers for `safe`, `integration`, `local_data`, `slow`, and `live_write`, and `docs/TESTING_FOR_AGENTS.md:9-18` documents the safe command loop. This is a strong base for agent-safe validation.
+4. `docs/TESTING_FOR_AGENTS.md:23-43` explicitly requires `INBOX_TEST_MODE=1` and forbids live-write, local-data, and provider-specific integration tests unless opted in. Any future validation task should preserve that contract.
+5. `inbox_test_mode.py:9-24` centralizes safe-mode environment handling and raises `LiveWriteBlocked`; `services.py:114-119` routes service-level live-write guards through that helper.
+6. `tests/test_services.py:909-951` covers representative write blockers for Gmail, Calendar, Apple Reminders, Google Tasks, Drive, Sheets, Docs, GitHub notifications, desktop notifications, and WhatsApp. This is the main regression fence for accidental live writes during agent runs.
+7. `services.py:65-80` redirects token files and local macOS databases into `INBOX_TEST_DATA_DIR` only when test mode is active. Without `INBOX_TEST_MODE=1`, importing or starting the server can reach real `~/Library` data paths and repo-local token paths.
+8. `services.py:88-98` requests broad Google OAuth scopes including Gmail modify/send, Calendar, Drive, Sheets, Docs, and Tasks. The repo needs tight validation around account resolution and write confirmation because a single token has many mutation powers.
+9. `services.py:330-416` builds all Google services from every token in `tokens/`, refreshes expired credentials, renames token files to account emails, and logs failures. This is operationally useful but increases startup side effects and makes offline validation sensitive to cached credentials and network availability.
+10. `inbox_server.py:1198-1285` starts contacts, Google auth, optional conversation prewarm, ambient audio autostart, and the scheduler in lifespan. Tests can inject a runtime, but the default app startup path is side-effectful unless a test or runner disables those pieces.
+11. `inbox_server.py:1313-1340` makes backend auth optional: if `INBOX_SERVER_TOKEN` is absent, all REST requests are accepted. This is reasonable for loopback-only local use, but deployment validation must prove the raw backend stays private.
+12. `mcp_gateway.py:36-58` makes HTTP MCP auth optional in the same way and exempts `/health`; `config/inbox.env.example:1-9` documents separate backend and MCP tokens. Remote deployment checks should fail closed when a token is missing.
+13. `tools_registry.py:52-78` adds `confirm=True` handling to generated MCP handlers, and `tools_registry.py:110-119` filters readonly tools for the readonly MCP server. That central registry is the right place to add mutation-surface regression tests.
+14. `inbox_mcp_readonly.py:44-77` still exposes sensitive read capabilities such as daily note reads and memory queries, even though it excludes mutation tools. "Read-only" should be treated as lower-risk, not public-safe.
+15. `.gitignore:12-25` ignores OAuth credentials, tokens, keys, secrets, env files, and local token dirs; `.gitignore:40-43` also ignores local MCP memory and scheduler SQLite files. Secret hygiene is present at the repo boundary.
+16. `.pre-commit-config.yaml:1-23` configures ruff, formatting, basic file checks, private-key detection, and Bandit, but `fd -H '^workflows$|\\.yml$|\\.yaml$' .github .` found no `.github/workflows` files. There is local validation config but no visible GitHub Actions workflow in this worktree.
+17. `.factory/services.yaml:1-8` defines `test`, `test_all`, `typecheck`, and `lint`, but the default `test` command excludes `tests/test_audio.py` and `tests/test_llm.py`. This is also called out as already documented in `.factory/validation/fix-broken-state/scrutiny/synthesis.json:31-35`.
+18. `.factory/validation/architecture-hardening/scrutiny/synthesis.json:41-57` records a systemic `Permission denied` issue for direct `.factory/init.sh` execution, and `ls -l .factory/init.sh` confirms the file is not executable (`-rw-r--r--`). This can break repeated agent setup.
+19. `.factory/validation/reminders-tab/scrutiny/synthesis.json:30-35` records a blocking reminder correctness issue: duplicate incomplete reminders with the same title and list can cause AppleScript to mutate the wrong reminder. The same file includes an orchestrator override at lines 46-52, so this is accepted risk, not resolved risk.
+20. `.factory/validation/voice-pipeline/scrutiny/synthesis.json:5-22` records a passing `uv run pytest -x -q`, `uv run pyright`, and `uv run ruff check .` validation set with 563 tests run. `DOCS_INDEX.md:40-45` still claims `uv run pytest` has "736 pass", which is a stale or at least unverified count in current local evidence.
+21. `.factory/services.yaml:12-14` hardcodes the service start path to `/Users/jwalinshah/projects/inbox` and port `9849`, while `CLAUDE.md` says worktrees should run on alternate ports. Factory service validation can accidentally target the daily-driver checkout instead of this isolated worktree.
+22. `scripts/run_inbox_backend.sh:1-9` uses `UV_CACHE_DIR=/tmp/uv-cache` before `uv run python inbox_server.py`. That cache override is necessary in this sandbox: plain `uv run` attempted to use `~/.cache/uv` and failed with `Operation not permitted`.
+
+## Risks and blockers
+
+- Required issue file missing: `items/inbox-sym-118-risk-and-validation-review/ISSUE.md` is not present. The prompt supplied the issue body, so the review could continue, but future workers should not depend on the missing path.
+- Offline validation is not currently guaranteed in a fresh sandbox. `UV_CACHE_DIR=/tmp/uv-cache INBOX_TEST_MODE=1 uv run pytest tests/test_inbox_test_mode.py -q` tried to download `hf-xet` through the `mlx-whisper` dependency chain and failed because network is unavailable.
+- There is no visible `.github/workflows` CI in this worktree. Local validation commands exist, but PR-level enforcement cannot be confirmed from repo-local files.
+- The default factory `test` command skips audio and LLM tests. That may be reasonable for speed, but the repo needs an explicit policy for when skipped domains must run.
+- Default server startup has real-data and background-process touchpoints: contacts, Google auth, optional ambient audio, scheduler, and optional prewarm.
+- Auth is opt-in for both the private backend and public MCP gateway. Deployment evidence must prove exposed surfaces always set tokens and bind the backend privately.
+- The readonly MCP gateway still exposes private notes and memory reads. It should be reviewed as a personal-data exfiltration surface, not just as a non-mutating API.
+- The Reminders duplicate-title mutation risk remains accepted by override rather than technically eliminated.
+- Documentation contains stale validation claims, especially the `DOCS_INDEX.md` test count.
+
+## Validation commands
+
+Commands run during this review:
+
+```bash
+git status --short --branch
+```
+
+Result before edits: clean branch output only, `## codex/goal-inbox-sym-118-risk-and-validation-review`.
+
+```bash
+INBOX_TEST_MODE=1 uv run pytest tests/test_inbox_test_mode.py -q
+```
+
+Result: failed before tests because sandboxed `uv` could not open `/Users/jwalinshah/.cache/uv/sdists-v9/.git`.
+
+```bash
+UV_CACHE_DIR=/tmp/uv-cache INBOX_TEST_MODE=1 uv run pytest tests/test_inbox_test_mode.py -q
+```
+
+Result: failed before tests because dependency setup attempted to download `hf-xet==1.4.3` via the `mlx-whisper -> huggingface-hub -> hf-xet` chain, and DNS/network access is unavailable.
+
+Required queue validation:
+
+```bash
+git status --short
+```
+
+Result after writing this report: exit code 0, output:
+
+```text
+?? docs/overnight/
+```
+
+## Implementation-ready follow-up tasks
+
+1. Make the agent-safe smoke test runnable offline.
+   Owned files: `pyproject.toml`, `uv.lock`, `docs/TESTING_FOR_AGENTS.md`, `tests/conftest.py`.
+   Acceptance criteria: a fresh sandbox can run the documented focused safe test without downloading ML/audio transitive dependencies; heavy ML/audio packages remain available for full local installs; docs explain the exact offline-safe command.
+   Smallest useful validation: `UV_CACHE_DIR=/tmp/uv-cache INBOX_TEST_MODE=1 uv run pytest tests/test_inbox_test_mode.py -q`.
+
+2. Add PR CI for the safe validation contract.
+   Owned files: `.github/workflows/safe-validation.yml`, `docs/TESTING_FOR_AGENTS.md`.
+   Acceptance criteria: CI runs `INBOX_TEST_MODE=1 uv run pytest -m safe`, `uv run ruff check .`, and `uv run pyright`; the workflow does not require local personal data, provider credentials, microphone access, or live writes; README or testing docs link to the CI contract.
+   Smallest useful validation: `git diff --check .github/workflows/safe-validation.yml docs/TESTING_FOR_AGENTS.md` plus `INBOX_TEST_MODE=1 uv run pytest tests/test_inbox_test_mode.py -q` in an environment with dependencies available.
+
+3. Align factory validation commands with the safe-test policy.
+   Owned files: `.factory/services.yaml`, `.factory/library/architecture-hardening.md`, `docs/TESTING_FOR_AGENTS.md`.
+   Acceptance criteria: `.factory/services.yaml` has distinct commands for safe smoke, default repo test, full test including audio/LLM, typecheck, and lint; skipped audio/LLM coverage is explicitly named rather than hidden; worktree service start commands do not hardcode the daily-driver checkout.
+   Smallest useful validation: `python -c "import yaml, pathlib; print(yaml.safe_load(pathlib.Path('.factory/services.yaml').read_text())['commands'].keys())"` or an equivalent repo-available YAML parse, then `git diff --check .factory/services.yaml docs/TESTING_FOR_AGENTS.md`.
+
+4. Add MCP mutation-surface regression tests.
+   Owned files: `tools_registry.py`, `tests/test_tools_registry.py`, `tests/test_mcp_gateway.py`, `tests/test_mcp_readonly.py` if created.
+   Acceptance criteria: every non-readonly registry tool is confirmation-gated; readonly MCP registration excludes all non-readonly tools; sensitive "read-only" tools are enumerated in tests so new personal-data read surfaces are intentional; full MCP memory and note write tools still require confirmation.
+   Smallest useful validation: `INBOX_TEST_MODE=1 uv run pytest tests/test_tools_registry.py tests/test_mcp_gateway.py -q`.
+
+5. Revisit Reminders mutation targeting or document the accepted limit at the API boundary.
+   Owned files: `services.py`, `tests/test_reminders.py`, `CLAUDE.md`, `docs/TESTING_FOR_AGENTS.md` if new opt-in validation is needed.
+   Acceptance criteria: duplicate-title same-list reminder mutations either fail with an explicit ambiguity error before AppleScript execution or have a documented EventKit-backed design issue; tests cover duplicate incomplete reminders with identical titles in one list; public API docs describe the behavior.
+   Smallest useful validation: `INBOX_TEST_MODE=1 uv run pytest tests/test_reminders.py -q`.
+
+## Handoff
+
+Changed files: `docs/overnight/2026-05-07-whole-portfolio-review/inbox-sym-118-risk-and-validation-review.md`.
+Commit SHA: no commit created; current HEAD is `2805b8400519da188ca7d3f6e39b19a8ca42b05a`.
+PR URL: none; external pushes and PR creation are out of scope for this worker.
+Blockers: missing queue `ISSUE.md`; safe pytest smoke blocked by sandbox cache permissions without `UV_CACHE_DIR` and then by restricted network while resolving `hf-xet`.

--- a/docs/overnight/2026-05-07-whole-portfolio-review/inbox-sym-119-implementation-readiness.md
+++ b/docs/overnight/2026-05-07-whole-portfolio-review/inbox-sym-119-implementation-readiness.md
@@ -1,0 +1,192 @@
+# inbox-sym-119 Implementation Readiness Review
+
+Date: 2026-05-07
+Branch: `codex/goal-inbox-sym-119-implementation-readiness`
+Queue item: `inbox-sym-119-implementation-readiness`
+Scope: read-only review and queue prep; no product code edits.
+
+## Summary
+
+`inbox-sym-119` is ready for several tightly scoped implementation slices around indexed inbox views, MCP tool coverage, scheduler safety, and validation hygiene. The repo has strong local evidence for the indexed read model and Google account policy direction, but implementation work should avoid live-provider validation by default because the project touches personal data, macOS local stores, OAuth tokens, and write-capable services.
+
+No previous overnight `runs/*/result.json`, `runs/*/handoff.md`, `items/*/ISSUE.md`, or `docs/overnight/*` artifacts were present in this worktree. The review therefore uses repo-local docs, tests, scripts, package metadata, and current git state only.
+
+## Concrete File Observations
+
+1. `PLAN.md` defines the current product target as an indexed local inbox with `items`, `threads`, and `sync_state`, and explicitly says bootstrap/incremental sync hardening must come before expanding the TUI surface.
+2. `README.md` says Python 3.10+ in Quick Start, while `pyproject.toml` requires `>=3.12,<3.15`; onboarding docs are stale relative to package metadata.
+3. `pyproject.toml` defines the default pytest run as `--cov=. --cov-report=term-missing` and registers `safe`, `integration`, `local_data`, `slow`, and `live_write` markers.
+4. `docs/TESTING_FOR_AGENTS.md` establishes the safe validation loop as `INBOX_TEST_MODE=1 uv run pytest -m safe`, `uv run ruff check .`, and `uv run pyright`.
+5. `tests/test_inbox_test_mode.py` and `tests/test_mcp_gateway.py` are the only files currently marked with `pytestmark = pytest.mark.safe`; most deterministic unit coverage is not included in the documented safe loop.
+6. `.pre-commit-config.yaml` runs Ruff with `--fix`, Ruff format, basic pre-commit hooks, and Bandit, but there is no `.github/**` workflow file in this worktree.
+7. `message_index_store.py` owns the SQLite operational index schema, including `sync_state`, `items`, `threads`, and `sender_stats`, plus filtered `list_threads()` support for actionable, waiting-on, recent, needs-reply, and sender-scoped views.
+8. `message_sync.py` has resumable Gmail bootstrap state, Gmail history-cursor incremental sync, timestamp fallback, iMessage rowid checkpoints, and scoped thread rebuilds after changed-source syncs.
+9. `tests/test_message_sync.py` covers resumable Gmail bootstrap, history cursor persistence, timestamp fallback, iMessage skipped-row checkpoint advancement, and scoped rebuild behavior.
+10. `tests/test_message_index_store.py` covers idempotent upserts/rebuilds, high-volume thread rebuilds, sender-frequency classification, waiting-on/recent filters, and latest-sender filtering.
+11. `inbox_server.py` exposes `/index/status`, `/index/health`, `/index/views/{view_name}`, `/index/sync/bootstrap`, and `/index/sync/incremental`; `tests/test_server.py` covers index health states and index-view routing.
+12. `inbox.py` already renders `Now`, `Actionable`, and `Waiting On` tabs from compact index views, but it refreshes `recent`, `actionable`, and `waiting-on` without also using `index_health()` for stale-index warnings.
+13. `google_account_resolution.py` centralizes default Google account selection through `INBOX_DEFAULT_GOOGLE_ACCOUNT` and powers `/preflight/google-write`; this means roadmap account-policy work has partially landed.
+14. `CONNECTOR_ROADMAP.md` still lists preflight and source-of-truth routing as future milestones even though `google_account_resolution.py` and `inbox_server.py` now implement part of that surface; future work should audit the remaining gaps, not rebuild the whole layer.
+15. `tools_registry.py` centrally registers MCP tools and confirms all mutating tools require `confirm=True`, but it does not expose read-only indexed inbox views such as `/index/views/actionable`, `/index/views/recent`, or `/index/health`.
+16. `scheduler.py` persists scheduled messages, follow-up reminders, and task-message links, while `inbox_server.py` exposes `/scheduled`, `/followups`, `/tasks/links`, and `/tasks/from-message`; `rg` found no scheduler-specific tests under `tests/`.
+17. `mcp_gateway.py` has public bearer-token middleware and health payloads, and `tests/test_mcp_gateway.py` covers token rejection, health access, memory DB configuration, and backend health error reporting.
+18. `scripts/setup_inbox_mcp.sh`, `config/inbox.env.example`, and `deploy/inbox-mcp.service.example` provide local service bootstrap surfaces, but they are manual local/deploy scaffolds rather than CI validation.
+
+## Validation Commands
+
+Required queue validation:
+
+```bash
+git status --short
+```
+
+Agent-safe baseline from repo docs:
+
+```bash
+INBOX_TEST_MODE=1 uv run pytest -m safe
+uv run ruff check .
+uv run pyright
+```
+
+Useful focused validation for the ready implementation areas:
+
+```bash
+INBOX_TEST_MODE=1 uv run pytest tests/test_message_sync.py tests/test_message_index_store.py -q
+INBOX_TEST_MODE=1 uv run pytest tests/test_server.py -q -k "IndexEndpoints or preflight or needs_action"
+INBOX_TEST_MODE=1 uv run pytest tests/test_client.py tests/test_tools_registry.py tests/test_mcp_gateway.py -q
+INBOX_TEST_MODE=1 uv run pytest tests/test_inbox_test_mode.py -q
+```
+
+Do not run live provider, local-data, or live-write tests unless explicitly requested:
+
+```bash
+INBOX_TEST_MODE=1 uv run pytest -m "not local_data and not live_write"
+```
+
+## Risks And Blockers
+
+- No CI workflow was present in this worktree, so there is no repo-local evidence that the safe suite, lint, type check, or pre-commit hooks run automatically on PRs.
+- The documented `pytest -m safe` loop currently covers only a small slice of deterministic tests; many implementation-ready paths are tested but not safely discoverable by agents.
+- The repo intentionally integrates with Gmail, Calendar, Drive, Docs, Sheets, Tasks, iMessage, Notes, Reminders, GitHub, microphone input, notifications, and local SQLite stores; live validation requires human approval and credentials.
+- `README.md` and `DOCS_INDEX.md` contain stale claims relative to current package metadata and test layout, including Python version mismatch and a fixed "736 tests pass" claim.
+- Scheduler behavior is write-capable and background-loop driven, but its persistence and server endpoints do not have dedicated local tests visible under `tests/`.
+- MCP registry coverage is strong for confirmation gating, but read-only high-signal index views are absent from the tool registry, so agents may keep using raw provider reads where compact index reads already exist.
+- Prior overnight runner artifacts were not available locally, so this pass cannot reconcile against earlier generated claims for this queue item.
+
+## Implementation-Ready Follow-Up Tasks
+
+### 1. Expand the agent-safe test lane for deterministic index coverage
+
+Owned files:
+- `tests/test_index_views_safe.py` or `tests/test_server.py`
+- `tests/test_client.py`
+- `docs/TESTING_FOR_AGENTS.md`
+
+Acceptance criteria:
+- Add safe-marked tests for `/index/health`, `/index/views/recent`, `/index/views/actionable`, `/index/views/waiting-on`, and `InboxClient.index_view()`.
+- The safe lane proves compact indexed read paths without touching live Gmail, iMessage, local personal DBs, or external writes.
+- `docs/TESTING_FOR_AGENTS.md` names the expanded safe coverage.
+
+Smallest useful validation:
+
+```bash
+INBOX_TEST_MODE=1 uv run pytest -m safe -q
+```
+
+### 2. Add scheduler persistence and endpoint tests before more background-loop work
+
+Owned files:
+- `tests/test_scheduler.py`
+- `tests/test_server.py`
+- `scheduler.py` only if tests expose a correctness bug
+
+Acceptance criteria:
+- Cover scheduling, cancellation, due-message lookup, follow-up creation/cancellation, due-followup lookup, task-message link creation, message lookup, task lookup, and unlink behavior using a temp SQLite DB.
+- Cover `/scheduled`, `/followups`, `/tasks/links`, and `/tasks/from-message` routing with fake server state and no live provider writes.
+- Preserve current confirmation-gated MCP exposure for scheduled/follow-up write tools.
+
+Smallest useful validation:
+
+```bash
+INBOX_TEST_MODE=1 uv run pytest tests/test_scheduler.py tests/test_server.py -q -k "scheduled or followup or task_link or from_message"
+```
+
+### 3. Expose compact indexed inbox views through the MCP tool registry
+
+Owned files:
+- `tools_registry.py`
+- `mcp_backend.py`
+- `tests/test_tools_registry.py`
+- `tests/test_mcp_gateway.py`
+
+Acceptance criteria:
+- Add read-only MCP tools for index health and index views, such as `get_index_health` and `list_index_view`.
+- Ensure `readonly_only=True` registration includes these tools.
+- Ensure generated handler path/query encoding still passes existing registry tests.
+- Do not add any write-capable index sync tools to the public read-only MCP surface unless separately confirmed.
+
+Smallest useful validation:
+
+```bash
+INBOX_TEST_MODE=1 uv run pytest tests/test_tools_registry.py tests/test_mcp_gateway.py -q
+```
+
+### 4. Make Gmail follow-up reply detection account-aware
+
+Owned files:
+- `scheduler.py`
+- `inbox_server.py`
+- `tests/test_scheduler.py`
+- `tests/test_server.py`
+
+Acceptance criteria:
+- Store or otherwise resolve the owning Gmail account for follow-up reminders.
+- `_process_followup_reminders()` must check the Gmail thread using the follow-up's owning account instead of `next(iter(state.gmail_services))`.
+- Existing imessage follow-up behavior remains unchanged.
+- Add a regression test with two fake Gmail accounts where only the owning account has the reply.
+
+Smallest useful validation:
+
+```bash
+INBOX_TEST_MODE=1 uv run pytest tests/test_scheduler.py tests/test_server.py -q -k "followup"
+```
+
+### 5. Surface index freshness in the TUI refresh path
+
+Owned files:
+- `inbox.py`
+- `inbox_client.py` only if a helper adjustment is needed
+- `tests/test_inbox_app.py`
+- `tests/test_client.py`
+
+Acceptance criteria:
+- During TUI auxiliary refresh, call `index_health()` alongside index views.
+- If index health is unhealthy or stale, show a compact sidebar/status warning without falling back to raw provider thread fetches.
+- Existing Now, Actionable, and Waiting On rendering remains index-backed.
+- Tests cover healthy, stale, and error index-health payloads with mocked client responses.
+
+Smallest useful validation:
+
+```bash
+INBOX_TEST_MODE=1 uv run pytest tests/test_inbox_app.py tests/test_client.py -q -k "index"
+```
+
+## Suggested Execution Order
+
+1. Expand safe deterministic validation for index paths.
+2. Add scheduler tests, because scheduler work is write-capable and undercovered.
+3. Add read-only MCP index tools so agents consume compact indexed views.
+4. Fix account-aware follow-up detection after tests pin the scheduler behavior.
+5. Surface index freshness in the TUI once the safe index lane is trustworthy.
+
+## Review Evidence Commands Run
+
+```bash
+llm-tldr tree .
+git status --short --branch
+git log --oneline -5
+rg --files -g .github/** -g Makefile -g tox.ini -g pytest.ini -g .pre-commit-config.yaml -g requirements*.txt -g Dockerfile* -g compose*.yml -g *.yml -g *.yaml -g *.toml .
+fd -H 'result.json|handoff.md|overnight|ISSUE.md' .
+rg -n "pytest.mark|@pytest.mark" tests
+rg -n "SchedulerStore|scheduled_messages|create_followup|list_followups|schedule_message" tests
+```

--- a/docs/overnight/2026-05-07-whole-portfolio-review/inbox-sym-119-risk-and-validation-review.md
+++ b/docs/overnight/2026-05-07-whole-portfolio-review/inbox-sym-119-risk-and-validation-review.md
@@ -1,0 +1,168 @@
+# inbox-sym-119 risk and validation review
+
+Date: 2026-05-07
+Branch: `codex/goal-inbox-sym-119-risk-and-validation-review`
+Base HEAD observed: `2805b84 Merge pull request #34 from jwalin-shah/codex/SYM-9-indexed-defaults`
+Review type: `risk-and-validation-review`
+
+## Scope and commands
+
+This review stayed inside this repo and did not edit product code. The only intended change is this report.
+
+Evidence commands run:
+- `llm-tldr tree .`
+- `git status --short --branch`
+- `git log -1 --oneline`
+- `rg --files docs`
+- `rg --files . | rg '^\.github/'`
+- `rg --files . | rg '^runs/'`
+- `rg --files . | rg '^docs/overnight/'`
+- `rg -n "pytestmark = pytest.mark.safe|@pytest.mark.safe|@pytest.mark.live_write|@pytest.mark.local_data|@pytest.mark.integration|@pytest.mark.slow" tests pyproject.toml docs/TESTING_FOR_AGENTS.md`
+- `rg -n "def drive_upload|def sheets_format|def sheets_rename|def sheets_copy|def docs_.*text|def docs_append|def docs_insert|def docs_create|def docs_delete|def drive_create_folder|def drive_delete|def sheets_add_sheet|def sheets_delete_sheet" services.py`
+- `UV_CACHE_DIR=/tmp/uv-cache INBOX_TEST_MODE=1 uv run pytest -m safe --collect-only -q`
+
+Queue validation command:
+- `git status --short`
+
+The safe pytest collection could not run in this sandbox because `uv` needed to download `rpds-py==0.30.0` and DNS/network access is unavailable. Running without `UV_CACHE_DIR=/tmp/uv-cache` also hit a sandbox permission error on `~/.cache/uv`; the service scripts already set `UV_CACHE_DIR` to `/tmp/uv-cache`, but `dev.sh` and docs commands do not.
+
+## Concrete observations
+
+1. `pyproject.toml:5` requires Python `>=3.12,<3.15`, and `.python-version:1` pins `3.12`; `README.md:32` still says Python 3.10+, so setup guidance can create an unsupported environment.
+
+2. `docs/TESTING_FOR_AGENTS.md:10-12` defines the agent-safe loop as `INBOX_TEST_MODE=1 uv run pytest -m safe`, `uv run ruff check .`, and `uv run pyright`; `pyproject.toml:54-61` registers markers and adds coverage to every pytest run.
+
+3. Only `tests/test_inbox_test_mode.py:8` and `tests/test_mcp_gateway.py:18` set `pytestmark = pytest.mark.safe`, based on repo search. Most service/server tests are unmarked, so `pytest -m safe` exercises only a small slice of the actual risk surface.
+
+4. `inbox_test_mode.py:22-24` blocks live writes by raising `LiveWriteBlocked` when `INBOX_TEST_MODE` is enabled. `services.py:114-119` centralizes the service-side wrapper, and many write helpers call it.
+
+5. Several external write helpers do not call the test-mode guard: `services.py:1769-1781` creates Gmail labels, `services.py:3864-3909` uploads files to Drive, `services.py:4315-4338` renames Sheets tabs, `services.py:4341-4355` sends raw Sheets `batchUpdate` formatting requests, `services.py:4358-4388` copies Sheets tabs, and `services.py:4476-4495` inserts text into Docs.
+
+6. The HTTP endpoints route directly to those unguarded helpers: `inbox_server.py:2548-2574` handles `/drive/upload`, `inbox_server.py:2732-2758` handles Sheets tab rename/copy/format, `inbox_server.py:2978-2983` handles Docs text insertion, and `inbox_server.py:3586-3594` handles Gmail label creation.
+
+7. `tests/test_services.py:909-951` already tests representative live-write blocking, but its coverage stops at `drive_create_folder`, `sheets_values_update`, and `docs_create`; it does not cover the missing-guard helpers above. `tests/test_drive.py:84-106` tests `drive_upload` success without checking `INBOX_TEST_MODE`.
+
+8. `google_account_resolution.py:24-33` implements `INBOX_DEFAULT_GOOGLE_ACCOUNT` fallback, and `google_account_resolution.py:109-146` applies it to Sheets, Drive, Tasks, Docs, and Calendar service selection. Tests such as `tests/test_server.py:612-657` verify default account selection for calendar writes.
+
+9. `CONNECTOR_ROADMAP.md:34-44` says Google writes should default to `jshah1331@gmail.com`, writes to other accounts must be explicit, and returned Google objects should include `owning_account`; `CONNECTOR_ROADMAP.md:231-240` also calls for preflight validation of destination, naming, and sharing.
+
+10. The current preflight endpoint exists at `inbox_server.py:3009-3020`, backed by `google_account_resolution.py:160-238`, but its kind coverage is narrower than the write surface: docs, sheets, drive folders, tasks, and calendar events are modeled; uploads, Gmail labels, Sheets format/rename/copy, and Docs text mutation are not.
+
+11. `inbox_server.py:1313-1340` protects the FastAPI backend with `INBOX_SERVER_TOKEN`, accepting Bearer and `X-API-Key`; `tests/test_server.py:376-410` covers missing, Bearer, and `X-API-Key` cases.
+
+12. `mcp_gateway.py:32-58` protects public MCP routes with `INBOX_MCP_TOKEN` while allowing `/health`; `mcp_backend.py:19-27` forwards `INBOX_SERVER_TOKEN` to the backend. `tests/test_mcp_gateway.py:36-53` covers the public gateway auth path.
+
+13. `scripts/run_inbox_backend.sh:7-9` and the MCP run scripts set `UV_CACHE_DIR=/tmp/uv-cache` before `uv run`, but `dev.sh:7-11` sets only port and URL before `uv run`. The docs commands in `README.md:155-157` and `docs/TESTING_FOR_AGENTS.md:10-12` omit the cache override.
+
+14. No `.github/` workflow files are present in the worktree. `.pre-commit-config.yaml:1-23` provides local ruff, formatting, basic hooks, and bandit, but there is no checked-in CI evidence for the validation loop.
+
+15. `SHEETS_CHANGELOG.md:38` and `SHEETS_CHANGELOG.md:114` claim "All 736 tests pass", but this review could not reproduce any pytest collection because dependency sync requires network access from a fresh sandbox.
+
+16. `config/inbox.env.example:1-6` separates `INBOX_SERVER_TOKEN` and `INBOX_MCP_TOKEN`, which matches the backend/gateway split, but missing env propagation remains a known runtime risk because the MCP backend silently sends no Authorization header when `INBOX_SERVER_TOKEN` is unset.
+
+## Key risks and blockers
+
+Risk 1: Test mode is incomplete for live external writes.
+
+The highest-impact finding is that several Google/Gmail/Drive/Docs/Sheets mutation helpers bypass `_assert_live_write_allowed`. This can let agent-safe tests or local probes touch real external resources if they call `drive_upload`, `gmail_label_create`, `sheets_rename_sheet`, `sheets_format`, `sheets_copy_to`, or `docs_insert_text` while live credentials are present.
+
+Risk 2: The documented safe pytest loop is too narrow.
+
+Only two test files are marked `safe`, so the default agent-safe command does not cover most server/service behavior. This creates false confidence, especially around personal-data integrations.
+
+Risk 3: Fresh sandbox validation is blocked by dependency download and cache defaults.
+
+`UV_CACHE_DIR=/tmp/uv-cache INBOX_TEST_MODE=1 uv run pytest -m safe --collect-only -q` failed because the environment cannot resolve PyPI. Running without `UV_CACHE_DIR` failed earlier due `~/.cache/uv` sandbox permissions. The run scripts mitigate this for services, but docs/dev commands do not.
+
+Risk 4: Preflight exists but does not cover the full write surface.
+
+`/preflight/google-write` models only a subset of write kinds. Raw Sheets formatting is explicitly documented as a flexible write surface, but it currently has neither test-mode guard nor preflight kind.
+
+Risk 5: No CI workflow is checked in.
+
+Local pre-commit exists, but there is no repository CI file proving ruff, pyright, and the safe pytest suite run outside a developer machine.
+
+## Implementation-ready follow-up tasks
+
+### 1. Close live-write guard gaps in service helpers
+
+Owned files:
+- `services.py`
+- `tests/test_services.py`
+
+Acceptance criteria:
+- `gmail_label_create`, `drive_upload`, `sheets_rename_sheet`, `sheets_format`, `sheets_copy_to`, and `docs_insert_text` call `_assert_live_write_allowed(...)` before touching provider service objects.
+- Add tests using `_WriteShouldNotRun` with `INBOX_TEST_MODE=1` that prove each helper raises `LiveWriteBlocked` before service access.
+- Existing representative live-write tests still pass.
+
+Smallest validation:
+- `UV_CACHE_DIR=/tmp/uv-cache INBOX_TEST_MODE=1 uv run pytest tests/test_services.py::test_test_mode_blocks_extended_live_writes -q`
+
+### 2. Make the safe marker set match the documented agent-safe loop
+
+Owned files:
+- `tests/test_services.py`
+- `tests/test_server.py`
+- `tests/test_gmail_actions.py`
+- `tests/test_drive.py`
+- `docs/TESTING_FOR_AGENTS.md`
+
+Acceptance criteria:
+- Mark deterministic, mocked tests for test-mode guards, auth middleware, account routing, and mocked Google write endpoints as `safe`.
+- Do not mark local-data, live-write, microphone, OAuth, or provider-backed integration tests as `safe`.
+- `pytest -m safe --collect-only -q` collects the guard/auth/account-routing tests, not only `test_inbox_test_mode.py` and `test_mcp_gateway.py`.
+
+Smallest validation:
+- `UV_CACHE_DIR=/tmp/uv-cache INBOX_TEST_MODE=1 uv run pytest -m safe --collect-only -q`
+
+### 3. Standardize sandbox-safe uv cache usage
+
+Owned files:
+- `dev.sh`
+- `docs/TESTING_FOR_AGENTS.md`
+- `README.md`
+- `CLAUDE.md`
+
+Acceptance criteria:
+- `dev.sh` exports `UV_CACHE_DIR="${UV_CACHE_DIR:-/tmp/uv-cache}"`, matching `scripts/run_inbox_backend.sh`.
+- Agent testing docs and README validation commands either set `UV_CACHE_DIR=/tmp/uv-cache` inline or explain the requirement for sandboxed agents.
+- README Python requirement is aligned with `pyproject.toml` and `.python-version`.
+
+Smallest validation:
+- `UV_CACHE_DIR=/tmp/uv-cache uv run python --version`
+- `rg -n "Python 3.10|UV_CACHE_DIR" README.md docs/TESTING_FOR_AGENTS.md CLAUDE.md dev.sh`
+
+### 4. Expand write preflight to the missing mutation kinds
+
+Owned files:
+- `google_account_resolution.py`
+- `inbox_server.py`
+- `tests/test_server.py`
+
+Acceptance criteria:
+- `/preflight/google-write` supports explicit kinds for `drive_upload`, `gmail_label`, `sheet_format`, `sheet_tab_rename`, `sheet_tab_copy`, and `doc_text_insert`.
+- Each new kind resolves the same account that the matching endpoint will use.
+- Tests cover valid and invalid destination/account cases where applicable.
+
+Smallest validation:
+- `UV_CACHE_DIR=/tmp/uv-cache INBOX_TEST_MODE=1 uv run pytest tests/test_server.py -k "Preflight or default_account" -q`
+
+### 5. Add repository CI for the agent-safe loop
+
+Owned files:
+- `.github/workflows/ci.yml`
+- `docs/TESTING_FOR_AGENTS.md`
+
+Acceptance criteria:
+- CI installs with `uv` on Python 3.12.
+- CI runs `uv run ruff check .`, `uv run pyright`, and `INBOX_TEST_MODE=1 uv run pytest -m safe`.
+- CI sets `INBOX_TEST_MODE=1`, avoids live credentials, and does not require macOS-only personal data stores for the safe suite.
+
+Smallest validation:
+- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check .`
+- `UV_CACHE_DIR=/tmp/uv-cache uv run pyright`
+- `UV_CACHE_DIR=/tmp/uv-cache INBOX_TEST_MODE=1 uv run pytest -m safe -q`
+
+## Handoff notes
+
+No external services were called intentionally, no tracker was updated, no PR was created, and no product code was edited. The only blocker encountered was local validation dependency resolution in a network-restricted sandbox.

--- a/docs/overnight/2026-05-07-whole-portfolio-review/inbox-sym-120-implementation-readiness.md
+++ b/docs/overnight/2026-05-07-whole-portfolio-review/inbox-sym-120-implementation-readiness.md
@@ -1,0 +1,359 @@
+# inbox-sym-120 implementation-readiness review
+
+Queue item: `inbox-sym-120-implementation-readiness`
+Branch: `codex/goal-inbox-sym-120-implementation-readiness`
+Reviewed HEAD: `2805b8400519da188ca7d3f6e39b19a8ca42b05a`
+Date: 2026-05-07
+
+## Scope
+
+This is a repo-local implementation-readiness pass. I did not touch product code,
+call external services, inspect live personal data stores, push branches, open
+PRs, or update trackers.
+
+Previous overnight artifacts were not present in this worktree. `rg --files -g
+'.github/**' -g 'docs/**' -g 'runs/**' -g '*handoff*' -g 'items/**'` returned
+only `docs/TESTING_FOR_AGENTS.md` from those requested artifact classes, so this
+report is based on the current repo docs, code, tests, scripts, config, and git
+state.
+
+## Repo observations
+
+1. `PLAN.md:71` says `message_index_store.py` and `message_sync.py` already
+   exist, and `PLAN.md:75` names the remaining Phase 1 risk: bootstrap sync is
+   not hardened enough and incremental sync needs stronger checkpoints.
+
+2. `PLAN.md:102` through `PLAN.md:122` define Milestone 1 around resumable
+   bootstrap, incremental checkpoints, deterministic `items` / `threads` /
+   `sync_state` upserts, and an API sync-health surface. This is already a good
+   source for issue acceptance criteria.
+
+3. `message_index_store.py:86` through `message_index_store.py:167` creates the
+   local operational index tables: `sync_state`, `items`, `threads`, and
+   `sender_stats`. The schema is explicit enough for focused data-model tests.
+
+4. `message_index_store.py:239` through `message_index_store.py:356` implements
+   sync-state writes, running/error status, metadata, and state listing. This
+   makes index freshness work implementation-ready without adding a new store.
+
+5. `message_index_store.py:407` through `message_index_store.py:563` rebuilds
+   thread summaries and classifications from indexed items. It also deletes
+   stale thread rows within the requested source/account scope, so future sync
+   work should preserve these scope guarantees.
+
+6. `message_index_store.py:565` through `message_index_store.py:612` supports
+   `actionable_only`, `needs_reply`, `has_open_loop`, `latest_sender`, and
+   `sort_mode`. The current `newest_only` filter is hard-coded to seven days,
+   which is simple but should be tested as product behavior before more views
+   depend on it.
+
+7. `message_sync.py:181` through `message_sync.py:268` implements Gmail
+   bootstrap with saved page tokens, timestamp checkpoints, and optional Gmail
+   history cursor recording. The resume behavior is already covered by
+   `tests/test_message_sync.py:143` through `tests/test_message_sync.py:201`.
+
+8. `message_sync.py:272` through `message_sync.py:449` implements Gmail
+   incremental sync through Gmail history when possible and timestamp fallback
+   otherwise. `tests/test_message_sync.py:312` through
+   `tests/test_message_sync.py:416` cover changed-message history sync and
+   missing-history fallback.
+
+9. `message_sync.py:498` through `message_sync.py:582` implements iMessage
+   bootstrap and incremental sync with rowid checkpoints. `tests/test_message_sync.py:418`
+   through `tests/test_message_sync.py:497` cover checkpoint advancement when
+   rows are skipped because they have no useful body.
+
+10. `message_sync.py:602` through `message_sync.py:627` rebuilds only changed
+    source/account scopes after bootstrap or incremental sync. The focused
+    regression tests at `tests/test_message_sync.py:499` through
+    `tests/test_message_sync.py:649` make this safe to extend.
+
+11. `thread_classifier.py:58` through `thread_classifier.py:130` is a compact
+    heuristic classifier for human score, noise class, topic, urgency, and
+    actionability. Existing tests in `tests/test_message_index_store.py:66`
+    through `tests/test_message_index_store.py:230` cover human replies, OTP,
+    frequent senders, and automated senders, but the fixture set is still thin
+    for appointment, health-admin, receipt, security, and newsletter cases.
+
+12. `inbox_server.py:565` through `inbox_server.py:624` defines response models
+    that explicitly mark indexed read models as `read_model="index"` and
+    `raw_provider_fetch=False`. This gives downstream clients a contract to
+    assert against.
+
+13. `inbox_server.py:2771` through `inbox_server.py:2807` routes named index
+    views for `actionable`, `recent`, `waiting-on-me`, `waiting-on-others`, and
+    `waiting-on`. `tests/test_server.py:276` through `tests/test_server.py:368`
+    verify these routes call the index store with the intended filters.
+
+14. `inbox_server.py:3739` through `inbox_server.py:3802` makes
+    `/inbox/needs-action` prefer indexed threads and avoid Gmail provider
+    fallback, but it still fetches live tasks and calendar events and silently
+    drops task/calendar exceptions at `inbox_server.py:3773` and
+    `inbox_server.py:3792`.
+
+15. `tests/test_server.py:1816` through `tests/test_server.py:1936` verify that
+    `/inbox/needs-action` returns index metadata and does not call live Gmail
+    search even when the index is empty. This is a strong starting point for
+    safe issue work around the Now view.
+
+16. `inbox_client.py:86` through `inbox_client.py:131` already has client
+    helpers for index threads, status, health, and indexed views. `inbox.py:2333`
+    through `inbox.py:2349` fetches the `recent`, `actionable`, and `waiting-on`
+    views for the TUI, but the TUI does not appear to surface `index_health()`
+    yet.
+
+17. `tui_tabs.py:19` through `tui_tabs.py:49` defines first-class `Now`,
+    `Actionable`, and `Waiting On` tabs. `inbox.py:1702` through `inbox.py:1723`
+    renders these tabs from indexed thread lists rather than raw provider
+    conversations.
+
+18. `tools_registry.py:126` through `tools_registry.py:173` starts the MCP tool
+    registry with raw Gmail list/search and reply tools. There are no index
+    status or index-view tools in the registry yet, so assistant-facing MCP usage
+    can still default to raw provider reads even though the TUI and REST client
+    have index-first surfaces.
+
+19. `tests/test_api_contract.py:75` through `tests/test_api_contract.py:88`
+    asserts that every MCP tool registry path exists on FastAPI, and
+    `tests/test_api_contract.py:91` through `tests/test_api_contract.py:122`
+    assert client/server shape for index status and health. This makes adding
+    MCP index tools straightforward and testable.
+
+20. `docs/TESTING_FOR_AGENTS.md:8` through `docs/TESTING_FOR_AGENTS.md:19`
+    define the intended safe loop: `INBOX_TEST_MODE=1 uv run pytest -m safe`,
+    `uv run ruff check .`, and `uv run pyright`. However, `rg` found
+    `pytestmark = pytest.mark.safe` only in `tests/test_inbox_test_mode.py` and
+    `tests/test_mcp_gateway.py`, so the documented safe suite is probably much
+    narrower than the deterministic tests currently available.
+
+21. `tests/conftest.py:15` through `tests/conftest.py:35` stubs ML and hardware
+    modules such as `mlx_lm`, `mlx_whisper`, `sounddevice`, `outlines`, and
+    `Quartz`, which should let many more tests run safely under
+    `INBOX_TEST_MODE=1`.
+
+22. `inbox_test_mode.py:18` through `inbox_test_mode.py:31` blocks live writes
+    and redirects test data paths, while `services.py` calls `_assert_live_write_allowed`
+    across Gmail, Calendar, Reminders, Tasks, Drive, Sheets, Docs, GitHub,
+    notifications, and WhatsApp write paths. The safety hooks are broad enough
+    to support a larger safe validation lane.
+
+23. `pyproject.toml:54` through `pyproject.toml:62` configures pytest coverage
+    and markers, but `.pre-commit-config.yaml:1` through `.pre-commit-config.yaml:23`
+    only runs Ruff formatting/linting and Bandit. There is no `.github/`
+    workflow in this worktree, so CI readiness cannot be verified from repo
+    config.
+
+24. `README.md:30` states Python 3.10+ as a requirement, while
+    `pyproject.toml:4` requires `>=3.12,<3.15`. `DOCS_INDEX.md:142` also claims
+    "All 736 tests pass" without tying that claim to a current validation run.
+
+25. `.gitignore:12` through `.gitignore:23` ignores credentials and token files,
+    and `.gitignore:34` through `.gitignore:58` ignores logs, local MCP memory,
+    scheduler DB, batch state, and `.inbox_index.sqlite3`. That is aligned with
+    the personal-data constraints in `docs/TESTING_FOR_AGENTS.md`.
+
+26. `dev.sh:1` through `dev.sh:11` runs worktree development on port 9850 by
+    default, and `scripts/run_inbox_backend.sh:1` through
+    `scripts/run_inbox_backend.sh:9` runs the backend with `UV_CACHE_DIR` in
+    `/tmp`. These scripts are useful validation surfaces for future agents but
+    were not executed during this read-only pass.
+
+## Risks and blockers
+
+- No previous `runs/*/result.json`, `runs/*/handoff.md`, or overnight report was
+  available in this worktree, so this pass could not reconcile runner outputs or
+  prior handoffs.
+
+- No `.github/` workflow was present. Local validation commands are documented,
+  but CI behavior is not repo-evident.
+
+- The documented safe pytest lane appears under-labeled. If agents run only
+  `INBOX_TEST_MODE=1 uv run pytest -m safe`, they may miss most deterministic
+  server, sync, index, and TUI regressions.
+
+- `/inbox/needs-action` reports index provenance for threads, but task/calendar
+  failures are swallowed silently. That can make the Now view look empty or
+  healthier than it is.
+
+- The MCP registry does not yet expose index-first read tools, so model-facing
+  usage can still pull raw Gmail/provider surfaces by default.
+
+- Thread intelligence is implementation-ready but still heuristic-heavy. Before
+  broader TUI or MCP workflows depend on it, the representative fixture set
+  should be expanded.
+
+- Docs contain stale or inconsistent claims: Python 3.10+ in `README.md` versus
+  Python 3.12+ in `pyproject.toml`, plus an unverified "736 tests pass" claim in
+  `DOCS_INDEX.md`.
+
+- Live-provider, local-data, external-write, and UI-browser validation were out
+  of scope for this queue item.
+
+## Validation commands
+
+Required queue validation:
+
+```bash
+git status --short
+```
+
+Agent-safe validation commands documented by the repo:
+
+```bash
+INBOX_TEST_MODE=1 uv run pytest -m safe
+uv run ruff check .
+uv run pyright
+```
+
+Focused commands that should be used by follow-up implementation issues:
+
+```bash
+INBOX_TEST_MODE=1 uv run pytest tests/test_message_sync.py tests/test_message_index_store.py -q
+INBOX_TEST_MODE=1 uv run pytest tests/test_server.py tests/test_api_contract.py -q
+INBOX_TEST_MODE=1 uv run pytest tests/test_inbox_app.py tests/test_tui_tabs.py -q
+INBOX_TEST_MODE=1 uv run pytest tests/test_inbox_test_mode.py tests/test_mcp_gateway.py -q
+```
+
+## Implementation-ready follow-up tasks
+
+### 1. Make the safe pytest lane representative
+
+Owned files:
+- `tests/test_api_contract.py`
+- `tests/test_server.py`
+- `tests/test_message_sync.py`
+- `tests/test_message_index_store.py`
+- `tests/test_inbox_app.py`
+- `tests/test_tui_tabs.py`
+- `docs/TESTING_FOR_AGENTS.md`
+
+Acceptance criteria:
+- Deterministic index, sync, server contract, and TUI unit tests are included in
+  `pytest -m safe`.
+- Tests that require live personal data, external writes, local macOS data, or
+  slow provider behavior remain excluded from `safe`.
+- The docs state what the safe suite covers and what remains opt-in.
+- `INBOX_TEST_MODE=1 uv run pytest -m safe --collect-only -q` shows the intended
+  expanded safe set.
+
+Smallest useful validation:
+
+```bash
+INBOX_TEST_MODE=1 uv run pytest -m safe --collect-only -q
+INBOX_TEST_MODE=1 uv run pytest -m safe -q
+```
+
+### 2. Add repo-local CI for non-live validation
+
+Owned files:
+- `.github/workflows/ci.yml`
+- `pyproject.toml`
+- `docs/TESTING_FOR_AGENTS.md`
+
+Acceptance criteria:
+- CI runs on pull requests and pushes without credentials or live personal data.
+- CI runs `uv run ruff check .`, `uv run pyright`, and
+  `INBOX_TEST_MODE=1 uv run pytest -m safe`.
+- CI sets `INBOX_TEST_MODE=1` and does not require macOS data stores, OAuth
+  tokens, microphones, or provider credentials.
+- The testing doc points agents at the same commands used by CI.
+
+Smallest useful validation:
+
+```bash
+uv run ruff check .
+uv run pyright
+INBOX_TEST_MODE=1 uv run pytest -m safe -q
+```
+
+### 3. Expose index-first read tools through MCP
+
+Owned files:
+- `tools_registry.py`
+- `tests/test_api_contract.py`
+- `tests/test_mcp_gateway.py`
+- `mcp_backend.py` if legacy backend methods are kept in sync
+
+Acceptance criteria:
+- Add readonly MCP tools for index status, index health, and named index views.
+- Tool responses preserve the REST contract: `read_model == "index"` and
+  `raw_provider_fetch is False`.
+- Indexed thread tools return compact summaries and do not expose `body_text`.
+- Existing raw Gmail tools remain available for drill-down, not the default
+  index-first path.
+
+Smallest useful validation:
+
+```bash
+INBOX_TEST_MODE=1 uv run pytest tests/test_api_contract.py tests/test_mcp_gateway.py -q
+```
+
+### 4. Surface index health in the TUI Now/Actionable/Waiting views
+
+Owned files:
+- `inbox.py`
+- `inbox_client.py`
+- `tests/test_inbox_app.py`
+- `tests/test_api_contract.py`
+
+Acceptance criteria:
+- The TUI calls `index_health()` during refresh or auxiliary-data collection.
+- If index health reports `no_sync_state`, `sync_error`, stale state, or missing
+  checkpoints, the status area surfaces that condition instead of showing a
+  silently empty indexed view.
+- Existing `Now`, `Actionable`, and `Waiting On` tab rendering continues to use
+  indexed views and does not fall back to live Gmail provider reads.
+- Tests cover healthy, stale, and no-sync-state health responses.
+
+Smallest useful validation:
+
+```bash
+INBOX_TEST_MODE=1 uv run pytest tests/test_inbox_app.py tests/test_api_contract.py -q
+```
+
+### 5. Expand thread-classification fixtures before adding more indexed workflows
+
+Owned files:
+- `thread_classifier.py`
+- `message_index_store.py`
+- `tests/test_message_index_store.py`
+- optional `tests/fixtures/thread_classifier_cases.py`
+
+Acceptance criteria:
+- Add representative deterministic cases for recruiter/opportunity,
+  appointment/health-admin, newsletter, receipt, OTP, security alert, human SMS,
+  and "latest sender is Me" waiting-on-others scenarios.
+- `reply`, `review`, and `track` threads appear in actionable views; `archive`
+  and `ignore` threads do not.
+- Frequent-sender promotion does not override automated/newsletter/receipt
+  noise classes.
+- Any classifier changes keep summaries compact enough for index-first TUI and
+  MCP usage.
+
+Smallest useful validation:
+
+```bash
+INBOX_TEST_MODE=1 uv run pytest tests/test_message_index_store.py -q
+```
+
+## Handoff
+
+Report written:
+- `docs/overnight/2026-05-07-whole-portfolio-review/inbox-sym-120-implementation-readiness.md`
+
+Product code changed:
+- None.
+
+External actions:
+- None. No deploys, pushes, PRs, tracker updates, live provider calls, or
+  destructive cleanup.
+
+Blockers:
+- No previous overnight run artifacts or CI config were available in this
+  worktree.
+- Broader tests were not run because the queue validation command is
+  `git status --short`.
+- Local staging/commit was blocked by the sandbox: `git add
+  docs/overnight/2026-05-07-whole-portfolio-review/inbox-sym-120-implementation-readiness.md`
+  failed because git could not create
+  `/Users/jwalinshah/projects/inbox/.git/worktrees/inbox-sym-120-implementation-readiness/index.lock`.

--- a/docs/overnight/2026-05-07-whole-portfolio-review/inbox-sym-120-risk-and-validation-review.md
+++ b/docs/overnight/2026-05-07-whole-portfolio-review/inbox-sym-120-risk-and-validation-review.md
@@ -1,0 +1,219 @@
+# inbox-sym-120 risk and validation review
+
+Queue item: `inbox-sym-120-risk-and-validation-review`
+Branch: `codex/goal-inbox-sym-120-risk-and-validation-review`
+Review date: 2026-05-07
+Review base: `2805b8400519da188ca7d3f6e39b19a8ca42b05a`
+
+## Scope
+
+This pass reviewed the repo-local docs, tests, scripts, config, generated validation output, recent git state, and validation surface for `inbox-sym-120`. It did not modify product code, call external services, push branches, create PRs, or update trackers.
+
+No prior report existed under `docs/overnight/2026-05-07-whole-portfolio-review/` at the start of this pass. The only existing `overnight` search hits were notification quiet-hours code/tests, not overnight review artifacts.
+
+## Current git state
+
+- Current branch: `codex/goal-inbox-sym-120-risk-and-validation-review`
+- Starting HEAD: `2805b8400519da188ca7d3f6e39b19a8ca42b05a`
+- Recent history shows the branch starts from merged index-default work: `2805b84 Merge pull request #34 from jwalin-shah/codex/SYM-9-indexed-defaults`.
+- `git status --short` was clean before this report was written.
+
+## Validation commands
+
+Required validation:
+
+```bash
+git status --short
+```
+
+Additional local validation attempted during review:
+
+```bash
+INBOX_TEST_MODE=1 uv run pytest --collect-only -q
+```
+
+Result: blocked before collection because `uv` attempted to initialize `/Users/jwalinshah/.cache/uv`, which is outside this worker sandbox.
+
+```bash
+UV_CACHE_DIR=/tmp/uv-cache INBOX_TEST_MODE=1 uv run pytest --collect-only -q
+```
+
+Result: blocked by restricted network while trying to download `googleapis-common-protos==1.74.0`. This created an ignored `.venv/` in the worktree but did not change tracked files.
+
+Repo-documented validation commands that should be used in an environment with dependencies available:
+
+```bash
+INBOX_TEST_MODE=1 uv run pytest -m safe
+uv run ruff check .
+uv run pyright
+uv run pytest -x -q
+```
+
+## File-path observations
+
+1. `pyproject.toml` declares `requires-python = ">=3.12,<3.15"`, while `README.md` still says the requirement is Python 3.10+. That is a stale setup claim that can send agents to the wrong interpreter.
+
+2. `docs/TESTING_FOR_AGENTS.md` defines the safe agent loop as `INBOX_TEST_MODE=1 uv run pytest -m safe`, `uv run ruff check .`, and `uv run pyright`, but only `tests/test_inbox_test_mode.py` and `tests/test_mcp_gateway.py` currently set `pytestmark = pytest.mark.safe`.
+
+3. `pyproject.toml` registers `safe`, `integration`, `local_data`, `slow`, and `live_write` markers, but the marker assignment coverage is much thinner than the total test tree under `tests/`, so `pytest -m safe` does not yet represent the repo's deterministic validation surface.
+
+4. `.factory/services.yaml` defines `test: uv run pytest --ignore=tests/test_audio.py --ignore=tests/test_llm.py -x -q`, while `test_all` is `uv run pytest -x -q`. Multiple generated validation summaries record full-suite passes, so the default factory command may now hide audio/LLM regressions.
+
+5. `.factory/validation/fix-broken-state/scrutiny/synthesis.json` records a pass but explicitly rejects, as already-documented, the observation that the default `.factory/services.yaml` test command skips `tests/test_audio.py` and `tests/test_llm.py`.
+
+6. `.factory/validation/architecture-hardening/scrutiny/synthesis.json` records a systemic setup issue: direct execution of `.factory/init.sh` failed with `Permission denied` in multiple reviews and required `bash .factory/init.sh`.
+
+7. `.factory/init.sh` and `.factory/services.yaml` hard-code `/Users/jwalinshah/projects/inbox`, which is risky for this whole-portfolio worktree pattern because validation can accidentally target the primary checkout instead of the isolated worktree.
+
+8. `deploy/com.inbox.backend.plist.example`, `deploy/com.inbox.mcp.plist.example`, `deploy/com.inbox.mcp-readonly.plist.example`, and the systemd examples also hard-code `/Users/jwalinshah/projects/inbox`. That is acceptable for personal deployment examples but risky if copied into worktree validation without editing.
+
+9. There is no `.github/` directory in this worktree, so CI/workflow validation is not repo-local. The only automated commit-time guard visible in the repo is `.pre-commit-config.yaml`.
+
+10. `.pre-commit-config.yaml` runs Ruff, Ruff format, generic hygiene hooks, private-key detection, and Bandit, but it does not run `pyright` or pytest. Type and test validation depend on manual commands or external automation not present in this repo.
+
+11. `services.py` has broad live-write guards through `_assert_live_write_allowed`, including Gmail, Calendar, Reminders, Google Tasks, Drive, Sheets, Docs, notifications, and GitHub notification mutations. `tests/test_inbox_test_mode.py` validates the helper and path redirection, but most broader write-surface tests are not marked `safe`.
+
+12. `inbox_server.py` makes API auth optional: if `INBOX_SERVER_TOKEN` is unset, `_is_authorized` returns true for all requests. This matches `README.md` and `CLAUDE.md`, but it means local security depends entirely on environment setup.
+
+13. `mcp_gateway.py` allows `/health` without `INBOX_MCP_TOKEN`, and if `INBOX_MCP_TOKEN` is unset, the public MCP middleware allows all paths. `MCP_SETUP.md` and `config/inbox.env.example` document the token, but a missing service env is a high-impact deployment misconfiguration.
+
+14. `tools_registry.py` centralizes MCP tool exposure and confirmation gates. `tests/test_tools_registry.py` checks that all mutating tools require `confirm=True` and that read-only registration excludes write tools. This is one of the strongest safety checks in the repo.
+
+15. `.factory/validation/reminders-tab/scrutiny/synthesis.json` still records a blocking risk for same-title duplicate Reminders: AppleScript selects the first reminder matching title and list. Current `services.py` confirms this path through `_applescript_find_reminder`, which uses `first reminder whose name is ...`.
+
+16. `inbox_server.py` exposes `/index/health` and flags `no_sync_state`, `missing_checkpoint`, `stale_checkpoint`, and `sync_error`, but `inbox.py` fetches indexed `recent`, `actionable`, and `waiting-on` views without querying or surfacing index health. A stale or empty index can therefore look like a quiet inbox in the TUI.
+
+17. Recent commit `a821b5a Make indexed inbox views the default` added indexed view behavior and tests in `inbox_server.py`, `inbox_client.py`, `message_index_store.py`, `tests/test_api_contract.py`, `tests/test_client.py`, `tests/test_message_index_store.py`, and `tests/test_server.py`. `README.md`, `CLAUDE.md`, and `DOCS_INDEX.md` do not document `/index/*` endpoints or index freshness operations.
+
+18. `message_index_store.py` now uses a temporary keep table during `rebuild_threads`, and `tests/test_message_index_store.py` covers 1100 threads to prevent expression-depth regressions. This addresses a recent scalability bug with a focused regression test.
+
+19. `google_account_resolution.py` implements `INBOX_DEFAULT_GOOGLE_ACCOUNT`, message-owner Gmail routing, and preflight payloads. Some endpoints still bypass the shared helpers: `inbox_server.py` falls back to the first Gmail service in `get_messages` when the cache misses, and `list_gmail_labels` also picks the first service directly.
+
+20. `CONNECTOR_ROADMAP.md` says Google objects should expose `owning_account`; `services.py` has `ThreadSummary.owning_account`, but several user-facing API shapes still expose `gmail_account` or per-type account fields rather than a single normalized ownership field.
+
+## Risk and blocker summary
+
+- Highest validation blocker: pytest collection cannot run in this sandbox unless dependencies are already cached. The first attempt failed on `~/.cache/uv` permissions; the second, with `UV_CACHE_DIR=/tmp/uv-cache`, failed on restricted network dependency download.
+- Highest runtime correctness risk: indexed TUI views can be stale or empty without surfacing `/index/health`.
+- Highest data-mutation risk: Reminders mutation semantics are not ID-stable for duplicate titles within the same list.
+- Highest account-routing risk: most Google write helpers use shared account resolution, but some Gmail read/label paths still use first-service fallback.
+- Highest process risk: no repo-local GitHub Actions config is present, and pre-commit does not cover pytest or pyright.
+- Highest documentation risk: setup/test claims have drifted from `pyproject.toml`, current test counts, and the newer index API surface.
+
+## Implementation-ready follow-up tasks
+
+### 1. Make agent validation runnable and explicit in isolated worktrees
+
+Owned files:
+- `docs/TESTING_FOR_AGENTS.md`
+- `.factory/services.yaml`
+- `.factory/init.sh`
+- Optional new helper: `scripts/validate_agent_safe.sh`
+
+Acceptance criteria:
+- Agent-safe validation commands set `INBOX_TEST_MODE=1` and `UV_CACHE_DIR=/tmp/uv-cache`.
+- `.factory/init.sh` can be run through `bash .factory/init.sh` from any worktree without hard-coding the primary checkout.
+- The docs distinguish dependency-cache/network failures from test failures.
+- `.factory/services.yaml` no longer makes the skipped audio/LLM subset look like the authoritative default if full-suite validation is expected.
+
+Smallest useful validation:
+
+```bash
+bash .factory/init.sh
+UV_CACHE_DIR=/tmp/uv-cache INBOX_TEST_MODE=1 uv run pytest --collect-only -q
+```
+
+### 2. Expand the deterministic `safe` pytest marker set
+
+Owned files:
+- `tests/test_api_contract.py`
+- `tests/test_client.py`
+- `tests/test_tools_registry.py`
+- `tests/test_message_index_store.py`
+- `tests/test_message_sync.py`
+- `docs/TESTING_FOR_AGENTS.md`
+
+Acceptance criteria:
+- Pure unit/API-contract tests that do not touch live data are marked `safe`.
+- Tests requiring local personal stores, live providers, microphone/audio hardware, or visible writes remain unmarked or receive explicit opt-in markers.
+- `INBOX_TEST_MODE=1 uv run pytest -m safe --collect-only -q` collects a meaningful cross-section of API contracts, MCP tool safety, index store behavior, and test-mode guards.
+
+Smallest useful validation:
+
+```bash
+UV_CACHE_DIR=/tmp/uv-cache INBOX_TEST_MODE=1 uv run pytest -m safe --collect-only -q
+UV_CACHE_DIR=/tmp/uv-cache INBOX_TEST_MODE=1 uv run pytest tests/test_inbox_test_mode.py tests/test_mcp_gateway.py tests/test_tools_registry.py -q
+```
+
+### 3. Surface index freshness in the TUI and docs
+
+Owned files:
+- `inbox.py`
+- `inbox_client.py`
+- `tests/test_client.py`
+- `tests/test_server.py`
+- `README.md`
+- `CLAUDE.md`
+
+Acceptance criteria:
+- TUI refresh calls `index_health()` before or alongside indexed views.
+- `no_sync_state`, `missing_checkpoint`, `stale_checkpoint`, and `sync_error` produce a visible status instead of silently showing empty indexed tabs.
+- Docs explain the `/index/status`, `/index/health`, `/index/views/{view}`, `/index/sync/bootstrap`, and `/index/sync/incremental` endpoints.
+- Existing indexed-view tests still pass, and at least one new test covers stale index status surfacing.
+
+Smallest useful validation:
+
+```bash
+UV_CACHE_DIR=/tmp/uv-cache INBOX_TEST_MODE=1 uv run pytest tests/test_client.py tests/test_server.py tests/test_api_contract.py -q
+```
+
+### 4. Finish shared Google account-resolution coverage
+
+Owned files:
+- `inbox_server.py`
+- `google_account_resolution.py`
+- `tests/test_gmail_actions.py`
+- `tests/test_server.py`
+
+Acceptance criteria:
+- `GET /messages/gmail/{msg_id}` resolves by explicit account, cache owner, message/thread existence, then `INBOX_DEFAULT_GOOGLE_ACCOUNT`; it does not silently use first service on cache miss.
+- `GET /gmail/labels` uses `get_gmail_service_for_account` and respects `INBOX_DEFAULT_GOOGLE_ACCOUNT`.
+- Tests cover default-account env behavior and cache-miss message lookup.
+- Response shapes consistently expose either `owning_account` or a documented compatibility field.
+
+Smallest useful validation:
+
+```bash
+UV_CACHE_DIR=/tmp/uv-cache INBOX_TEST_MODE=1 uv run pytest tests/test_gmail_actions.py tests/test_server.py -q
+```
+
+### 5. Remove or explicitly fence the duplicate-title Reminders mutation hazard
+
+Owned files:
+- `services.py`
+- `inbox_server.py`
+- `inbox_client.py`
+- `tests/test_reminders.py`
+- `tests/test_server.py`
+
+Acceptance criteria:
+- Completing, editing, uncompleting, or deleting a reminder cannot mutate an arbitrary same-title reminder in the same list.
+- If stable ID targeting is impossible through AppleScript, the API detects ambiguous title/list matches and returns a conflict requiring user disambiguation.
+- Tests cover duplicate incomplete reminders with the same title and list.
+- Existing list-name disambiguation across different lists remains supported.
+
+Smallest useful validation:
+
+```bash
+UV_CACHE_DIR=/tmp/uv-cache INBOX_TEST_MODE=1 uv run pytest tests/test_reminders.py tests/test_server.py -q
+```
+
+## Handoff
+
+Changed file:
+- `docs/overnight/2026-05-07-whole-portfolio-review/inbox-sym-120-risk-and-validation-review.md`
+
+Local commit blocker:
+- `git add docs/overnight/2026-05-07-whole-portfolio-review/inbox-sym-120-risk-and-validation-review.md && git diff --cached --check && git commit -m "Add inbox risk validation review"` failed because git could not create `/Users/jwalinshah/projects/inbox/.git/worktrees/inbox-sym-120-risk-and-validation-review/index.lock` from this sandbox.
+
+No PR was created. External services, deploys, pushes, tracker updates, and product-code edits were intentionally out of scope.

--- a/docs/overnight/2026-05-07-whole-portfolio-review/inbox-sym-214-implementation-readiness.md
+++ b/docs/overnight/2026-05-07-whole-portfolio-review/inbox-sym-214-implementation-readiness.md
@@ -1,0 +1,211 @@
+# inbox-sym-214 Implementation Readiness Review
+
+Date: 2026-05-07
+Queue item: `inbox-sym-214-implementation-readiness`
+Branch: `codex/goal-inbox-sym-214-implementation-readiness`
+
+## Scope
+
+This is a read-only implementation-readiness pass for the `inbox-sym-214`
+worktree. The only repo change from this pass is this report. Product code,
+external trackers, deploys, pushes, and PRs are out of scope.
+
+Evidence inspected:
+
+- Repo structure from `llm-tldr tree .`.
+- Current git state from `git status --short`, `git status -sb`, `git log --oneline -8`, and `git remote -v`.
+- Project docs, test guidance, package metadata, scripts, MCP config, and relevant source/test files.
+- Previous overnight artifacts were checked with `rg --files -g 'docs/**' -g 'runs/**' -g 'items/**'`; this worktree only contained `docs/TESTING_FOR_AGENTS.md` in that scan, so no prior overnight report or runner output was available locally.
+
+## Current State
+
+- Initial `git status --short` was clean.
+- Branch is `codex/goal-inbox-sym-214-implementation-readiness`.
+- Remote is `origin https://github.com/jwalin-shah/inbox.git`.
+- Recent history shows index-first work already landed: `2805b84 Merge pull request #34 from jwalin-shah/codex/SYM-9-indexed-defaults`, `05fc249 Add index sync health endpoint`, and `ae5f2fe Fix calendar range parameter forwarding`.
+- No `.github` workflow files were present in this worktree, so CI behavior could not be verified from repo-local config.
+
+## Concrete File Observations
+
+1. `PLAN.md` defines Phase 1 around a local SQLite operational index, reliable bootstrap/incremental sync, indexed endpoints, and a TUI home surface that uses compact indexed state before raw provider fetches.
+2. `README.md` describes a broad privacy-first TUI and API surface, but its requirement says Python 3.10+ while `pyproject.toml` requires `>=3.12,<3.15` and `.python-version` pins `3.12`.
+3. `pyproject.toml` defines the real validation stack: `ruff`, `pyright`, `pytest`, coverage addopts, `bandit`, and markers for `safe`, `integration`, `local_data`, `slow`, and `live_write`.
+4. `docs/TESTING_FOR_AGENTS.md` gives the safe agent loop as `INBOX_TEST_MODE=1 uv run pytest -m safe`, `uv run ruff check .`, and `uv run pyright`, and explicitly blocks local data/live-write tests unless opted in.
+5. `tests/test_inbox_test_mode.py` and `tests/test_mcp_gateway.py` are the only files found with module-level `pytest.mark.safe`, so the documented safe loop appears too narrow for index/sync implementation work unless more deterministic suites are marked.
+6. `message_sync.py` has concrete implementation surfaces for Gmail bootstrap resume tokens, Gmail history/timestamp cursors, iMessage rowid cursors, changed-scope thread rebuilds, and a CLI with `bootstrap`, `incremental`, `rebuild`, and `summary` modes.
+7. `tests/test_message_sync.py` already covers Gmail bootstrap resume, history cursor capture, timestamp fallback without a history cursor, iMessage skipped-row checkpoint advancement, and changed-scope rebuilds. This makes sync hardening safe to continue with focused fake-service tests.
+8. `message_index_store.py` owns the SQLite schema for `sync_state`, `items`, `threads`, and `sender_stats`, plus `list_threads` filters for actionable, recent, waiting/open-loop, needs-reply, latest-sender, and priority/recent sorting.
+9. `tests/test_message_index_store.py` covers item/thread idempotence, human sender stats, OTP ignoring, high-volume automated sender demotion, waiting/recent filters, latest-sender filters, and a 1100-thread rebuild path that avoids SQLite expression-depth failures.
+10. `thread_classifier.py` is intentionally heuristic and compact; `tests/test_thread_classifier.py` currently has only a direct OTP fixture, so classifier behavior is not yet protected across the main product classes described in `PLAN.md`.
+11. `inbox_server.py` exposes `/index/threads`, `/index/status`, `/index/health`, `/index/views/{view_name}`, `/index/sync/bootstrap`, `/index/sync/incremental`, and `/inbox/needs-action`.
+12. `tests/test_server.py` validates index endpoint shapes, stale/missing/error health reasons, view routing for `actionable`, `waiting-on`, `waiting-on-me`, and `waiting-on-others`, and confirms `/inbox/needs-action` does not fall back to live Gmail when the index is empty.
+13. `inbox_client.py` has helpers for `index_health`, generic `index_view`, `indexed_recent_threads`, `indexed_actionable_threads`, `indexed_waiting_on_me_threads`, and `indexed_waiting_on_others_threads`.
+14. `inbox.py` fetches `recent`, `actionable`, and `waiting-on` indexed views for the TUI, but does not currently surface the separate `waiting-on-me` and `waiting-on-others` helpers exposed by `inbox_client.py`.
+15. `tools_registry.py` centralizes the MCP tool surface and `tests/test_tools_registry.py` confirms mutating tools are confirmation-gated and readonly registration excludes writes. The registry does not currently expose `/index/health`, `/index/views/{view_name}`, or `/inbox/needs-action`, so MCP agents may still reach for raw Gmail/thread tools instead of compact indexed views.
+16. `MCP_SETUP.md`, `dev.sh`, `scripts/run_inbox_backend.sh`, `.mcp.json`, and `config/inbox.env.example` document a primary-vs-dev split, default dev port `9850`, and tokenized backend/MCP routing. This is enough to assign runtime-readiness work without touching provider credentials.
+17. `.pre-commit-config.yaml` includes `ruff --fix`, `ruff-format`, `trailing-whitespace`, `end-of-file-fixer`, `check-yaml`, `check-added-large-files`, `detect-private-key`, and `bandit -c pyproject.toml`, but no repo-local CI workflow was found to enforce them remotely.
+18. `DOCS_INDEX.md` claims "All 736 tests pass" and "production-ready" for Sheets, but that count is a stale claim unless refreshed by a current test run; no current runner output was available in this worktree.
+
+## Readiness Assessment
+
+The repo is ready for small, executable implementation slices around the
+indexed-inbox path. The index store, sync layer, server endpoints, client
+helpers, and TUI already have enough boundaries and tests to assign narrow
+follow-up work with file ownership and focused validation.
+
+The safest next wave should avoid live providers and use fake services,
+`INBOX_TEST_MODE=1`, and endpoint/client unit tests. Work that requires real
+Gmail, Calendar, Drive, Reminders, iMessage, microphone, OAuth, or MCP exposure
+should stay out of unattended implementation unless the issue explicitly opts
+into those surfaces.
+
+## Risks And Blockers
+
+- No previous overnight `runs/*/result.json`, `runs/*/handoff.md`, or repo-local `docs/overnight` reports were available in this worktree, so this pass cannot compare against prior generated findings.
+- No `.github` workflow files were present, so CI enforcement is unknown from repo-local evidence.
+- The documented safe loop is underpowered for the current implementation queue because only two test modules are marked `safe`.
+- `README.md` and `pyproject.toml` disagree on supported Python versions.
+- `DOCS_INDEX.md` contains stale-looking pass-count and production-readiness claims that should not be used as acceptance evidence without rerunning tests.
+- MCP tools currently expose many raw or provider-shaped operations but not the compact index/needs-action read models, which conflicts with the Phase 1 plan to reduce raw-provider reads.
+- `/inbox/needs-action` returns indexed threads only, which is good, but an empty stale index can look like "no work" unless callers also inspect `/index/health`.
+- Live provider validation is intentionally blocked by the queue scope and by `docs/TESTING_FOR_AGENTS.md` unless a human explicitly opts in.
+
+## Validation Commands
+
+Queue validation command:
+
+```bash
+git status --short
+```
+
+Recommended repo-safe validation loop for implementation tasks:
+
+```bash
+INBOX_TEST_MODE=1 uv run pytest -m safe
+uv run ruff check .
+uv run pyright
+```
+
+Focused validation commands for the index workstream:
+
+```bash
+INBOX_TEST_MODE=1 uv run pytest tests/test_message_sync.py tests/test_message_index_store.py -q
+INBOX_TEST_MODE=1 uv run pytest tests/test_server.py::TestIndexEndpoints tests/test_client.py::TestClientIndexedInbox -q
+INBOX_TEST_MODE=1 uv run pytest tests/test_tools_registry.py tests/test_mcp_gateway.py -q
+```
+
+## Implementation-Ready Follow-Up Tasks
+
+### 1. Expand The Agent-Safe Test Lane For Index Work
+
+Owned files:
+
+- `tests/test_message_sync.py`
+- `tests/test_message_index_store.py`
+- `tests/test_server.py`
+- `tests/test_client.py`
+- `docs/TESTING_FOR_AGENTS.md`
+
+Acceptance criteria:
+
+- Deterministic index, sync fake-service, index endpoint, and client index-view tests are included in the `safe` marker lane.
+- Tests that touch local personal stores, live OAuth providers, microphones, or external writes remain unmarked or explicitly marked `local_data`/`live_write`.
+- `docs/TESTING_FOR_AGENTS.md` names the focused safe index command so future agents do not overrun live surfaces.
+
+Smallest useful validation:
+
+```bash
+INBOX_TEST_MODE=1 uv run pytest -m safe tests/test_inbox_test_mode.py tests/test_mcp_gateway.py tests/test_message_sync.py tests/test_message_index_store.py tests/test_server.py tests/test_client.py -q
+```
+
+### 2. Expose Compact Indexed Inbox Reads Through MCP
+
+Owned files:
+
+- `tools_registry.py`
+- `tests/test_tools_registry.py`
+- `MCP_SETUP.md`
+
+Acceptance criteria:
+
+- Add readonly MCP tools for index health, one indexed view by name, and needs-action rollup.
+- New tools route to `/index/health`, `/index/views/{view_name}`, and `/inbox/needs-action` without exposing body text.
+- Readonly registration includes the new read tools; full registration still requires confirmation for mutating tools.
+- MCP docs tell agents to prefer indexed/needs-action tools before raw Gmail search for triage.
+
+Smallest useful validation:
+
+```bash
+INBOX_TEST_MODE=1 uv run pytest tests/test_tools_registry.py tests/test_mcp_gateway.py -q
+```
+
+### 3. Surface Stale Or Empty Index State In Needs-Action And TUI
+
+Owned files:
+
+- `inbox_server.py`
+- `inbox_client.py`
+- `inbox.py`
+- `tests/test_server.py`
+- `tests/test_client.py`
+- `tests/test_inbox_app.py`
+
+Acceptance criteria:
+
+- `/inbox/needs-action` includes index health/freshness metadata or an explicit stale/empty reason while still avoiding live Gmail fallback.
+- `InboxClient` exposes that metadata without changing existing compact thread shapes.
+- The TUI shows a clear index stale/error/no-sync state when indexed views are empty because the index is unhealthy.
+- Existing index endpoint behavior remains backward compatible.
+
+Smallest useful validation:
+
+```bash
+INBOX_TEST_MODE=1 uv run pytest tests/test_server.py::TestIndexEndpoints tests/test_client.py::TestClientIndexedInbox tests/test_inbox_app.py -q
+```
+
+### 4. Harden Gmail History-Cursor Failure Fallback
+
+Owned files:
+
+- `message_sync.py`
+- `tests/test_message_sync.py`
+
+Acceptance criteria:
+
+- A Gmail history API failure caused by an invalid or expired cursor falls back to timestamp incremental sync instead of leaving the account stuck on an unusable history cursor.
+- Metadata records a distinct fallback reason such as `history_cursor_invalid` or `history_cursor_expired`.
+- If both history and timestamp fallback fail, `sync_state.status` becomes `error` and preserves the last useful checkpoint/error.
+- Existing bootstrap resume and history-cursor tests continue to pass.
+
+Smallest useful validation:
+
+```bash
+INBOX_TEST_MODE=1 uv run pytest tests/test_message_sync.py -q
+```
+
+### 5. Add Representative Thread-Classifier Fixtures
+
+Owned files:
+
+- `thread_classifier.py`
+- `tests/test_thread_classifier.py`
+- `tests/test_message_index_store.py`
+
+Acceptance criteria:
+
+- Add deterministic fixtures for recruiter/opportunity, appointment or health admin, security alert, newsletter/job alert, receipt/order, survey, and frequent human sender cases.
+- Expected `noise_class`, `topic`, `urgency`, `actionability`, `needs_reply`, and `open_loop` outcomes are asserted.
+- Any classifier changes remain local to the heuristic classifier and do not require live message bodies.
+
+Smallest useful validation:
+
+```bash
+INBOX_TEST_MODE=1 uv run pytest tests/test_thread_classifier.py tests/test_message_index_store.py -q
+```
+
+## Handoff Notes
+
+- Product code was not edited.
+- External services, pushes, PR creation, and tracker updates were not attempted.
+- The only intended changed file is this report.
+- Final worker response should include the local commit SHA, final `git status --short` result, PR URL if any, and blockers.

--- a/docs/overnight/2026-05-07-whole-portfolio-review/inbox-sym-214-risk-and-validation-review.md
+++ b/docs/overnight/2026-05-07-whole-portfolio-review/inbox-sym-214-risk-and-validation-review.md
@@ -1,0 +1,315 @@
+# inbox-sym-214 risk and validation review
+
+Queue item: `inbox-sym-214-risk-and-validation-review`
+Branch: `codex/goal-inbox-sym-214-risk-and-validation-review`
+Review date: 2026-05-07
+Repo HEAD at review start: `2805b84`
+
+## Scope
+
+This is a read-only risk-and-validation review for the local `inbox-sym-214`
+worktree. Product code was not changed. The only intended repo change is this
+report.
+
+The queue item referenced `items/inbox-sym-214-risk-and-validation-review/ISSUE.md`,
+but that file is not present in this worktree. I used the issue body from the
+goal prompt as the task contract and recorded the missing local issue artifact as
+a blocker below.
+
+## Evidence observations
+
+1. `README.md` describes the app as a privacy-first TUI combining iMessage,
+   Gmail, Google Calendar, Sheets, Apple Notes, Apple Reminders, GitHub, and
+   Drive, with server endpoints on `localhost:9849`. This is a broad
+   personal-data surface, so validation needs to separate deterministic tests
+   from live-provider checks.
+
+2. `README.md:31-34` says the runtime requirement is Python 3.10+, while
+   `pyproject.toml:5` requires `>=3.12,<3.15`. This is a stale setup claim that
+   can send agents or humans down the wrong dependency path.
+
+3. `pyproject.toml:53-62` defines pytest markers for `safe`, `integration`,
+   `local_data`, `slow`, and `live_write`, and `docs/TESTING_FOR_AGENTS.md:9-18`
+   tells agents to use `INBOX_TEST_MODE=1 uv run pytest -m safe` or the focused
+   `tests/test_inbox_test_mode.py` command. That is the right safety model for a
+   personal-data repo.
+
+4. Only `tests/test_inbox_test_mode.py:8` and `tests/test_mcp_gateway.py:18`
+   declare `pytestmark = pytest.mark.safe`. Static search found 31 files under
+   `tests/`, but only two files marked safe; the safe gate currently covers the
+   test-mode helper and MCP gateway auth, not most server, service, registry, or
+   account-routing regressions.
+
+5. `tests/conftest.py` stubs hardware and ML dependencies such as `mlx_lm`,
+   `mlx_whisper`, `sounddevice`, `outlines`, and `Quartz`, which is good for CI
+   portability. However, there is no `.github/**` workflow file in the current
+   checkout, so the repo has no visible GitHub Actions validation contract.
+
+6. `DOCS_INDEX.md:42-44` lists `uv run ruff check --fix .`, `uv run pyright`,
+   and `uv run pytest` as dev commands, and `DOCS_INDEX.md:140` claims "All 736
+   tests pass." This review could not verify that claim locally because `uv run`
+   needed a network download for `tokenizers`; the pinned test-count claim should
+   be treated as stale until a fresh validation artifact exists.
+
+7. `inbox_test_mode.py:22-24` blocks live writes when `INBOX_TEST_MODE` is set,
+   and `services.py:114-119` routes write guards through that helper. Static
+   search shows many service-level mutators call `_assert_live_write_allowed`,
+   including Gmail, Calendar, Reminders, Google Tasks, Drive, Sheets, Docs,
+   GitHub notification mutation, desktop notifications, and WhatsApp.
+
+8. `services.py:56-80` redirects Google token files and macOS data-store paths
+   into `INBOX_TEST_DATA_DIR` during test mode, and
+   `tests/test_inbox_test_mode.py:29-42` verifies several of those redirects.
+   `scheduler.py:15-17` and `memory_store.py:9-10`, however, default to
+   repo-local `.inbox_scheduler.sqlite3` and `.inbox_memory.sqlite3`; these are
+   ignored by `.gitignore`, but not covered by the same test-data redirection.
+
+9. `inbox_server.py:1180-1187` starts a background scheduler loop by default,
+   and `inbox_server.py:982-1030` can send due Gmail/iMessage scheduled
+   messages while `inbox_server.py:1048-1114` can create Google Tasks or Apple
+   Reminders for followups. Tests can disable the scheduler through
+   `InboxServerRuntime(start_scheduler=False)`, but runtime default behavior is
+   still a high-risk write surface.
+
+10. `inbox_server.py:2066-2104` creates scheduled messages and followup records
+    by writing through `SchedulerStore` without a local test-mode guard at the
+    endpoint boundary. The actual send/create paths hit service-level live-write
+    guards later, but queued work can persist and fire in a different runtime
+    context.
+
+11. `tools_registry.py:41-77` models MCP tools with `readonly` and `confirm`
+    flags, and `tests/test_tools_registry.py:41-43` asserts every non-readonly
+    registry tool is confirmation-gated. That is a strong guard for agent-facing
+    mutation, but these tests are not part of the current `safe` marker set.
+
+12. `inbox_server.py:1313-1340` allows all HTTP endpoints when
+    `INBOX_SERVER_TOKEN` is unset, and `mcp_gateway.py:28-45` similarly allows
+    MCP access when `INBOX_MCP_TOKEN` is unset except for a public `/health`
+    route. `config/inbox.env.example:1-6` provides token placeholders, but auth
+    remains optional by code path.
+
+13. `google_account_resolution.py:24-31` implements
+    `INBOX_DEFAULT_GOOGLE_ACCOUNT` preference when the env value exists in the
+    service map. `tests/test_server.py:612-657` and `tests/test_server.py:1494-1621`
+    cover default calendar/preflight routing, but `config/inbox.env.example`
+    does not include `INBOX_DEFAULT_GOOGLE_ACCOUNT`, so the source-of-truth
+    account policy is easy to omit in deployed config.
+
+14. `CONNECTOR_ROADMAP.md:38-44` says Google writes should default to
+    `jshah1331@gmail.com` and returned Google objects should include
+    `owning_account`. `service_models.py:143-153` has `owning_account` on
+    `ThreadSummary`, but other Google-facing dataclasses such as
+    `GoogleTask`, `DriveFile`, `Spreadsheet`, and `Document` still use either
+    no account field or `account`, so normalized ownership is not consistent.
+
+15. `inbox_server.py:3009-3020` exposes `/preflight/google-write`, and
+    `google_account_resolution.py:160-272` implements payloads for docs, sheets,
+    drive folders, tasks, and calendar events. The roadmap still names a broader
+    `preflight_google_write(kind, account?, destination?, sharing?, naming?)`;
+    current preflight checks destination existence for some paths, but does not
+    yet encode sharing or naming policy.
+
+16. `rg --files -g 'runs/**' -g 'docs/overnight/**' -g '.github/**' -g 'items/**'`
+    returned no files before this report was created. There were no prior
+    overnight outputs, runner handoffs, local queue `items/` files, or CI config
+    files available for this pass.
+
+## Validation commands
+
+Required queue validation:
+
+```bash
+git status --short
+```
+
+Agent-safe validation documented by the repo:
+
+```bash
+INBOX_TEST_MODE=1 uv run pytest -m safe
+uv run ruff check .
+uv run pyright
+INBOX_TEST_MODE=1 uv run pytest tests/test_inbox_test_mode.py -q
+```
+
+Additional review command attempted:
+
+```bash
+UV_CACHE_DIR=/private/tmp/inbox-sym-214-uv-cache INBOX_TEST_MODE=1 uv run pytest -m safe --collect-only -q
+```
+
+Result: blocked by restricted network while downloading `tokenizers==0.22.2`,
+pulled through `mlx-lm -> transformers -> tokenizers`. The first attempt without
+`UV_CACHE_DIR` also failed because `uv` tried to open `/Users/jwalinshah/.cache/uv`,
+which is outside this sandbox's writable roots.
+
+## Risks and blockers
+
+- Missing local queue issue file:
+  `items/inbox-sym-214-risk-and-validation-review/ISSUE.md` is absent.
+- No visible CI workflow: no `.github/**` files were present.
+- Safe test marker coverage is narrow: only two test files are marked `safe`.
+- `uv run` validation could not complete offline because dependency resolution
+  attempted to download `tokenizers`.
+- Runtime docs are stale or ambiguous: README says Python 3.10+, while
+  `pyproject.toml` requires Python 3.12+; docs also contain an unverified
+  "736 tests pass" claim.
+- Auth is optional by environment; unset `INBOX_SERVER_TOKEN` or
+  `INBOX_MCP_TOKEN` leaves local HTTP/MCP endpoints open.
+- Background scheduler defaults can perform live sends/tasks/reminders and can
+  persist scheduled work in a repo-local ignored SQLite DB.
+- Source-of-truth Google account policy exists in code and tests, but is not
+  represented in `config/inbox.env.example`.
+- Normalized ownership is incomplete: `owning_account` is implemented for
+  thread summaries, but not consistently across tasks, files, docs, and sheets.
+
+## Implementation-ready follow-up tasks
+
+### 1. Add a repo CI workflow for the agent-safe validation loop
+
+Owned files:
+- `.github/workflows/ci.yml`
+- `docs/TESTING_FOR_AGENTS.md`
+- `DOCS_INDEX.md`
+
+Acceptance criteria:
+- CI runs on pull requests and push to main.
+- CI installs dependencies with `uv` and runs the documented safe loop:
+  `INBOX_TEST_MODE=1 uv run pytest -m safe`, `uv run ruff check .`, and
+  `uv run pyright`.
+- CI sets `INBOX_TEST_MODE=1` and a temp `INBOX_TEST_DATA_DIR`.
+- Docs link the CI workflow as the source of truth for agent-safe validation.
+
+Smallest useful validation:
+
+```bash
+uv run ruff check .
+uv run pyright
+INBOX_TEST_MODE=1 uv run pytest -m safe
+```
+
+### 2. Expand the `safe` marker to cover deterministic guard and contract tests
+
+Owned files:
+- `tests/test_services.py`
+- `tests/test_tools_registry.py`
+- `tests/test_server.py`
+- `tests/test_api_contract.py`
+- `docs/TESTING_FOR_AGENTS.md`
+
+Acceptance criteria:
+- Deterministic tests for live-write blocking, MCP confirmation gating, auth
+  behavior, API/tool path contracts, and account/preflight routing are included
+  in `pytest -m safe`.
+- Tests that touch live provider data, local macOS stores, microphone input, or
+  external writes remain unmarked or explicitly marked `local_data`/`live_write`.
+- `docs/TESTING_FOR_AGENTS.md` explains which test classes belong in the safe
+  marker.
+
+Smallest useful validation:
+
+```bash
+INBOX_TEST_MODE=1 uv run pytest -m safe --collect-only -q
+INBOX_TEST_MODE=1 uv run pytest -m safe
+```
+
+### 3. Make test-mode storage isolation cover scheduler and memory databases
+
+Owned files:
+- `scheduler.py`
+- `memory_store.py`
+- `inbox_test_mode.py`
+- `tests/test_inbox_test_mode.py`
+- `tests/test_server.py`
+
+Acceptance criteria:
+- In `INBOX_TEST_MODE=1`, default scheduler and memory DB paths live under
+  `INBOX_TEST_DATA_DIR` or another temp test-data root.
+- Creating scheduled messages, followups, task links, or memory entries during
+  tests cannot write `.inbox_scheduler.sqlite3` or `.inbox_memory.sqlite3` in the
+  repo root.
+- Tests prove the default path redirection and preserve explicit constructor DB
+  path overrides.
+
+Smallest useful validation:
+
+```bash
+INBOX_TEST_MODE=1 uv run pytest tests/test_inbox_test_mode.py tests/test_mcp_gateway.py -q
+INBOX_TEST_MODE=1 uv run pytest tests/test_server.py -k "scheduler or memory or test_mode" -q
+```
+
+### 4. Encode Google account policy in config and normalize ownership fields
+
+Owned files:
+- `config/inbox.env.example`
+- `google_account_resolution.py`
+- `service_models.py`
+- `services.py`
+- `inbox_server.py`
+- `tests/test_server.py`
+
+Acceptance criteria:
+- `config/inbox.env.example` documents `INBOX_DEFAULT_GOOGLE_ACCOUNT`.
+- Google write endpoints and preflight return the same resolved account when
+  account is omitted.
+- Google-facing response models consistently expose `owning_account` or a
+  documented compatibility alias from `account`.
+- Tests cover Docs, Sheets, Drive, Tasks, Calendar, and Gmail reply routing under
+  a configured default account and under an explicit override.
+
+Smallest useful validation:
+
+```bash
+INBOX_TEST_MODE=1 uv run pytest tests/test_server.py -k "default_account or preflight or owning_account or reply_auto_routes" -q
+```
+
+### 5. Replace stale validation/setup claims with generated or test-backed docs
+
+Owned files:
+- `README.md`
+- `DOCS_INDEX.md`
+- `CLAUDE.md`
+- `docs/TESTING_FOR_AGENTS.md`
+- `tests/test_inbox_test_mode.py`
+
+Acceptance criteria:
+- Python version docs match `pyproject.toml`.
+- Documentation avoids hard-coded "all tests pass" counts unless generated from
+  a current validation artifact.
+- Docs distinguish quick local smoke tests from full live-provider or local-data
+  checks.
+- Existing doc tests are updated so stale Python/test-count claims fail fast.
+
+Smallest useful validation:
+
+```bash
+rg -n "Python 3.10|736 tests|736 pass" README.md DOCS_INDEX.md CLAUDE.md docs
+INBOX_TEST_MODE=1 uv run pytest tests/test_inbox_test_mode.py -q
+```
+
+## Handoff
+
+Files changed:
+- `docs/overnight/2026-05-07-whole-portfolio-review/inbox-sym-214-risk-and-validation-review.md`
+
+Commit SHA:
+- Current HEAD during review: `2805b84`
+- No commit was created; PR creation and pushes are out of scope for this queue
+  item.
+
+PR URL:
+- None. External pushes and PR creation are out of scope.
+
+Required validation:
+- `git status --short` exited 0 after writing this report and returned:
+
+```text
+?? docs/overnight/
+```
+
+Blockers:
+- Local queue issue file was missing.
+- Dependency-backed pytest collection could not run in this sandbox because
+  `uv` needed network access to download `tokenizers`.
+- The `uv` retry created an ignored `.venv` before failing; `git status --short`
+  does not show ignored files, and cleanup with `rm -rf .venv` was blocked by
+  local execution policy.

--- a/docs/overnight/2026-05-07-whole-portfolio-review/inbox-sym-30-implementation-readiness.md
+++ b/docs/overnight/2026-05-07-whole-portfolio-review/inbox-sym-30-implementation-readiness.md
@@ -1,0 +1,191 @@
+# inbox-sym-30 implementation-readiness review
+
+Queue item: `inbox-sym-30-implementation-readiness`
+Branch: `codex/goal-inbox-sym-30-implementation-readiness`
+Base HEAD inspected: `2805b8400519da188ca7d3f6e39b19a8ca42b05a`
+
+## Scope and validation
+
+This is a read-only implementation-readiness pass. I did not edit product code, run external services, push, open a PR, or update trackers.
+
+Queue validation command:
+
+```bash
+git status --short
+```
+
+Agent-safe validation commands documented by the repo:
+
+```bash
+INBOX_TEST_MODE=1 uv run pytest -m safe
+uv run ruff check .
+uv run pyright
+```
+
+Factory validation commands used by previous generated reviews:
+
+```bash
+uv run pytest -x -q
+uv run pyright
+uv run ruff check .
+```
+
+Repo-local overnight outputs: none found under `docs/overnight/` or `runs/`. Generated `.factory/validation/*/synthesis.json` files were used as the available prior validation evidence.
+
+## Concrete file observations
+
+1. `PLAN.md` defines Phase 1 as index-first inbox work and explicitly says bootstrap sync, incremental sync, classification, indexed TUI views, waiting-on views, and calendar context are incomplete or next up.
+2. `message_sync.py` has concrete bootstrap and incremental entrypoints for Gmail and iMessage, with Gmail page-token resume metadata, Gmail history cursor support, iMessage rowid checkpoints, and scoped thread rebuilds.
+3. `message_index_store.py` owns the local `.inbox_index.sqlite3` schema with `sync_state`, `items`, `threads`, and `sender_stats`; `list_threads()` already supports `actionable_only`, `newest_only`, `actions`, `needs_reply`, `has_open_loop`, `latest_sender`, and priority/recent sorting.
+4. `inbox_server.py` exposes `/index/threads`, `/index/status`, `/index/health`, `/index/views/{view_name}`, `/index/sync/bootstrap`, and `/index/sync/incremental`; the sync endpoints execute live provider syncs through `asyncio.to_thread`.
+5. `inbox_server.py` maps `waiting-on-me` to `needs_reply=True`, `waiting-on-others` to `latest_sender="Me"`, and aggregate `waiting-on` to `actions=("track",), has_open_loop=True`; those are executable but semantically different views.
+6. `inbox_client.py` has helpers for `index_health()`, `index_view()`, `indexed_recent_threads()`, `indexed_actionable_threads()`, `indexed_waiting_on_me_threads()`, and `indexed_waiting_on_others_threads()`.
+7. `inbox.py` already fetches indexed `recent`, `actionable`, and aggregate `waiting-on` views for the TUI, but there is no use of `index_health()` and no distinct TUI surface for `waiting-on-me` versus `waiting-on-others`.
+8. `tui_tabs.py` already renames the first tab to `Now` and includes `Actionable` and `Waiting On`, which makes the index-first information architecture partially implemented.
+9. `tests/test_message_sync.py` covers Gmail bootstrap resume, history cursor recording, timestamp fallback, iMessage skipped-row checkpoint advancement, and scoped thread rebuilds.
+10. `tests/test_message_index_store.py` covers idempotent upserts/rebuilds, sender stats, high-volume automated senders, waiting/recent filters, latest-sender filtering, and large rebuild scope behavior.
+11. `tests/test_server.py` covers index endpoints, index health reasons, `/inbox/needs-action` using the index without live Gmail fallback, Google account defaults, Gmail reply routing, and Google write preflight behavior.
+12. `docs/TESTING_FOR_AGENTS.md` defines the default safe loop as `INBOX_TEST_MODE=1 uv run pytest -m safe`, but `rg` found only two safe-marked test modules: `tests/test_mcp_gateway.py` and `tests/test_inbox_test_mode.py`.
+13. `pyproject.toml` registers `safe`, `integration`, `local_data`, `slow`, and `live_write` markers and sets default pytest coverage, but most deterministic index/account tests are not marked `safe`.
+14. `google_account_resolution.py` already implements `INBOX_DEFAULT_GOOGLE_ACCOUNT`, message/thread-owner Gmail resolution, and `preflight_google_write_payload()`, so the account-policy foundation exists.
+15. `tools_registry.py` centralizes the MCP tool surface, confirm-gates every mutating registered tool, and supports readonly-only registration, but it does not yet expose the existing `/preflight/google-write` endpoint as an MCP tool.
+16. `mcp_server.py`, `inbox_mcp_readonly.py`, `MCP_SETUP.md`, `config/inbox.env.example`, and `deploy/Caddyfile.example` document separate private backend, full MCP, and readonly MCP surfaces with separate tokens.
+17. `.factory/services.yaml` uses `uv run pytest --ignore=tests/test_audio.py --ignore=tests/test_llm.py -x -q` for the default factory test command, while `test_all` is `uv run pytest -x -q`; prior `.factory/validation/*/synthesis.json` files show lint/typecheck/test passes but also record the audio/LLM exclusion as already documented.
+18. `.pre-commit-config.yaml` has ruff, ruff-format, basic file hygiene hooks, and Bandit configured with `pyproject.toml`; no `.github` workflow files were found by `fd -H`.
+19. `modes/morning-brief.md`, `modes/triage.md`, and `modes/followup-sweep.md` still instruct agents to start from raw `/conversations` reads, even though `PLAN.md` says raw provider dumps should not be the default and `/index/views/*` exists.
+20. `batch/batch-runner.sh` has a dry-run mode but defaults to `DRY_RUN=false` and calls Gmail mutation endpoints directly, so it is not yet an ideal safe default for delegated overnight execution.
+
+## Risks and blockers
+
+- The code is close to executable index-first work, but the safe test marker coverage is too narrow for overnight agents. The default documented `-m safe` command currently misses most index, sync, server, account-routing, and TUI tests.
+- Index freshness can be diagnosed through `/index/health`, but the TUI does not surface stale, missing, or errored sync state. An empty index could look like an empty inbox.
+- The slash-command mode docs still bias agents toward raw conversation fetches, which conflicts with the current Phase 1 product direction and can reintroduce high-token raw provider workflows.
+- The aggregate `waiting-on` view is not the same as either `waiting-on-me` or `waiting-on-others`; implementation agents need a product decision before changing labels or tab behavior beyond the concrete split proposed below.
+- Full bootstrap/incremental sync validation needs live Gmail/iMessage access and local personal data. That should stay out of automated overnight validation unless explicitly requested.
+- There is no repo-local GitHub Actions workflow evidence in this worktree, so CI readiness is inferred from `pyproject.toml`, `.pre-commit-config.yaml`, `.factory/services.yaml`, and prior `.factory/validation` outputs.
+- `batch/batch-runner.sh` can perform Gmail archive mutations if invoked without `--dry-run`; any future automation around it needs explicit confirmation or test-mode protection first.
+
+## Implementation-ready follow-up tasks
+
+### 1. Expand the agent-safe test lane for index-first work
+
+Owned files:
+
+- `tests/test_message_sync.py`
+- `tests/test_message_index_store.py`
+- `tests/test_server.py`
+- `tests/test_client.py`
+- `tests/test_gmail_actions.py`
+- `docs/TESTING_FOR_AGENTS.md`
+
+Acceptance criteria:
+
+- Deterministic index, sync-store, index endpoint, preflight, account-routing, and client-helper tests are marked `pytest.mark.safe` at module/class/function granularity.
+- No `local_data`, `live_write`, or live provider tests are included in the safe lane.
+- `docs/TESTING_FOR_AGENTS.md` names the expanded safe coverage and keeps live-write opt-in guidance intact.
+
+Smallest useful validation:
+
+```bash
+INBOX_TEST_MODE=1 uv run pytest -m safe tests/test_message_sync.py tests/test_message_index_store.py tests/test_server.py tests/test_client.py tests/test_gmail_actions.py -q
+```
+
+### 2. Expose Google write preflight through the client and MCP registry
+
+Owned files:
+
+- `inbox_client.py`
+- `tools_registry.py`
+- `tests/test_client.py`
+- `tests/test_tools_registry.py`
+- `tests/test_mcp_gateway.py`
+
+Acceptance criteria:
+
+- `InboxClient` has a `preflight_google_write(...)` helper for `/preflight/google-write`.
+- `tools_registry.TOOLS` includes a readonly `preflight_google_write` tool that is registered in both full and readonly MCP surfaces.
+- Tool parameters cover `kind`, `account`, `folder_id`, `list_id`, `calendar_id`, and `title`.
+- Registry tests prove the tool is readonly, not confirm-gated, and present in readonly registration.
+
+Smallest useful validation:
+
+```bash
+INBOX_TEST_MODE=1 uv run pytest tests/test_client.py tests/test_tools_registry.py tests/test_server.py::TestPreflight -q
+```
+
+### 3. Surface index health in the TUI status flow
+
+Owned files:
+
+- `inbox.py`
+- `inbox_client.py`
+- `tests/test_inbox_app.py`
+- `tests/test_client.py`
+
+Acceptance criteria:
+
+- The TUI polls `client.index_health()` during refresh/poll flows without crashing if the health request fails.
+- Stale, missing-checkpoint, no-sync-state, and sync-error states produce a clear status warning.
+- Healthy index state keeps the existing indexed-thread status behavior.
+- Existing sustained-outage behavior remains unchanged.
+
+Smallest useful validation:
+
+```bash
+INBOX_TEST_MODE=1 uv run pytest tests/test_inbox_app.py tests/test_client.py::TestClientIndexedInbox -q
+```
+
+### 4. Make slash-command modes index-first
+
+Owned files:
+
+- `modes/morning-brief.md`
+- `modes/triage.md`
+- `modes/followup-sweep.md`
+- `modes/_shared.md`
+- `README.md` or `CLAUDE.md` if command docs need a brief update
+
+Acceptance criteria:
+
+- Morning brief starts from `/inbox/needs-action` plus `/index/views/recent` instead of raw Gmail conversations.
+- Triage starts from `/index/views/actionable`, `/index/views/waiting-on-me`, `/index/views/waiting-on-others`, and only drills into raw messages for confirmation.
+- Followup sweep uses indexed waiting/reply views before falling back to TSV or raw threads.
+- The mode docs preserve explicit caps and avoid raw provider dumps as the default context.
+
+Smallest useful validation:
+
+```bash
+rg -n "/index/views|/inbox/needs-action|/conversations\\?source" modes README.md CLAUDE.md
+```
+
+### 5. Split waiting-on-me and waiting-on-others in the TUI
+
+Owned files:
+
+- `tui_tabs.py`
+- `inbox.py`
+- `inbox_client.py`
+- `tests/test_inbox_app.py`
+- `tests/test_tui_tabs.py`
+- `tests/test_server.py`
+
+Acceptance criteria:
+
+- The UI exposes separate user-visible filters or commands for `waiting-on-me` and `waiting-on-others`, or the aggregate `Waiting On` tab clearly combines both with stable section ordering.
+- TUI refresh fetches the same server views as the labels imply.
+- Tests cover the server route parameters, client helper calls, tab metadata, and TUI rendering/status counts.
+- No raw provider fetch is added for these views.
+
+Smallest useful validation:
+
+```bash
+INBOX_TEST_MODE=1 uv run pytest tests/test_server.py::TestIndexEndpoints tests/test_client.py::TestClientIndexedInbox tests/test_tui_tabs.py tests/test_inbox_app.py -q
+```
+
+## Handoff
+
+Recommended next issue: start with task 1. It widens the safe validation lane before workers change index or TUI behavior.
+
+Commit/PR blocker: a local commit could not be created from this sandbox because `git add`/`git commit` needs to write `/Users/jwalinshah/projects/inbox/.git/worktrees/inbox-sym-30-implementation-readiness/index.lock`, which is outside the writable roots.
+
+Do not mark external trackers done from this review. No PR was created.

--- a/docs/overnight/2026-05-07-whole-portfolio-review/inbox-sym-30-risk-and-validation-review.md
+++ b/docs/overnight/2026-05-07-whole-portfolio-review/inbox-sym-30-risk-and-validation-review.md
@@ -1,0 +1,172 @@
+# inbox-sym-30 Risk and Validation Review
+
+Queue item: `inbox-sym-30-risk-and-validation-review`
+Branch: `codex/goal-inbox-sym-30-risk-and-validation-review`
+Review date: 2026-05-07
+
+## Scope and Method
+
+This pass reviewed repo-local evidence only: docs, tests, scripts, config, generated `.factory` validation outputs, package metadata, and current git state. Product code was not edited.
+
+The queue referenced `items/inbox-sym-30-risk-and-validation-review/ISSUE.md`, but that file is not present in this worktree. The issue body supplied in the Goal Pack prompt was used as the task contract.
+
+## Current State
+
+- `git branch --show-current` returned `codex/goal-inbox-sym-30-risk-and-validation-review`.
+- `git status --short` was clean before this report was written.
+- `git rev-parse HEAD` returned `2805b8400519da188ca7d3f6e39b19a8ca42b05a`.
+- No `.github/` directory is present, so no repo-local GitHub Actions workflow was available to inspect.
+- No prior `docs/overnight/` report exists in this worktree. Prior generated review evidence is under `.factory/validation/`.
+
+## Concrete File-Path Observations
+
+1. `README.md` and `CLAUDE.md` describe a privacy-first localhost FastAPI server plus Textual TUI with live iMessage, Gmail, Calendar, Drive, Notes, Reminders, GitHub, audio, and local ML integrations. This is a high-risk personal-data app, so default validation must avoid live stores and external writes.
+
+2. `inbox_server.py` has an auth middleware that allows every request when `INBOX_SERVER_TOKEN` is unset. `README.md`, `CLAUDE.md`, `config/inbox.env.example`, `.mcp.json`, and `.cursor/mcp.json` all document token-based auth, but the default remains optional.
+
+3. `inbox_client.py` auto-starts `inbox_server.py` and writes `server.log` when the server is not running. `CLAUDE.md` and `dev.sh` correctly steer worktrees to alternate ports, but `.factory/services.yaml` still starts the daily-driver checkout at `/Users/jwalinshah/projects/inbox` on port `9849`.
+
+4. `tools_registry.py` centralizes MCP tool registration and marks write tools with `confirm=True`; `inbox_mcp_readonly.py` registers only `readonly=True` registry tools plus local read-only daily-note and memory tools. This is a good safety boundary, but it depends on accurate `readonly` flags in one large registry.
+
+5. `docs/TESTING_FOR_AGENTS.md` defines the agent-safe loop as `INBOX_TEST_MODE=1 uv run pytest -m safe`, `uv run ruff check .`, and `uv run pyright`. `pyproject.toml` registers `safe`, `integration`, `local_data`, `slow`, and `live_write` markers.
+
+6. `tests/test_inbox_test_mode.py` and `tests/test_mcp_gateway.py` are the only files found with `pytest.mark.safe`. Many deterministic tests in `tests/` are unmarked, so the documented safe gate currently exercises only a narrow slice of the test suite.
+
+7. `inbox_test_mode.py` provides `assert_live_writes_allowed`, `test_data_dir`, and `test_now`. `services.py` redirects local personal-data paths under `INBOX_TEST_DATA_DIR` when `INBOX_TEST_MODE=1`.
+
+8. `services.py` calls `_assert_live_write_allowed(...)` across many mutation functions, including Gmail, Calendar, Reminders, Tasks, GitHub notifications, Drive, Sheets, Docs, WhatsApp, and desktop notifications. `tests/test_services.py` has representative and extended live-write blocking tests, but not every server endpoint is covered at the HTTP layer.
+
+9. `tests/conftest.py` stubs heavy or platform-specific dependencies such as `mlx_lm`, `mlx_whisper`, `sounddevice`, `Quartz`, and `outlines`, which supports deterministic CI-style tests without real hardware or ML installs.
+
+10. `.factory/services.yaml` defines `test: uv run pytest --ignore=tests/test_audio.py --ignore=tests/test_llm.py -x -q`, while later `.factory/validation/fix-broken-state/*` and `.factory/validation/architecture-hardening/*` outputs repeatedly note that excluding audio and LLM tests can hide regressions.
+
+11. `.pre-commit-config.yaml` configures Ruff, Ruff format, generic pre-commit hooks, and Bandit. Without a `.github/` workflow or another repo-local CI config, these checks appear locally configured but not enforced by a visible remote gate.
+
+12. `message_sync.py` and `message_index_store.py` implement the recent indexed inbox sync path, including Gmail history cursors, timestamp fallback, iMessage rowid checkpoints, resumable bootstrap, and scoped thread rebuilds. `tests/test_message_sync.py` and `tests/test_message_index_store.py` cover these paths well with fake services and temp SQLite DBs.
+
+13. `.gitignore` excludes local credentials, token stores, logs, coverage, `.inbox_index.sqlite3`, `.inbox_memory.sqlite3`, `.inbox_scheduler.sqlite3`, and `.venv`, reducing accidental commits of sensitive or generated state.
+
+14. `.factory/init.sh` is not executable and hard-codes `cd /Users/jwalinshah/projects/inbox`, `uv sync`, and killing port `9849`. `.factory/validation/architecture-hardening/scrutiny/synthesis.json` already records repeated `Permission denied` setup issues for direct execution of this script.
+
+15. `.factory/library/architecture.md` is stale in several places: it says `google_auth_all()` returns three service dicts and lists only older Google scopes, while current code and `CLAUDE.md` include Drive, Sheets, Docs, and Tasks service maps and scopes.
+
+## Risks and Blockers
+
+- Validation is not hermetic in this worker. `uv run` could not use the default cache due sandbox permissions, and with `UV_CACHE_DIR` redirected it attempted to download `textual==8.2.3` but network/DNS is unavailable.
+- The documented safe test gate is too narrow because most tests are not marked `safe`.
+- The factory default test command excludes audio and LLM tests even though later validation records say those tests were restored and should be part of full-suite validation.
+- There is no repo-local CI workflow to prove `pytest`, `ruff`, `pyright`, or Bandit run before merge.
+- Optional server auth is convenient for local development but risky for MCP and agent surfaces if the server is exposed beyond loopback or launched with permissive defaults.
+- `.factory/init.sh` is unsafe for isolated workers because it targets the main checkout and daily-driver port rather than the current worktree and configured port.
+- Some generated `.factory/library` docs are stale relative to current code, which can mislead implementation agents that start from those docs.
+- Live personal-data integrations cannot be fully validated without explicit opt-in and credentials, so default validation must remain mocked, temp-dir-backed, or read-only.
+
+## Validation Commands
+
+Commands run during this review:
+
+```bash
+git status --short
+```
+
+Result before report: exit code 0, clean output.
+
+```bash
+INBOX_TEST_MODE=1 uv run pytest -m safe -q
+```
+
+Result: blocked before tests by sandbox denial opening `/Users/jwalinshah/.cache/uv/sdists-v9/.git`.
+
+```bash
+UV_CACHE_DIR=/private/tmp/uv-cache-inbox-sym-30 INBOX_TEST_MODE=1 uv run pytest -m safe -q
+```
+
+Result: blocked before tests because there was no local `.venv`; `uv` attempted to create one and download `textual==8.2.3`, but network/DNS is unavailable.
+
+Useful validation commands once dependencies are available:
+
+```bash
+UV_CACHE_DIR=/private/tmp/uv-cache-inbox-sym-30 INBOX_TEST_MODE=1 uv run pytest -m safe -q
+uv run pytest -x -q
+uv run ruff check .
+uv run pyright
+uv run bandit -c pyproject.toml -r .
+```
+
+## Implementation-Ready Follow-Up Tasks
+
+### 1. Align the repo validation contract
+
+Owned files: `.factory/services.yaml`, `docs/TESTING_FOR_AGENTS.md`, `README.md`, `CLAUDE.md`
+
+Acceptance criteria:
+- The documented agent-safe, default, and full validation commands agree across docs and `.factory/services.yaml`.
+- The default test command no longer silently excludes `tests/test_audio.py` and `tests/test_llm.py` unless the exclusion is renamed to an explicit fast or partial lane.
+- Docs distinguish safe mocked tests from live/local-data tests.
+
+Smallest useful validation:
+
+```bash
+rg -n "pytest|test_audio|test_llm|pytest -m safe|pyright|ruff" .factory/services.yaml docs/TESTING_FOR_AGENTS.md README.md CLAUDE.md
+```
+
+### 2. Expand and audit `safe` pytest marker coverage
+
+Owned files: `tests/`, `pyproject.toml`, `docs/TESTING_FOR_AGENTS.md`
+
+Acceptance criteria:
+- Deterministic tests that use mocks, temp paths, and `INBOX_TEST_MODE=1` are marked `safe`.
+- Tests that require local personal data, live provider calls, or live writes are marked `local_data`, `integration`, or `live_write`.
+- A small audit test prevents new unmarked live-write tests from slipping into the safe lane.
+
+Smallest useful validation:
+
+```bash
+INBOX_TEST_MODE=1 uv run pytest -m safe -q
+```
+
+### 3. Make factory startup worktree-safe
+
+Owned files: `.factory/init.sh`, `.factory/services.yaml`, `.factory/library/environment.md`
+
+Acceptance criteria:
+- `.factory/init.sh` runs from the current repo root rather than hard-coded `/Users/jwalinshah/projects/inbox`.
+- Startup and stop commands respect `INBOX_SERVER_PORT` and do not kill port `9849` by default from an isolated worktree.
+- The script can be run consistently via executable bit or documented `bash .factory/init.sh`.
+
+Smallest useful validation:
+
+```bash
+bash -n .factory/init.sh
+rg -n "/Users/jwalinshah/projects/inbox|lsof -ti :9849|INBOX_SERVER_PORT" .factory/init.sh .factory/services.yaml .factory/library/environment.md
+```
+
+### 4. Add HTTP-layer live-write safety tests
+
+Owned files: `inbox_server.py`, `tests/test_server_endpoints.py`, `tests/test_inbox_test_mode.py`
+
+Acceptance criteria:
+- `INBOX_TEST_MODE=1` blocks representative HTTP mutation endpoints before mocked live services are touched.
+- Coverage includes Gmail send/read/archive, Calendar create/update/delete, Reminders create/complete/delete, Tasks create/update/delete, Drive/Sheets/Docs writes, GitHub mark-read, and notifications.
+- Existing read-only endpoints still work under test mode with temp or mocked data.
+
+Smallest useful validation:
+
+```bash
+INBOX_TEST_MODE=1 uv run pytest tests/test_server_endpoints.py tests/test_inbox_test_mode.py -q
+```
+
+### 5. Refresh stale architecture and validation library docs
+
+Owned files: `.factory/library/architecture.md`, `.factory/library/environment.md`, `.factory/library/architecture-hardening.md`, `DOCS_INDEX.md`
+
+Acceptance criteria:
+- Google service maps, OAuth scopes, shipped tabs, indexed inbox behavior, and MCP surfaces match current code.
+- Planned additions no longer list features already present in `README.md`, `CLAUDE.md`, or implemented modules.
+- The docs point future workers to `docs/TESTING_FOR_AGENTS.md` for safe validation rules.
+
+Smallest useful validation:
+
+```bash
+rg -n "returns three|3 new TUI tabs|gmail.readonly \\+ gmail.send \\+ calendar \\+ drive|test_audio.py|test_llm.py" .factory/library DOCS_INDEX.md
+```


### PR DESCRIPTION
## Summary

Adds generated whole-portfolio review reports from `2026-05-07-whole-portfolio-review`.

This PR is docs-only and includes successful `docs/overnight` report outputs.

## Included work

- Registered repo IDs: inbox, inbox-sym-115, inbox-sym-116, inbox-sym-117, inbox-sym-118, inbox-sym-119, inbox-sym-120, inbox-sym-214, inbox-sym-30
- Report files: 15

## Validation

- Secret-like scan over copied reports found no live token/API-key patterns.
- Placeholder secret examples such as `*_API_KEY=...` were redacted in copied report text.
- No product code, deploys, external tracker updates, or generated runtime logs are included.

## Review notes

Opened as a draft because the reports are generated audit output and should be skimmed before merge.