### PR TITLE
[codex] Package Now queue and repo typing updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  tests:
+    name: Test
+    runs-on: ubuntu-latest
+    env:
+      INBOX_TEST_MODE: "1"
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Run focused tests
+        run: uv run pytest tests/test_server.py tests/test_client.py tests/test_inbox_app.py -q

--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,5 @@ batch/.batch-state.lock
 # Hook-generated temp files
 CLAUDE.md.new
 .inbox_index.sqlite3
+.inbox_index.sqlite3-shm
+.inbox_index.sqlite3-wal

--- a/CODEX_WORKPAD.md
+++ b/CODEX_WORKPAD.md
@@ -1,0 +1,87 @@
+# inbox-existing-branch-handoff Workpad
+
+## Queue Item
+
+- Goal pack: Overnight stabilization
+- Item: `inbox-existing-branch-handoff`
+- Lane: `review_reconciliation`
+- Repo/worktree: `/Users/jwalinshah/projects/agent-stack/.agent-stack-worktrees/2026-05-09-overnight-stabilization/inbox-existing-branch-handoff`
+- Current branch: `codex/goal-inbox-existing-branch-handoff`
+- Existing branch under review: `codex/package-now-queue-clean-repo-typing`
+- Remote comparison base: `origin/codex/package-now-queue-clean-repo-typing`
+
+## Branch Evidence
+
+- Current HEAD: `a7f00c14958e96523795818836c790d1552d7115`
+- Ahead commit under review: `a7f00c1 Fix needs-action account rollup`
+- `git rev-list --left-right --count origin/codex/package-now-queue-clean-repo-typing...codex/package-now-queue-clean-repo-typing`: `0 1`
+- Local `codex/goal-inbox-existing-branch-handoff` and `codex/package-now-queue-clean-repo-typing` both pointed at `a7f00c1` before this workpad/handoff was added.
+
+## Validation
+
+Required command run:
+
+```bash
+INBOX_TEST_MODE=1 uv run pytest tests/test_server.py tests/test_client.py tests/test_inbox_app.py -q
+```
+
+Result: blocked before pytest, exit code `2`.
+
+Output:
+
+```text
+error: Failed to initialize cache at `/Users/jwalinshah/.cache/uv`
+  Caused by: failed to open file `/Users/jwalinshah/.cache/uv/sdists-v9/.git`: Operation not permitted (os error 1)
+```
+
+Diagnostic command run to separate code health from the sandbox cache issue:
+
+```bash
+UV_CACHE_DIR=/private/tmp/inbox-existing-branch-handoff-uv-cache INBOX_TEST_MODE=1 uv run pytest tests/test_server.py tests/test_client.py tests/test_inbox_app.py -q
+```
+
+Result: blocked before pytest, exit code `1`.
+
+Output:
+
+```text
+Using CPython 3.12.12
+Creating virtual environment at: .venv
+  x Failed to download `pyobjc-framework-quartz==12.1`
+  |- Request failed after 3 retries in 4.3s
+  |- Failed to fetch:
+  |  `https://files.pythonhosted.org/packages/e9/9b/780f057e5962f690f23fdff1083a4cfda5a96d5b4d3bb49505cac4f624f2/pyobjc_framework_quartz-12.1-cp312-cp312-macosx_10_13_universal2.whl`
+  |- error sending request for url
+  |  (https://files.pythonhosted.org/packages/e9/9b/780f057e5962f690f23fdff1083a4cfda5a96d5b4d3bb49505cac4f624f2/pyobjc_framework_quartz-12.1-cp312-cp312-macosx_10_13_universal2.whl)
+  |- client error (Connect)
+  |- dns error
+  `- failed to lookup address information: nodename nor servname provided, or
+      not known
+  help: `pyobjc-framework-quartz` (v12.1) was included because `inbox`
+        (v0.1.0) depends on `pyobjc-framework-quartz`
+```
+
+The diagnostic run created an ignored `.venv/` before dependency resolution failed. Cleanup with `rm -rf .venv` was blocked by local command policy; `.venv/` does not appear in `git status --short`.
+
+## Decision
+
+Packaging commit: none.
+
+No-commit reason: this worker produced a blocker handoff after the required validation command failed before pytest; the owned handoff files are intentionally left as local artifacts for coordinator review.
+
+The existing branch is not PR-ready from this worker because the required validation command could not reach pytest. The code change is small and test-backed in the ahead commit, but it needs validation rerun in an environment with a writable/accessible `uv` cache or preinstalled locked dependencies.
+
+## Final Local Status
+
+Expected `git status --short` for this handoff:
+
+```text
+?? CODEX_WORKPAD.md
+?? docs/handoffs/
+```
+
+## Next Reviewer Command
+
+```bash
+INBOX_TEST_MODE=1 uv run pytest tests/test_server.py tests/test_client.py tests/test_inbox_app.py -q
+```

--- a/docs/handoffs/package-now-queue-clean-repo-typing.md
+++ b/docs/handoffs/package-now-queue-clean-repo-typing.md
@@ -1,0 +1,118 @@
+# package-now-queue-clean-repo-typing Handoff
+
+## Summary
+
+Validated packaging was attempted for the existing ahead Inbox branch `codex/package-now-queue-clean-repo-typing`. The branch has one local commit ahead of its remote tracking comparison, but the required focused validation command was blocked before pytest by local `uv` cache permissions in this sandbox.
+
+Current PR-readiness: blocked. Do not publish or merge this branch until the required validation command passes in an environment that can access a writable `uv` cache and locked dependencies.
+
+## Branch And Commit
+
+- Worktree path: `/Users/jwalinshah/projects/agent-stack/.agent-stack-worktrees/2026-05-09-overnight-stabilization/inbox-existing-branch-handoff`
+- Worker branch: `codex/goal-inbox-existing-branch-handoff`
+- Existing branch under review: `codex/package-now-queue-clean-repo-typing`
+- Remote comparison base: `origin/codex/package-now-queue-clean-repo-typing`
+- Existing branch commit under review: `a7f00c14958e96523795818836c790d1552d7115`
+- Commit title: `Fix needs-action account rollup`
+- Ahead check: `git rev-list --left-right --count origin/codex/package-now-queue-clean-repo-typing...codex/package-now-queue-clean-repo-typing` returned `0 1`
+- Initial branch state: local `codex/goal-inbox-existing-branch-handoff` and `codex/package-now-queue-clean-repo-typing` both pointed at `a7f00c1`.
+
+## Packaging Artifacts
+
+- Files changed by this worker: `CODEX_WORKPAD.md`, `docs/handoffs/package-now-queue-clean-repo-typing.md`
+- Packaging commit: none.
+- No-commit reason: the required validation command failed before pytest, so this worker produced an uncommitted blocker handoff instead of advancing the worker branch with a docs-only commit.
+- Expected `git status --short`:
+
+```text
+?? CODEX_WORKPAD.md
+?? docs/handoffs/
+```
+
+## Existing Branch Diff
+
+Compared with `origin/codex/package-now-queue-clean-repo-typing`, the existing branch changes:
+
+```text
+ inbox_server.py      | 11 +++++++--
+ tests/test_server.py | 66 ++++++++++++++++++++++++++++++++++++++++++++++++++++
+ 2 files changed, 75 insertions(+), 2 deletions(-)
+```
+
+Behavioral scope observed from the diff:
+
+- `/inbox/needs-action` now treats undated tasks with either `needsAction` or `needs_action` status as action items.
+- `/inbox/needs-action?account=...` now scopes calendar rollup fetches to the requested account when that account exists.
+- `tests/test_server.py` adds coverage for account-scoped calendar events and undated `needsAction` tasks.
+
+## Validation
+
+Required validation command:
+
+```bash
+INBOX_TEST_MODE=1 uv run pytest tests/test_server.py tests/test_client.py tests/test_inbox_app.py -q
+```
+
+Result: failed before pytest, exit code `2`.
+
+Stdout/stderr record:
+
+```text
+error: Failed to initialize cache at `/Users/jwalinshah/.cache/uv`
+  Caused by: failed to open file `/Users/jwalinshah/.cache/uv/sdists-v9/.git`: Operation not permitted (os error 1)
+```
+
+Additional diagnostic command:
+
+```bash
+UV_CACHE_DIR=/private/tmp/inbox-existing-branch-handoff-uv-cache INBOX_TEST_MODE=1 uv run pytest tests/test_server.py tests/test_client.py tests/test_inbox_app.py -q
+```
+
+Result: failed before pytest, exit code `1`.
+
+Stdout/stderr record:
+
+```text
+Using CPython 3.12.12
+Creating virtual environment at: .venv
+  x Failed to download `pyobjc-framework-quartz==12.1`
+  |- Request failed after 3 retries in 4.3s
+  |- Failed to fetch:
+  |  `https://files.pythonhosted.org/packages/e9/9b/780f057e5962f690f23fdff1083a4cfda5a96d5b4d3bb49505cac4f624f2/pyobjc_framework_quartz-12.1-cp312-cp312-macosx_10_13_universal2.whl`
+  |- error sending request for url
+  |  (https://files.pythonhosted.org/packages/e9/9b/780f057e5962f690f23fdff1083a4cfda5a96d5b4d3bb49505cac4f624f2/pyobjc_framework_quartz-12.1-cp312-cp312-macosx_10_13_universal2.whl)
+  |- client error (Connect)
+  |- dns error
+  `- failed to lookup address information: nodename nor servname provided, or
+      not known
+  help: `pyobjc-framework-quartz` (v12.1) was included because `inbox`
+        (v0.1.0) depends on `pyobjc-framework-quartz`
+```
+
+The diagnostic command created an ignored `.venv/` before dependency resolution failed. Cleanup with `rm -rf .venv` was blocked by local command policy; `.venv/` is ignored and does not appear in `git status --short`.
+
+## PR Status
+
+- PR URL: none.
+- Publication was not attempted because this Goal Pack disallows external writes, and the required validation command did not pass.
+
+## Blockers
+
+- Required validation cannot run exactly in this sandbox because `uv` cannot access `/Users/jwalinshah/.cache/uv`.
+- The local-cache diagnostic path cannot install dependencies because network/DNS access is blocked.
+- No PR should be opened until the required validation command completes successfully.
+
+## Residual Risk
+
+- The branch diff is small and has focused tests in the ahead commit, but no pytest cases actually ran in this worker.
+- Calendar account scoping now passes `{}` to `calendar_events` when an unknown account is requested; this appears intentional for account filtering but still needs the focused suite.
+
+## Required Follow-Up
+
+Rerun:
+
+```bash
+INBOX_TEST_MODE=1 uv run pytest tests/test_server.py tests/test_client.py tests/test_inbox_app.py -q
+```
+
+If it passes, the existing branch `codex/package-now-queue-clean-repo-typing` can be reconsidered for PR publication.

--- a/gmail_triage.py
+++ b/gmail_triage.py
@@ -29,6 +29,12 @@ class GmailThreadSummaryOut(BaseModel):
     rank: float = 0.0
     brief: str = ""
     rich_data: dict[str, str] = {}
+    source: str = "gmail"
+    latest_external_id: str = ""
+    actionability: str = ""
+    urgency: str = ""
+    noise_class: str = ""
+    open_loop: str = ""
 
 
 class ThreadBriefOut(BaseModel):
@@ -252,6 +258,7 @@ def contact_to_thread_summary(c: Contact) -> GmailThreadSummaryOut:
         rank=rank,
         brief=" ".join(brief_parts),
         rich_data=extract_rich_data(wf, c.snippet),
+        source="gmail",
     )
 
 
@@ -260,7 +267,8 @@ def indexed_thread_to_summary(row: dict[str, object]) -> GmailThreadSummaryOut:
     summary = str(row.get("summary", "") or subject)
     workflow = classify_workflow(f"{subject}\n{summary}")
     needs_reply = bool(row.get("needs_reply"))
-    action_items = [str(row["open_loop"])] if row.get("open_loop") else []
+    open_loop = str(row.get("open_loop", "") or "")
+    action_items = [open_loop] if open_loop else []
     last_message_at = str(row.get("latest_item_at", ""))
     rank = rank_thread(
         last_message_at,
@@ -302,6 +310,12 @@ def indexed_thread_to_summary(row: dict[str, object]) -> GmailThreadSummaryOut:
         rank=rank,
         brief=" ".join(brief_parts),
         rich_data=extract_rich_data(workflow, rich_text),
+        source=str(row.get("source", "")),
+        latest_external_id=str(row.get("latest_external_id", "")),
+        actionability=str(row.get("actionability", "")),
+        urgency=str(row.get("urgency", "")),
+        noise_class=str(row.get("noise_class", "")),
+        open_loop=open_loop,
     )
 
 
@@ -334,4 +348,5 @@ def thread_summary_to_out(ts: ThreadSummary, label_map: dict[str, str]) -> Gmail
         rank=rank,
         brief=" ".join(brief_parts),
         rich_data=extract_rich_data(workflow, text),
+        source="gmail",
     )

--- a/inbox.py
+++ b/inbox.py
@@ -14,6 +14,7 @@ import time
 import webbrowser
 from dataclasses import dataclass
 from datetime import date, datetime, timedelta
+from typing import Any
 
 import httpx
 from rich.align import Align
@@ -60,6 +61,110 @@ def _format_request_error(action: str, exc: Exception) -> str:
     if isinstance(exc, httpx.RequestError):
         return "Server unreachable — press Ctrl+R to retry"
     return f"{action} failed: {exc}"
+
+
+def _now_item_key(item: dict) -> str:
+    if item.get("now_id"):
+        return str(item["now_id"])
+    if item.get("thread_id"):
+        return (
+            f"thread:{item.get('source', '')}:{item.get('owning_account', '')}:{item['thread_id']}"
+        )
+    if item.get("id"):
+        return f"{item.get('now_kind', 'item')}:{item.get('account', '')}:{item['id']}"
+    if item.get("event_id"):
+        return f"event:{item.get('account', '')}:{item.get('calendar_id', '')}:{item['event_id']}"
+    return repr(sorted(item.items()))
+
+
+def _format_now_due(value: str | None) -> str:
+    if not value:
+        return ""
+    try:
+        return datetime.fromisoformat(value).strftime("%b %d")
+    except (TypeError, ValueError):
+        return value
+
+
+def _normalize_needs_action(data: dict) -> list[dict]:
+    items: list[dict] = []
+    for thread in data.get("threads", []):
+        normalized = dict(thread)
+        normalized["now_kind"] = "thread"
+        normalized["title"] = thread.get("subject", "Untitled")
+        normalized["now_id"] = _now_item_key(normalized)
+        normalized["now_meta"] = [
+            thread.get("source", "thread"),
+            thread.get("actionability", ""),
+            thread.get("urgency", ""),
+            thread.get("workflow", ""),
+        ]
+        items.append(normalized)
+
+    for task in data.get("tasks", []):
+        due = _format_now_due(task.get("due"))
+        normalized = {
+            **task,
+            "now_kind": "task",
+            "now_id": f"task:{task.get('account', '')}:{task.get('list_id', '')}:{task.get('id', '')}",
+            "title": task.get("title", "Untitled task"),
+            "summary": task.get("notes", ""),
+            "source": "tasks",
+            "actionability": "task",
+            "now_meta": [
+                "task",
+                due,
+                task.get("list_title", ""),
+                task.get("workflow", ""),
+            ],
+        }
+        items.append(normalized)
+
+    for event in data.get("events", []):
+        start = event.get("start", "")
+        time_label = ""
+        if start:
+            try:
+                time_label = datetime.fromisoformat(start).strftime("%b %d %H:%M")
+            except (TypeError, ValueError):
+                time_label = start
+        normalized = {
+            **event,
+            "now_kind": "event",
+            "now_id": f"event:{event.get('account', '')}:{event.get('calendar_id', '')}:{event.get('event_id', '')}",
+            "title": event.get("summary", "Untitled event"),
+            "summary": event.get("description", "") or event.get("location", ""),
+            "source": "calendar",
+            "actionability": "prep",
+            "now_meta": [
+                "calendar",
+                time_label,
+                event.get("location", ""),
+                event.get("workflow", ""),
+            ],
+        }
+        items.append(normalized)
+    return items
+
+
+def _index_thread_message_ref(thread: dict) -> dict[str, str]:
+    source = str(thread.get("source", ""))
+    if source == "gmail":
+        conv_id = str(thread.get("latest_external_id") or thread.get("thread_id") or "")
+        return {
+            "source": source,
+            "conv_id": conv_id,
+            "thread_id": str(thread.get("thread_id", "")),
+            "account": str(thread.get("owning_account", "")),
+        }
+    if source == "imessage":
+        return {
+            "source": source,
+            "conv_id": str(thread.get("thread_id", "")),
+            "thread_id": "",
+            "account": "",
+        }
+    return {"source": "", "conv_id": "", "thread_id": "", "account": ""}
 
 
 @dataclass(frozen=True)
@@ -385,6 +490,15 @@ class IndexedThreadItem(ListItem):
         t.append(d.get("subject", "Untitled"), style="bold white")
         participants = ", ".join(d.get("participants", [])[:2])
         meta_parts: list[str] = []
+        source = d.get("source", "")
+        if source:
+            meta_parts.append(str(source))
+        actionability = d.get("actionability", "")
+        if actionability:
+            meta_parts.append(str(actionability))
+        urgency = d.get("urgency", "")
+        if urgency in ("high", "medium"):
+            meta_parts.append(f"{urgency} urgency")
         if participants:
             meta_parts.append(participants)
         workflow = d.get("workflow", "")
@@ -392,9 +506,40 @@ class IndexedThreadItem(ListItem):
             meta_parts.append(workflow)
         if meta_parts:
             t.append(f"\n  {' · '.join(meta_parts)}", style="dim")
-        brief = d.get("brief", "") or d.get("summary", "")
+        brief = d.get("open_loop", "") or d.get("brief", "") or d.get("summary", "")
         if brief:
             t.append(f"\n  {brief[:72]}", style="dim")
+        yield Static(t)
+
+
+class NowItem(ListItem):
+    def __init__(self, data: dict) -> None:
+        super().__init__()
+        self.data = data
+
+    def compose(self) -> ComposeResult:
+        d = self.data
+        kind = d.get("now_kind", "thread")
+        t = Text()
+        if kind == "task":
+            t.append("☐ ", style="yellow")
+        elif kind == "event":
+            t.append("󰃮 ", style="cyan")
+        elif d.get("needs_reply"):
+            t.append("↩ ", style="bold yellow")
+        else:
+            t.append("• ", style="dim")
+
+        title = d.get("title") or d.get("subject") or "Untitled"
+        t.append(str(title), style="bold white")
+
+        meta_parts = [str(value) for value in d.get("now_meta", []) if value]
+        if meta_parts:
+            t.append(f"\n  {' · '.join(meta_parts)}", style="dim")
+
+        brief = d.get("open_loop") or d.get("brief") or d.get("summary") or d.get("notes") or ""
+        if brief:
+            t.append(f"\n  {str(brief)[:72]}", style="dim")
         yield Static(t)
 
 
@@ -1700,10 +1845,17 @@ class InboxApp(App):
             return
 
         if self._active_filter == "all":
-            for thread in self.now_threads:
-                lv.append(IndexedThreadItem(thread))
-            status = f"[green]{len(self.now_threads)} indexed threads[/]"
-            status += "  [dim]Now view · summaries first[/]"
+            for item in self.now_threads:
+                lv.append(NowItem(item))
+            counts: dict[str, int] = {}
+            for item in self.now_threads:
+                kind = str(item.get("now_kind", "thread"))
+                counts[kind] = counts.get(kind, 0) + 1
+            count_parts = [f"{count} {kind}" for kind, count in sorted(counts.items())]
+            status = f"[green]{len(self.now_threads)} now items[/]"
+            if count_parts:
+                status += f"  [dim]{' · '.join(count_parts)}[/]"
+            status += "  [dim]threads / tasks / events[/]"
             self._update_sidebar_status(status)
             return
 
@@ -1770,7 +1922,13 @@ class InboxApp(App):
         lv = self.query_one("#contact-list", ListView)
         target_index = -1
 
-        if self._active_filter in ("all", "actionable", "waiting") and self.active_index_thread:
+        if self._active_filter == "all" and self.active_index_thread:
+            target_key = _now_item_key(self.active_index_thread)
+            for i, child in enumerate(lv.children):
+                if isinstance(child, NowItem) and _now_item_key(child.data) == target_key:
+                    target_index = i
+                    break
+        elif self._active_filter in ("actionable", "waiting") and self.active_index_thread:
             thread_id = self.active_index_thread.get("thread_id")
             for i, child in enumerate(lv.children):
                 if (
@@ -1859,7 +2017,7 @@ class InboxApp(App):
 
     # ── Vim mode actions ─────────────────────────────────────────────────
 
-    def _vim_focused_nav_widget(self):
+    def _vim_focused_nav_widget(self) -> Any | None:
         """Return the currently focused navigable widget (ListView/DataTable), or None."""
         focused = self.focused
         if focused is None:
@@ -2331,10 +2489,15 @@ class InboxApp(App):
             errors.append(_format_request_error("GitHub refresh", exc))
 
         try:
-            result = self.client.index_view("recent", limit=20)
-            now_threads = result.get("threads", []) if isinstance(result, dict) else []
+            result = self.client.needs_action()
+            now_threads = _normalize_needs_action(result) if isinstance(result, dict) else []
         except Exception as exc:
-            errors.append(_format_request_error("Indexed recent refresh", exc))
+            errors.append(_format_request_error("Now refresh", exc))
+            try:
+                result = self.client.index_view("now", limit=20)
+                now_threads = result.get("threads", []) if isinstance(result, dict) else []
+            except Exception:
+                pass
 
         try:
             result = self.client.index_view("actionable", limit=20)
@@ -2417,8 +2580,8 @@ class InboxApp(App):
         )
         auxiliary = self._collect_auxiliary_data()
         if not changed:
-            old_now_ids = [t.get("thread_id") for t in self.now_threads]
-            new_now_ids = [t.get("thread_id") for t in auxiliary.now_threads]
+            old_now_ids = [_now_item_key(t) for t in self.now_threads]
+            new_now_ids = [_now_item_key(t) for t in auxiliary.now_threads]
             old_action_ids = [t.get("thread_id") for t in self.actionable_threads]
             new_action_ids = [t.get("thread_id") for t in auxiliary.actionable_threads]
             old_wait_ids = [t.get("thread_id") for t in self.waiting_threads]
@@ -2648,6 +2811,18 @@ class InboxApp(App):
             self.query_one("#detail-view", DetailView).detail = item.data
             return
 
+        if isinstance(item, NowItem):
+            self.active_index_thread = item.data
+            self.active_conv = None
+            self.active_event = item.data if item.data.get("now_kind") == "event" else None
+            self.active_reminder = None
+            self.active_notification = None
+            if item.data.get("now_kind", "thread") == "thread":
+                self._load_index_thread(item.data)
+            else:
+                self._show_now_item(item.data)
+            return
+
         if isinstance(item, NoteItem):
             self.active_event = None
             self._load_note(item.data)
@@ -2659,7 +2834,7 @@ class InboxApp(App):
             self.active_event = None
             self.active_reminder = None
             self.active_notification = None
-            self._show_index_thread(item.data)
+            self._load_index_thread(item.data)
             return
 
         if isinstance(item, ConversationItem):
@@ -2682,6 +2857,39 @@ class InboxApp(App):
                 f"[red]{_format_request_error('Thread load', e)}[/]",
             )
             return
+        self.call_from_thread(self._show_thread, msgs, conv)
+
+    @work(thread=True, exit_on_error=False)
+    def _load_index_thread(self, thread: dict) -> None:
+        ref = _index_thread_message_ref(thread)
+        if not ref["source"] or not ref["conv_id"]:
+            self.call_from_thread(self._show_index_thread, thread)
+            return
+        try:
+            msgs = self.client.messages(
+                source=ref["source"],
+                conv_id=ref["conv_id"],
+                thread_id=ref["thread_id"],
+                account=ref["account"],
+            )
+        except Exception as exc:
+            self.call_from_thread(
+                self.query_one("#status", Static).update,
+                f"[yellow]{_format_request_error('Indexed thread load', exc)} · showing summary[/]",
+            )
+            self.call_from_thread(self._show_index_thread, thread)
+            return
+        if not msgs:
+            self.call_from_thread(self._show_index_thread, thread)
+            return
+
+        conv = {
+            "id": ref["conv_id"],
+            "source": ref["source"],
+            "name": thread.get("subject") or thread.get("summary") or "Indexed thread",
+            "thread_id": ref["thread_id"],
+            "gmail_account": ref["account"],
+        }
         self.call_from_thread(self._show_thread, msgs, conv)
 
     def _show_thread(self, msgs: list[dict], conv: dict) -> None:
@@ -2717,14 +2925,85 @@ class InboxApp(App):
                 key = conv.get("id", "") or str(hash(body))
                 self._do_extract_actions(body, key)
 
+    def _show_now_item(self, item: dict) -> None:
+        if item.get("now_kind", "thread") == "thread":
+            self._show_index_thread(item)
+            return
+
+        mv = self.query_one("#messages", MessageView)
+        kind = str(item.get("now_kind", "item"))
+        title = str(item.get("title") or item.get("summary") or "Untitled")
+        lines: list[str] = []
+
+        meta_parts = [str(value) for value in item.get("now_meta", []) if value]
+        if meta_parts:
+            lines.append(" · ".join(meta_parts))
+            lines.append("")
+
+        if kind == "task":
+            if item.get("due"):
+                lines.append(f"Due: {item['due']}")
+            if item.get("list_title"):
+                lines.append(f"List: {item['list_title']}")
+            if item.get("notes"):
+                lines.append("")
+                lines.append(str(item["notes"]))
+        elif kind == "event":
+            if item.get("start") and item.get("end"):
+                lines.append(f"When: {item['start']} -> {item['end']}")
+            if item.get("location"):
+                lines.append(f"Where: {item['location']}")
+            if item.get("description"):
+                lines.append("")
+                lines.append(str(item["description"]))
+        else:
+            lines.append(str(item.get("summary", "")))
+
+        body = "\n".join(lines).strip() or title
+        mv.ai_summary = None
+        mv.messages = [
+            {
+                "body": body,
+                "ts": item.get("start") or item.get("due") or "",
+                "sender": "Inbox Now",
+                "is_me": False,
+            }
+        ]
+        self.query_one("#status", Static).update(f"[bold]{title}[/]  [dim]now · {kind}[/]")
+
     def _show_index_thread(self, thread: dict) -> None:
         mv = self.query_one("#messages", MessageView)
         lines = []
+        meta_parts = [
+            str(value)
+            for value in (
+                thread.get("source", ""),
+                thread.get("owning_account", ""),
+                thread.get("actionability", ""),
+                thread.get("urgency", ""),
+            )
+            if value
+        ]
+        if meta_parts:
+            lines.append(" · ".join(meta_parts))
+            lines.append("")
         if thread.get("summary"):
             lines.append(str(thread["summary"]))
+        if thread.get("open_loop"):
+            lines.append("")
+            lines.append(f"Open loop: {thread['open_loop']}")
         if thread.get("action_items"):
-            lines.append("Action items:")
-            lines.extend(f"- {item}" for item in thread["action_items"][:5])
+            action_items = [
+                item for item in thread["action_items"][:5] if item != thread.get("open_loop")
+            ]
+            if action_items:
+                lines.append("Action items:")
+                lines.extend(f"- {item}" for item in action_items)
+        if thread.get("rich_data"):
+            lines.append("")
+            lines.append("Signals:")
+            for key, value in thread["rich_data"].items():
+                lines.append(f"- {key}: {value}")
         if thread.get("brief"):
             lines.append("")
             lines.append(str(thread["brief"]))
@@ -4128,7 +4407,7 @@ class InboxApp(App):
     @work(thread=True, exit_on_error=False)
     def _do_run_readonly_assistant(self, query: str, context_text: str) -> None:
         try:
-            from agents.runner import Supervisor
+            from agents.runner import Supervisor  # type: ignore[reportMissingImports]
 
             result = Supervisor().run_codex_exec(
                 profile_name="readonly",

--- a/inbox_client.py
+++ b/inbox_client.py
@@ -121,6 +121,9 @@ class InboxClient:
     def indexed_recent_threads(self, *, limit: int = 20) -> dict:
         return self.index_view("recent", limit=limit)
 
+    def indexed_now_threads(self, *, limit: int = 20) -> dict:
+        return self.index_view("now", limit=limit)
+
     def indexed_actionable_threads(self, *, limit: int = 20) -> dict:
         return self.index_view("actionable", limit=limit)
 
@@ -130,6 +133,16 @@ class InboxClient:
     def indexed_waiting_on_others_threads(self, *, limit: int = 20) -> dict:
         return self.index_view("waiting-on-others", limit=limit)
 
+    def needs_action(self, *, workflow: str = "", account: str = "") -> dict:
+        params = {}
+        if workflow:
+            params["workflow"] = workflow
+        if account:
+            params["account"] = account
+        r = self._client.get("/inbox/needs-action", params=params)
+        r.raise_for_status()
+        return r.json()
+
     # ── Messages ─────────────────────────────────────────────────────────
 
     def messages(
@@ -138,10 +151,13 @@ class InboxClient:
         conv_id: str,
         thread_id: str = "",
         limit: int = 50,
+        account: str = "",
     ) -> list[dict]:
         params: dict = {"limit": limit}
         if thread_id:
             params["thread_id"] = thread_id
+        if account:
+            params["account"] = account
         r = self._client.get(f"/messages/{source}/{conv_id}", params=params)
         r.raise_for_status()
         return r.json()

--- a/inbox_mcp_readonly.py
+++ b/inbox_mcp_readonly.py
@@ -44,7 +44,7 @@ health = make_health_handler(
 @mcp.tool()
 async def read_daily_note(date: str = "") -> dict:
     """Read today's daily note or a specific YYYY-MM-DD note if present."""
-    path = ambient_notes._today_file() if not date else ambient_notes.VAULT_DIR / f"{date}.md"
+    path = ambient_notes._today_file() if not date else ambient_notes.DAILY_DIR / f"{date}.md"
     if not path.exists():
         return {"ok": False, "path": str(path), "content": ""}
     return {"ok": True, "path": str(path), "content": path.read_text(encoding="utf-8")}

--- a/inbox_server.py
+++ b/inbox_server.py
@@ -1070,7 +1070,7 @@ async def _process_followup_reminders() -> None:
                         contacts = await asyncio.to_thread(imsg_contacts, 200)
                         contact = next((c for c in contacts if c.id == fu["conv_id"]), None)
                     if contact:
-                        msgs = await asyncio.to_thread(imsg_thread, contact, 20)
+                        msgs = await asyncio.to_thread(imsg_thread, contact.id, 20)
                         replied = any(m.ts > created_at and not m.is_me for m in msgs)
 
                 if replied:
@@ -1411,13 +1411,17 @@ async def list_conversations(source: str = "all", limit: int = 50, account: str 
 
 
 @app.get("/messages/{source}/{conv_id}", response_model=list[MessageOut])
-async def get_messages(source: str, conv_id: str, thread_id: str = "", limit: int = 50):
+async def get_messages(
+    source: str, conv_id: str, thread_id: str = "", limit: int = 50, account: str = ""
+):
     if source == "imessage":
         msgs = await asyncio.to_thread(imsg_thread, conv_id, limit=limit)
     elif source == "gmail":
         # Find the right service
         contact = state.conv_cache.get(_cache_key("gmail", conv_id))
-        if contact and contact.gmail_account in state.gmail_services:
+        if account and account in state.gmail_services:
+            svc = state.gmail_services[account]
+        elif contact and contact.gmail_account in state.gmail_services:
             svc = state.gmail_services[contact.gmail_account]
         elif state.gmail_services:
             svc = next(iter(state.gmail_services.values()))
@@ -2769,6 +2773,13 @@ def _get_docs_service_for_account(account: str = "") -> tuple[str, object]:
 
 
 def _index_view_rows(view: str, limit: int) -> list[dict[str, object]]:
+    if view == "now":
+        return state.index_store.list_threads(
+            limit=limit,
+            actions=("reply", "review", "track"),
+            newest_only=True,
+            sort_mode="priority",
+        )
     if view == "actionable":
         return state.index_store.list_threads(
             limit=limit,
@@ -3514,7 +3525,7 @@ async def set_reminders(
     req: EventRemindersRequest,
 ):
     acct, svc = _get_cal_service_for_account(req.account)
-    reminders_dict = {"useDefault": req.use_default}
+    reminders_dict: dict[str, Any] = {"useDefault": req.use_default}
     if not req.use_default:
         reminders_dict["overrides"] = req.overrides
     ok = await asyncio.to_thread(
@@ -3605,8 +3616,8 @@ async def check_calendar_conflicts(start: str, end: str, account: str = ""):
         return {
             "conflicts": [
                 {
-                    "id": c.id,
-                    "title": c.title,
+                    "id": c.event_id,
+                    "title": c.summary,
                     "start": c.start,
                     "end": c.end,
                     "location": c.location or "",
@@ -3622,7 +3633,7 @@ async def check_calendar_conflicts(start: str, end: str, account: str = ""):
 async def extract_memory_endpoint(text: str, source: str = "manual", auto_save: bool = False):
     """Extract memory entities from text and optionally save to memory store."""
     try:
-        extracted = await asyncio.to_thread(ai_extract_memory, text)
+        extracted: Any = await asyncio.to_thread(ai_extract_memory, text)
         saved_count = 0
 
         if auto_save:
@@ -3902,11 +3913,11 @@ async def cross_silo_query(req: _QueryRequest):
     Returns gracefully with 503 when not installed.
     """
     try:
-        import gemma4_hackathon.silos.calendar  # noqa: F401
-        import gemma4_hackathon.silos.gmail  # noqa: F401
-        import gemma4_hackathon.silos.imessage  # noqa: F401  trigger registration
-        import gemma4_hackathon.silos.memory  # noqa: F401
-        import gemma4_hackathon.silos.photos  # noqa: F401
+        import gemma4_hackathon.silos.calendar  # type: ignore[reportMissingImports]  # noqa: F401
+        import gemma4_hackathon.silos.gmail  # type: ignore[reportMissingImports]  # noqa: F401
+        import gemma4_hackathon.silos.imessage  # type: ignore[reportMissingImports]  # noqa: F401
+        import gemma4_hackathon.silos.memory  # type: ignore[reportMissingImports]  # noqa: F401
+        import gemma4_hackathon.silos.photos  # type: ignore[reportMissingImports]  # noqa: F401
         from gemma4_hackathon.orchestrator import Orchestrator  # type: ignore
     except ImportError as exc:
         raise HTTPException(503, f"gemma4_hackathon not installed: {exc}") from exc

--- a/inbox_server.py
+++ b/inbox_server.py
@@ -3777,7 +3777,9 @@ async def get_needs_action(workflow: str = "", account: str = ""):
                 task_out = _task_to_out(t, acct)
                 if workflow and task_out.workflow != workflow:
                     continue
-                if (t.due and t.due <= today) or (t.status == "needs_action" and not t.due):
+                if (t.due and t.due <= today) or (
+                    t.status in {"needsAction", "needs_action"} and not t.due
+                ):
                     tasks.append(task_out)
                 if len(tasks) >= 10:
                     break
@@ -3787,9 +3789,14 @@ async def get_needs_action(workflow: str = "", account: str = ""):
     events: list[CalendarEventOut] = []
     if state.cal_services:
         try:
+            cal_services = (
+                {account: state.cal_services[account]}
+                if account and account in state.cal_services
+                else ({} if account else state.cal_services)
+            )
             evts = await asyncio.to_thread(
                 calendar_events,
-                state.cal_services,
+                cal_services,
                 start_date=today,
                 end_date=three_days_out,
             )

--- a/memory_store.py
+++ b/memory_store.py
@@ -112,7 +112,9 @@ class MemoryStore:
                     metadata_json,
                 ),
             )
-            entry_id = int(cursor.lastrowid)
+            entry_id = cursor.lastrowid
+            if entry_id is None:
+                raise RuntimeError("SQLite did not return an id for the inserted memory entry")
         return self.get_entry(entry_id)
 
     def get_entry(self, entry_id: int) -> dict[str, object]:

--- a/organize_inbox.py
+++ b/organize_inbox.py
@@ -54,8 +54,8 @@ def main():
                 print(f"  {label_name}: 0 emails matched")
                 continue
 
-            # Get message IDs
-            msg_ids = [conv["message_id"] for conv in conversations if conv.get("message_id")]
+            # gmail_search returns Contact objects whose id is the Gmail message id.
+            msg_ids = [conv.id for conv in conversations if conv.id]
 
             if msg_ids:
                 # Batch apply label (no removal, no archiving)

--- a/services.py
+++ b/services.py
@@ -4337,6 +4337,7 @@ def sheets_rename_sheet(
     sheets_service: Any, spreadsheet_id: str, sheet_id: int, new_title: str
 ) -> bool:
     """Rename a sheet tab."""
+    _assert_live_write_allowed("rename Google Sheet tab")
     try:
         sheets_service.spreadsheets().batchUpdate(
             spreadsheetId=spreadsheet_id,
@@ -4361,6 +4362,7 @@ def sheets_rename_sheet(
 
 def sheets_format(sheets_service: Any, spreadsheet_id: str, requests: list[dict]) -> dict | None:
     """Apply formatting via raw batchUpdate requests. For max flexibility."""
+    _assert_live_write_allowed("format Google Sheet")
     try:
         result = (
             sheets_service.spreadsheets()
@@ -4380,6 +4382,7 @@ def sheets_copy_to(
     sheets_service: Any, spreadsheet_id: str, sheet_id: int, dest_spreadsheet_id: str
 ) -> SheetTab | None:
     """Copy a sheet to another spreadsheet."""
+    _assert_live_write_allowed("copy Google Sheet tab")
     try:
         result = (
             sheets_service.spreadsheets()
@@ -4496,6 +4499,7 @@ def docs_export(
 
 def docs_insert_text(docs_service: Any, document_id: str, text: str, index: int = 1) -> bool:
     """Insert text into a document at specified index."""
+    _assert_live_write_allowed("insert Google Doc text")
     try:
         docs_service.documents().batchUpdate(
             documentId=document_id,

--- a/services.py
+++ b/services.py
@@ -6,6 +6,7 @@ All data fetching, auth, mutation, audio, and LLM logic lives here.
 from __future__ import annotations
 
 import base64
+import contextlib
 import fcntl
 import json
 import mimetypes
@@ -20,12 +21,10 @@ from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from email.mime.text import MIMEText
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, TypedDict, cast
 
 if TYPE_CHECKING:
     from pydantic import BaseModel as PydanticBaseModel
-
-import contextlib
 
 import httpx
 from google.auth.transport.requests import Request
@@ -50,6 +49,20 @@ from service_models import (
     Spreadsheet,
     ThreadSummary,
 )
+
+
+class UnsubscribeInfo(TypedDict):
+    url: str | None
+    mailto: str | None
+    one_click: bool
+    raw: str
+
+
+class UnsubscribeResult(TypedDict):
+    method: str
+    ok: bool
+    raw: str
+
 
 # ── Config ────────────────────────────────────────────────────────────────────
 
@@ -328,12 +341,12 @@ def _load_creds(token_path: Path) -> Credentials | None:
 
 
 def google_auth_all() -> tuple[
-    dict[str, object],
-    dict[str, object],
-    dict[str, object],
-    dict[str, object],
-    dict[str, object],
-    dict[str, object],
+    dict[str, Any],
+    dict[str, Any],
+    dict[str, Any],
+    dict[str, Any],
+    dict[str, Any],
+    dict[str, Any],
 ]:
     """Auth all accounts from tokens/ dir. Returns (gmail_svcs, cal_svcs, drive_svcs, sheets_svcs, docs_svcs, tasks_svcs)."""
     TOKENS_DIR.mkdir(parents=True, exist_ok=True)
@@ -357,12 +370,12 @@ def google_auth_all() -> tuple[
                     dest = TOKENS_DIR / f"{email}.json"
                     _write_text_with_lock(dest, new_creds.to_json())
 
-    gmail_svcs: dict[str, object] = {}
-    cal_svcs: dict[str, object] = {}
-    drive_svcs: dict[str, object] = {}
-    sheets_svcs: dict[str, object] = {}
-    docs_svcs: dict[str, object] = {}
-    tasks_svcs: dict[str, object] = {}
+    gmail_svcs: dict[str, Any] = {}
+    cal_svcs: dict[str, Any] = {}
+    drive_svcs: dict[str, Any] = {}
+    sheets_svcs: dict[str, Any] = {}
+    docs_svcs: dict[str, Any] = {}
+    tasks_svcs: dict[str, Any] = {}
 
     for token_path in sorted(TOKENS_DIR.glob("*.json")):
         creds = _load_creds(token_path)
@@ -1008,7 +1021,7 @@ def gmail_archive(service, msg_id: str) -> bool:
         return False
 
 
-def gmail_get_unsubscribe_info(service, msg_id: str) -> dict[str, str]:
+def gmail_get_unsubscribe_info(service, msg_id: str) -> UnsubscribeInfo:
     """Return {'url': ..., 'mailto': ..., 'one_click': bool} from List-Unsubscribe headers."""
     try:
         msg = (
@@ -1041,7 +1054,7 @@ def gmail_get_unsubscribe_info(service, msg_id: str) -> dict[str, str]:
         return {"url": None, "mailto": None, "one_click": False, "raw": ""}
 
 
-def gmail_unsubscribe(service, msg_id: str) -> dict[str, str]:
+def gmail_unsubscribe(service, msg_id: str) -> UnsubscribeResult:
     """
     Execute unsubscribe via List-Unsubscribe header, then archive the message.
     Returns {"method": "url|mailto|none", "ok": bool}.
@@ -1473,7 +1486,7 @@ def gmail_contacts_by_label(
 
 
 def calendar_events(
-    cal_services: dict[str, object],
+    cal_services: dict[str, Any],
     date: datetime | None = None,
     start_date: datetime | None = None,
     end_date: datetime | None = None,
@@ -1782,7 +1795,7 @@ def gmail_label_create(service, name: str, visibility: str = "labelShow") -> dic
 
 
 def calendar_find_conflicts(
-    cal_services: dict[str, object], start: datetime, end: datetime
+    cal_services: dict[str, Any], start: datetime, end: datetime
 ) -> list[CalendarEvent]:
     """Find calendar events that conflict with time range [start, end] across all accounts."""
     conflicts = []
@@ -1854,11 +1867,12 @@ def ai_extract_memory(text: str) -> dict[str, object]:
                 schema=MemoryExtractionResult,
             )
         if result:
+            extracted = cast(MemoryExtractionResult, result)
             return {
-                "people": [p.dict() for p in result.people],
-                "projects": [p.dict() for p in result.projects],
-                "commitments": [c.dict() for c in result.commitments],
-                "action_items": result.action_items,
+                "people": [p.dict() for p in extracted.people],
+                "projects": [p.dict() for p in extracted.projects],
+                "commitments": [c.dict() for c in extracted.commitments],
+                "action_items": extracted.action_items,
             }
     except Exception:
         _log_service_failure("ai_extract_memory")
@@ -2021,14 +2035,30 @@ def parse_quick_event(text: str) -> dict:
 # ── WhatsApp (via macOS Accessibility API) ───────────────────────────────────
 
 
+def _foundation_module() -> Any:
+    import Foundation
+
+    return cast(Any, Foundation)
+
+
+def _application_services() -> Any:
+    import ApplicationServices
+
+    return cast(Any, ApplicationServices)
+
+
+def _core_foundation() -> Any:
+    import CoreFoundation
+
+    return cast(Any, CoreFoundation)
+
+
 def _whatsapp_pid() -> int | None:
     """Find WhatsApp.app PID via NSRunningApplication.
     Returns None if WhatsApp is not running or Objective-C imports fail.
     """
     try:
-        from Foundation import NSWorkspace
-
-        ws = NSWorkspace.sharedWorkspace()
+        ws = _foundation_module().NSWorkspace.sharedWorkspace()
         apps = ws.runningApplications()
         for app in apps:
             if app.bundleIdentifier() == "net.whatsapp.WhatsApp":
@@ -2041,9 +2071,7 @@ def _whatsapp_pid() -> int | None:
 def _ax_attr(el: Any, name: str) -> Any:
     """Safe AX attribute getter. Returns None on failure."""
     try:
-        from ApplicationServices import AXUIElementCopyAttributeValue
-
-        err, val = AXUIElementCopyAttributeValue(el, name, None)
+        err, val = _application_services().AXUIElementCopyAttributeValue(el, name, None)
         if err != 0:
             return None
         return val
@@ -2078,26 +2106,20 @@ def whatsapp_check_accessibility(prompt: bool = False) -> bool:
     """Check if this process has Accessibility permission. If prompt=True, shows system dialog."""
     try:
         if prompt:
-            from ApplicationServices import AXIsProcessTrustedWithOptions
-            from CoreFoundation import (
-                CFDictionaryCreate,
-                kCFTypeDictionaryKeyCallBacks,
-                kCFTypeDictionaryValueCallBacks,
-            )
+            app_services = _application_services()
+            core_foundation = _core_foundation()
 
             key = "AXTrustedCheckOptionPrompt"
-            opts = CFDictionaryCreate(
+            opts = core_foundation.CFDictionaryCreate(
                 None,
                 [key],
                 [True],
                 1,
-                kCFTypeDictionaryKeyCallBacks,
-                kCFTypeDictionaryValueCallBacks,
+                core_foundation.kCFTypeDictionaryKeyCallBacks,
+                core_foundation.kCFTypeDictionaryValueCallBacks,
             )
-            return bool(AXIsProcessTrustedWithOptions(opts))
-        from ApplicationServices import AXIsProcessTrusted
-
-        return bool(AXIsProcessTrusted())
+            return bool(app_services.AXIsProcessTrustedWithOptions(opts))
+        return bool(_application_services().AXIsProcessTrusted())
     except Exception:
         return False
 
@@ -2128,9 +2150,7 @@ def _whatsapp_app_ref() -> Any:
         pid = _whatsapp_pid()
         if not pid:
             return None
-        from ApplicationServices import AXUIElementCreateApplication
-
-        return AXUIElementCreateApplication(pid)
+        return _application_services().AXUIElementCreateApplication(pid)
     except Exception:
         return None
 
@@ -2258,7 +2278,7 @@ def whatsapp_contacts(limit: int = 20) -> list[Contact]:
 def _whatsapp_select_chat(chat_name: str) -> bool:
     """Click the sidebar AXButton whose parsed name matches chat_name."""
     try:
-        from ApplicationServices import AXUIElementPerformAction
+        app_services = _application_services()
 
         window = _whatsapp_main_window()
         if not window:
@@ -2277,7 +2297,7 @@ def _whatsapp_select_chat(chat_name: str) -> bool:
             if parsed[0].lower() == target_lower:
                 # AXStaticText = already-selected row, no press needed
                 if role == "AXButton":
-                    AXUIElementPerformAction(row, "AXPress")
+                    app_services.AXUIElementPerformAction(row, "AXPress")
                 return True
         return False
     except Exception:
@@ -2310,26 +2330,28 @@ def _cg_type_text(text: str) -> None:
     """Type a unicode string via synthesized keyboard events at HID level."""
     import Quartz
 
-    src = Quartz.CGEventSourceCreate(Quartz.kCGEventSourceStateHIDSystemState)
+    quartz = cast(Any, Quartz)
+    src = quartz.CGEventSourceCreate(quartz.kCGEventSourceStateHIDSystemState)
     # Chunk into pieces CGEventKeyboardSetUnicodeString can carry (<= 20 chars per event)
     for i in range(0, len(text), 20):
         chunk = text[i : i + 20]
-        down = Quartz.CGEventCreateKeyboardEvent(src, 0, True)
-        Quartz.CGEventKeyboardSetUnicodeString(down, len(chunk), chunk)
-        Quartz.CGEventPost(Quartz.kCGHIDEventTap, down)
-        up = Quartz.CGEventCreateKeyboardEvent(src, 0, False)
-        Quartz.CGEventKeyboardSetUnicodeString(up, len(chunk), chunk)
-        Quartz.CGEventPost(Quartz.kCGHIDEventTap, up)
+        down = quartz.CGEventCreateKeyboardEvent(src, 0, True)
+        quartz.CGEventKeyboardSetUnicodeString(down, len(chunk), chunk)
+        quartz.CGEventPost(quartz.kCGHIDEventTap, down)
+        up = quartz.CGEventCreateKeyboardEvent(src, 0, False)
+        quartz.CGEventKeyboardSetUnicodeString(up, len(chunk), chunk)
+        quartz.CGEventPost(quartz.kCGHIDEventTap, up)
 
 
 def _cg_press_key(keycode: int) -> None:
     import Quartz
 
-    src = Quartz.CGEventSourceCreate(Quartz.kCGEventSourceStateHIDSystemState)
-    down = Quartz.CGEventCreateKeyboardEvent(src, keycode, True)
-    up = Quartz.CGEventCreateKeyboardEvent(src, keycode, False)
-    Quartz.CGEventPost(Quartz.kCGHIDEventTap, down)
-    Quartz.CGEventPost(Quartz.kCGHIDEventTap, up)
+    quartz = cast(Any, Quartz)
+    src = quartz.CGEventSourceCreate(quartz.kCGEventSourceStateHIDSystemState)
+    down = quartz.CGEventCreateKeyboardEvent(src, keycode, True)
+    up = quartz.CGEventCreateKeyboardEvent(src, keycode, False)
+    quartz.CGEventPost(quartz.kCGHIDEventTap, down)
+    quartz.CGEventPost(quartz.kCGHIDEventTap, up)
 
 
 def whatsapp_send(chat_name: str, text: str) -> bool:
@@ -2343,7 +2365,7 @@ def whatsapp_send(chat_name: str, text: str) -> bool:
             return False
         if not text.strip():
             return False
-        from ApplicationServices import AXUIElementSetAttributeValue
+        app_services = _application_services()
 
         if not _wa_activate_app():
             return False
@@ -2365,7 +2387,7 @@ def whatsapp_send(chat_name: str, text: str) -> bool:
         areas = _ax_walk(window, is_compose, max_depth=25)
         if not areas:
             return False
-        AXUIElementSetAttributeValue(areas[0], "AXFocused", True)
+        app_services.AXUIElementSetAttributeValue(areas[0], "AXFocused", True)
         time.sleep(0.2)
 
         _cg_type_text(text)
@@ -2383,7 +2405,7 @@ def whatsapp_scroll_sidebar(pages: int = 1) -> int:
     try:
         if not whatsapp_check_accessibility(prompt=False):
             return 0
-        from ApplicationServices import AXUIElementPerformAction
+        app_services = _application_services()
 
         window = _whatsapp_main_window()
         if not window:
@@ -2395,7 +2417,7 @@ def whatsapp_scroll_sidebar(pages: int = 1) -> int:
         import time
 
         for _ in range(max(1, pages)):
-            err = AXUIElementPerformAction(chat_list, "AXScrollDownByPage")
+            err = app_services.AXUIElementPerformAction(chat_list, "AXScrollDownByPage")
             if err != 0:
                 break
             done += 1
@@ -2413,7 +2435,7 @@ def whatsapp_contacts_all(max_pages: int = 10) -> list[Contact]:
     try:
         if not whatsapp_check_accessibility(prompt=False):
             return []
-        from ApplicationServices import AXUIElementPerformAction
+        app_services = _application_services()
 
         window = _whatsapp_main_window()
         if not window:
@@ -2425,7 +2447,7 @@ def whatsapp_contacts_all(max_pages: int = 10) -> list[Contact]:
 
         # Rewind to top
         for _ in range(max_pages):
-            err = AXUIElementPerformAction(chat_list, "AXScrollUpByPage")
+            err = app_services.AXUIElementPerformAction(chat_list, "AXScrollUpByPage")
             if err != 0:
                 break
             time.sleep(0.1)
@@ -2437,7 +2459,7 @@ def whatsapp_contacts_all(max_pages: int = 10) -> list[Contact]:
                 if c.name and c.name not in seen:
                     seen[c.name] = c
             before = len(seen)
-            err = AXUIElementPerformAction(chat_list, "AXScrollDownByPage")
+            err = app_services.AXUIElementPerformAction(chat_list, "AXScrollDownByPage")
             if err != 0:
                 break
             time.sleep(0.3)
@@ -2463,7 +2485,7 @@ def whatsapp_thread_full(chat_name: str, max_loads: int = 10, limit: int = 500) 
     try:
         if not whatsapp_check_accessibility(prompt=False):
             return []
-        from ApplicationServices import AXUIElementPerformAction
+        app_services = _application_services()
 
         if not _wa_activate_app():
             return []
@@ -2487,14 +2509,14 @@ def whatsapp_thread_full(chat_name: str, max_loads: int = 10, limit: int = 500) 
             if not hits:
                 break
             # The clickable is typically a parent AXButton of the static text; press static too
-            err = AXUIElementPerformAction(hits[0], "AXPress")
+            err = app_services.AXUIElementPerformAction(hits[0], "AXPress")
             if err != 0:
                 # Try parent
-                from ApplicationServices import AXUIElementCopyAttributeValue
-
-                p_err, parent = AXUIElementCopyAttributeValue(hits[0], "AXParent", None)
+                p_err, parent = app_services.AXUIElementCopyAttributeValue(
+                    hits[0], "AXParent", None
+                )
                 if parent is not None:
-                    AXUIElementPerformAction(parent, "AXPress")
+                    app_services.AXUIElementPerformAction(parent, "AXPress")
             time.sleep(0.8)
 
         return whatsapp_thread(chat_name, limit=limit)
@@ -3259,6 +3281,7 @@ def _get_gemini_model(model_name: str = "gemini-2.5-flash"):
     try:
         import google.generativeai as genai
 
+        genai = cast(Any, genai)
         genai.configure(api_key=api_key)
         _gemini_model = genai.GenerativeModel(model_name)
         return _gemini_model
@@ -4024,7 +4047,7 @@ def drive_download(drive_service, file_id: str) -> tuple[bytes, str] | None:
 
 
 def sheets_list(
-    drive_service: object, query: str = "", limit: int = 20, account: str = ""
+    drive_service: Any, query: str = "", limit: int = 20, account: str = ""
 ) -> list[Spreadsheet]:
     """List spreadsheets from Drive. Returns list of Spreadsheet, empty on error."""
     try:
@@ -4053,7 +4076,7 @@ def sheets_list(
         return []
 
 
-def sheets_get(sheets_service: object, spreadsheet_id: str) -> Spreadsheet | None:
+def sheets_get(sheets_service: Any, spreadsheet_id: str) -> Spreadsheet | None:
     """Get spreadsheet metadata including sheet tabs."""
     try:
         result = sheets_service.spreadsheets().get(spreadsheetId=spreadsheet_id).execute()
@@ -4081,7 +4104,7 @@ def sheets_get(sheets_service: object, spreadsheet_id: str) -> Spreadsheet | Non
 
 
 def sheets_create(
-    sheets_service: object, title: str, sheets: list[str] | None = None
+    sheets_service: Any, title: str, sheets: list[str] | None = None
 ) -> Spreadsheet | None:
     """Create a new spreadsheet with optional sheet tabs."""
     _assert_live_write_allowed("create Google Sheet")
@@ -4109,7 +4132,7 @@ def sheets_create(
         return None
 
 
-def sheets_delete(drive_service: object, spreadsheet_id: str) -> bool:
+def sheets_delete(drive_service: Any, spreadsheet_id: str) -> bool:
     """Soft-delete (trash) a spreadsheet."""
     _assert_live_write_allowed("delete Google Sheet")
     try:
@@ -4120,9 +4143,7 @@ def sheets_delete(drive_service: object, spreadsheet_id: str) -> bool:
         return False
 
 
-def sheets_values_get(
-    sheets_service: object, spreadsheet_id: str, range_: str
-) -> list[list] | None:
+def sheets_values_get(sheets_service: Any, spreadsheet_id: str, range_: str) -> list[list] | None:
     """Read a range from a spreadsheet. Returns list[list] or None on error."""
     try:
         result = (
@@ -4138,7 +4159,7 @@ def sheets_values_get(
 
 
 def sheets_values_batch_get(
-    sheets_service: object, spreadsheet_id: str, ranges: list[str]
+    sheets_service: Any, spreadsheet_id: str, ranges: list[str]
 ) -> dict[str, list[list]] | None:
     """Read multiple ranges. Returns dict[range: list[list]] or None on error."""
     try:
@@ -4159,7 +4180,7 @@ def sheets_values_batch_get(
 
 
 def sheets_values_update(
-    sheets_service: object,
+    sheets_service: Any,
     spreadsheet_id: str,
     range_: str,
     values: list[list],
@@ -4186,7 +4207,7 @@ def sheets_values_update(
 
 
 def sheets_values_batch_update(
-    sheets_service: object,
+    sheets_service: Any,
     spreadsheet_id: str,
     data: list[dict],
     value_input: str = "USER_ENTERED",
@@ -4213,7 +4234,7 @@ def sheets_values_batch_update(
 
 
 def sheets_values_append(
-    sheets_service: object,
+    sheets_service: Any,
     spreadsheet_id: str,
     range_: str,
     values: list[list],
@@ -4239,7 +4260,7 @@ def sheets_values_append(
         return None
 
 
-def sheets_values_clear(sheets_service: object, spreadsheet_id: str, range_: str) -> bool:
+def sheets_values_clear(sheets_service: Any, spreadsheet_id: str, range_: str) -> bool:
     """Clear a range."""
     _assert_live_write_allowed("clear Google Sheet values")
     try:
@@ -4253,7 +4274,7 @@ def sheets_values_clear(sheets_service: object, spreadsheet_id: str, range_: str
 
 
 def sheets_add_sheet(
-    sheets_service: object,
+    sheets_service: Any,
     spreadsheet_id: str,
     title: str,
     rows: int = 1000,
@@ -4296,7 +4317,7 @@ def sheets_add_sheet(
         return None
 
 
-def sheets_delete_sheet(sheets_service: object, spreadsheet_id: str, sheet_id: int) -> bool:
+def sheets_delete_sheet(sheets_service: Any, spreadsheet_id: str, sheet_id: int) -> bool:
     """Delete a sheet tab by sheet_id."""
     _assert_live_write_allowed("delete Google Sheet tab")
     try:
@@ -4313,7 +4334,7 @@ def sheets_delete_sheet(sheets_service: object, spreadsheet_id: str, sheet_id: i
 
 
 def sheets_rename_sheet(
-    sheets_service: object, spreadsheet_id: str, sheet_id: int, new_title: str
+    sheets_service: Any, spreadsheet_id: str, sheet_id: int, new_title: str
 ) -> bool:
     """Rename a sheet tab."""
     try:
@@ -4338,7 +4359,7 @@ def sheets_rename_sheet(
         return False
 
 
-def sheets_format(sheets_service: object, spreadsheet_id: str, requests: list[dict]) -> dict | None:
+def sheets_format(sheets_service: Any, spreadsheet_id: str, requests: list[dict]) -> dict | None:
     """Apply formatting via raw batchUpdate requests. For max flexibility."""
     try:
         result = (
@@ -4356,7 +4377,7 @@ def sheets_format(sheets_service: object, spreadsheet_id: str, requests: list[di
 
 
 def sheets_copy_to(
-    sheets_service: object, spreadsheet_id: str, sheet_id: int, dest_spreadsheet_id: str
+    sheets_service: Any, spreadsheet_id: str, sheet_id: int, dest_spreadsheet_id: str
 ) -> SheetTab | None:
     """Copy a sheet to another spreadsheet."""
     try:
@@ -4392,7 +4413,7 @@ def sheets_copy_to(
 
 
 def docs_list(
-    drive_service: object, query: str = "", limit: int = 20, account: str = ""
+    drive_service: Any, query: str = "", limit: int = 20, account: str = ""
 ) -> list[Document]:
     """List documents from Drive. Returns list of Document, empty on error."""
     try:
@@ -4420,7 +4441,7 @@ def docs_list(
         return []
 
 
-def docs_get(docs_service: object, document_id: str) -> Document | None:
+def docs_get(docs_service: Any, document_id: str) -> Document | None:
     """Get document metadata and content."""
     try:
         result = docs_service.documents().get(documentId=document_id).execute()
@@ -4434,7 +4455,7 @@ def docs_get(docs_service: object, document_id: str) -> Document | None:
         return None
 
 
-def docs_create(docs_service: object, title: str) -> Document | None:
+def docs_create(docs_service: Any, title: str) -> Document | None:
     """Create a new Google Doc."""
     _assert_live_write_allowed("create Google Doc")
     try:
@@ -4450,7 +4471,7 @@ def docs_create(docs_service: object, title: str) -> Document | None:
         return None
 
 
-def docs_delete(drive_service: object, document_id: str) -> bool:
+def docs_delete(drive_service: Any, document_id: str) -> bool:
     """Soft-delete (trash) a document."""
     _assert_live_write_allowed("delete Google Doc")
     try:
@@ -4462,7 +4483,7 @@ def docs_delete(drive_service: object, document_id: str) -> bool:
 
 
 def docs_export(
-    drive_service: object, document_id: str, mime_type: str = "text/plain"
+    drive_service: Any, document_id: str, mime_type: str = "text/plain"
 ) -> bytes | None:
     """Export document content. Supports: text/plain, application/pdf, text/html."""
     try:
@@ -4473,7 +4494,7 @@ def docs_export(
         return None
 
 
-def docs_insert_text(docs_service: object, document_id: str, text: str, index: int = 1) -> bool:
+def docs_insert_text(docs_service: Any, document_id: str, text: str, index: int = 1) -> bool:
     """Insert text into a document at specified index."""
     try:
         docs_service.documents().batchUpdate(
@@ -4495,7 +4516,7 @@ def docs_insert_text(docs_service: object, document_id: str, text: str, index: i
         return False
 
 
-def docs_get_text(docs_service: object, document_id: str) -> str | None:
+def docs_get_text(docs_service: Any, document_id: str) -> str | None:
     """Get plain text content of a document."""
     try:
         result = docs_service.documents().get(documentId=document_id).execute()
@@ -5585,7 +5606,7 @@ def save_favorites(ids: set[str]) -> None:
 
 
 def contacts_search(
-    gmail_services: dict[str, object],
+    gmail_services: dict[str, Any],
     q: str,
     limit: int = 20,
 ) -> list[dict]:
@@ -5710,8 +5731,8 @@ def contacts_search(
 
 def contacts_profile(
     contact_id: str,
-    gmail_services: dict[str, object],
-    cal_services: dict[str, object],
+    gmail_services: dict[str, Any],
+    cal_services: dict[str, Any],
 ) -> dict:
     """Aggregate cross-source profile for a contact."""
 
@@ -6192,7 +6213,7 @@ def _event_to_calendar(
         return None
 
 
-def calendar_list_calendars(cal_services: dict[str, object]) -> list[dict]:
+def calendar_list_calendars(cal_services: dict[str, Any]) -> list[dict]:
     """List all calendars across all accounts."""
     result: list[dict] = []
     for account, svc in cal_services.items():
@@ -6330,7 +6351,7 @@ def calendar_get_recurring_instances(
 
 
 def calendar_search_events(
-    cal_services: dict[str, object],
+    cal_services: dict[str, Any],
     query: str = "",
     attendee_email: str = "",
     location: str = "",

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -112,15 +112,26 @@ class TestClientIndexedInbox:
         client.index_view = MagicMock(return_value={"threads": []})
 
         assert client.indexed_recent_threads(limit=1) == {"threads": []}
-        assert client.indexed_actionable_threads(limit=2) == {"threads": []}
-        assert client.indexed_waiting_on_me_threads(limit=3) == {"threads": []}
-        assert client.indexed_waiting_on_others_threads(limit=4) == {"threads": []}
+        assert client.indexed_now_threads(limit=2) == {"threads": []}
+        assert client.indexed_actionable_threads(limit=3) == {"threads": []}
+        assert client.indexed_waiting_on_me_threads(limit=4) == {"threads": []}
+        assert client.indexed_waiting_on_others_threads(limit=5) == {"threads": []}
         assert client.index_view.call_args_list == [
             call("recent", limit=1),
-            call("actionable", limit=2),
-            call("waiting-on-me", limit=3),
-            call("waiting-on-others", limit=4),
+            call("now", limit=2),
+            call("actionable", limit=3),
+            call("waiting-on-me", limit=4),
+            call("waiting-on-others", limit=5),
         ]
+
+    def test_needs_action(self, client):
+        client._client.get.return_value = _mock_response({"threads": [], "tasks": [], "events": []})
+        result = client.needs_action(workflow="job_hunt", account="me@gmail.com")
+        assert result == {"threads": [], "tasks": [], "events": []}
+        client._client.get.assert_called_once_with(
+            "/inbox/needs-action",
+            params={"workflow": "job_hunt", "account": "me@gmail.com"},
+        )
 
 
 # ── Messages ────────────────────────────────────────────────────────────────
@@ -137,6 +148,12 @@ class TestClientMessages:
         client.messages("gmail", "msg1", thread_id="t1")
         call_args = client._client.get.call_args
         assert call_args[1]["params"]["thread_id"] == "t1"
+
+    def test_messages_with_account(self, client):
+        client._client.get.return_value = _mock_response([])
+        client.messages("gmail", "msg1", thread_id="t1", account="me@gmail.com")
+        call_args = client._client.get.call_args
+        assert call_args[1]["params"]["account"] == "me@gmail.com"
 
     def test_send(self, client):
         client._client.post.return_value = _mock_response({"ok": True})

--- a/tests/test_inbox_app.py
+++ b/tests/test_inbox_app.py
@@ -82,6 +82,126 @@ def test_collect_refresh_data_preserves_other_data_on_partial_failure() -> None:
     assert snapshot.status == "[red]Calendar refresh failed (HTTP 500)[/]"
 
 
+def test_collect_auxiliary_data_uses_needs_action_rollup_for_now_tab() -> None:
+    client = MagicMock()
+    client.calendar_events.return_value = []
+    client.notes.return_value = []
+    client.reminders.return_value = []
+    client.reminder_lists.return_value = []
+    client.github_notifications.return_value = []
+    client.needs_action.return_value = {
+        "threads": [
+            {
+                "thread_id": "t1",
+                "subject": "Reply needed",
+                "source": "gmail",
+                "owning_account": "me@gmail.com",
+                "actionability": "reply",
+            }
+        ],
+        "tasks": [
+            {
+                "id": "task-1",
+                "title": "Pay bill",
+                "status": "needsAction",
+                "list_id": "@default",
+                "list_title": "My Tasks",
+                "due": "2026-05-06T00:00:00+00:00",
+                "notes": "",
+                "account": "me@gmail.com",
+                "workflow": "finance",
+            }
+        ],
+        "events": [
+            {
+                "event_id": "event-1",
+                "summary": "Doctor visit",
+                "start": "2026-05-06T13:00:00+00:00",
+                "end": "2026-05-06T14:00:00+00:00",
+                "account": "me@gmail.com",
+                "calendar_id": "primary",
+                "workflow": "medical",
+            }
+        ],
+    }
+
+    def index_view(view: str, *, limit: int) -> dict:
+        return {"threads": [{"thread_id": view, "limit": limit}]}
+
+    client.index_view.side_effect = index_view
+    app = _make_app(client)
+
+    snapshot = app._collect_auxiliary_data()
+
+    assert [item["now_kind"] for item in snapshot.now_threads] == ["thread", "task", "event"]
+    assert snapshot.now_threads[0]["thread_id"] == "t1"
+    assert snapshot.now_threads[1]["title"] == "Pay bill"
+    assert snapshot.now_threads[2]["title"] == "Doctor visit"
+    assert snapshot.actionable_threads == [{"thread_id": "actionable", "limit": 20}]
+    assert snapshot.waiting_threads == [{"thread_id": "waiting-on", "limit": 20}]
+    client.needs_action.assert_called_once_with()
+    assert [call.args[0] for call in client.index_view.call_args_list] == [
+        "actionable",
+        "waiting-on",
+    ]
+
+
+def test_collect_auxiliary_data_falls_back_to_now_index_view() -> None:
+    client = MagicMock()
+    client.calendar_events.return_value = []
+    client.notes.return_value = []
+    client.reminders.return_value = []
+    client.reminder_lists.return_value = []
+    client.github_notifications.return_value = []
+    client.needs_action.side_effect = RuntimeError("rollup down")
+
+    def index_view(view: str, *, limit: int) -> dict:
+        return {"threads": [{"thread_id": view, "limit": limit}]}
+
+    client.index_view.side_effect = index_view
+    app = _make_app(client)
+
+    snapshot = app._collect_auxiliary_data()
+
+    assert snapshot.now_threads == [{"thread_id": "now", "limit": 20}]
+    assert "Now refresh failed: rollup down" in snapshot.errors
+    assert [call.args[0] for call in client.index_view.call_args_list] == [
+        "now",
+        "actionable",
+        "waiting-on",
+    ]
+
+
+def test_index_thread_message_ref_routes_gmail_by_owner_account() -> None:
+    ref = inbox._index_thread_message_ref(
+        {
+            "source": "gmail",
+            "thread_id": "thread-1",
+            "latest_external_id": "msg-1",
+            "owning_account": "me@gmail.com",
+        }
+    )
+
+    assert ref == {
+        "source": "gmail",
+        "conv_id": "msg-1",
+        "thread_id": "thread-1",
+        "account": "me@gmail.com",
+    }
+
+
+def test_index_thread_message_ref_routes_imessage_by_chat_id() -> None:
+    ref = inbox._index_thread_message_ref(
+        {
+            "source": "imessage",
+            "thread_id": "42",
+            "latest_external_id": "99",
+        }
+    )
+
+    assert ref == {"source": "imessage", "conv_id": "42", "thread_id": "", "account": ""}
+
+
 def test_collect_poll_data_reports_server_unreachable() -> None:
     client = MagicMock()
     client.conversations.side_effect = httpx.ConnectError(
@@ -469,7 +589,7 @@ def test_status_bar_clears_unreachable_message_after_recovery() -> None:
             assert "unreachable" not in status, (
                 f"Status bar still shows outage after recovery: {status!r}"
             )
-            assert "indexed threads" in status
+            assert "now items" in status
 
     asyncio.run(runner())
 

--- a/tests/test_mcp_gateway.py
+++ b/tests/test_mcp_gateway.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any, cast
+
 import pytest
 from starlette.applications import Starlette
 from starlette.middleware import Middleware
@@ -74,12 +76,12 @@ async def test_health_handler_includes_backend_and_extra_payload(monkeypatch):
         db_path = "/tmp/mem.db"
 
     handler = make_health_handler(
-        backend=HealthyBackend(),
-        memory_store=FakeStore(),
+        backend=cast(Any, HealthyBackend()),
+        memory_store=cast(Any, FakeStore()),
         extra_payload={"mode": "readonly"},
     )
-    resp = await handler(None)
-    payload = resp.body.decode("utf-8")
+    resp = await handler(cast(Any, None))
+    payload = bytes(resp.body).decode("utf-8")
 
     assert '"status":"ok"' in payload
     assert '"mode":"readonly"' in payload
@@ -97,9 +99,11 @@ async def test_health_handler_handles_backend_error(monkeypatch):
     class FakeStore:
         db_path = "/tmp/mem.db"
 
-    handler = make_health_handler(backend=FailingBackend(), memory_store=FakeStore())
-    resp = await handler(None)
-    payload = resp.body.decode("utf-8")
+    handler = make_health_handler(
+        backend=cast(Any, FailingBackend()), memory_store=cast(Any, FakeStore())
+    )
+    resp = await handler(cast(Any, None))
+    payload = bytes(resp.body).decode("utf-8")
 
     assert '"backend":{"status":"error","detail":"down"}' in payload
     assert '"auth_enabled":false' in payload

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 from datetime import UTC, datetime, timedelta
+from typing import Any, cast
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -141,6 +142,11 @@ class TestIndexEndpoints:
                     "needs_reply": 1,
                     "message_count": 2,
                     "latest_sender": "Mehak Bhatia",
+                    "source": "gmail",
+                    "latest_external_id": "m2",
+                    "actionability": "reply",
+                    "urgency": "medium",
+                    "noise_class": "",
                 }
             ]
         )
@@ -155,6 +161,9 @@ class TestIndexEndpoints:
         assert data["threads"][0]["thread_id"] == "t1"
         assert data["threads"][0]["needs_reply"] is True
         assert data["threads"][0]["workflow"] == ""
+        assert data["threads"][0]["source"] == "gmail"
+        assert data["threads"][0]["latest_external_id"] == "m2"
+        assert data["threads"][0]["actionability"] == "reply"
         assert "body_text" not in data["threads"][0]
 
     def test_index_status_exposes_counts_and_sync_states(self, client):
@@ -306,6 +315,25 @@ class TestIndexEndpoints:
         assert "body_text" not in data["threads"][0]
         inbox_server.state.index_store.list_threads.assert_called_once_with(
             limit=5,
+            actions=("reply", "review", "track"),
+            newest_only=True,
+            sort_mode="priority",
+        )
+
+    def test_index_view_now_routes_to_priority_index_store(self, client):
+        import inbox_server
+
+        inbox_server.state.index_store.list_threads = MagicMock(return_value=[])
+
+        resp = client.get("/index/views/now", params={"limit": 6})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["view"] == "now"
+        assert data["read_model"] == "index"
+        assert data["raw_provider_fetch"] is False
+        assert data["threads"] == []
+        inbox_server.state.index_store.list_threads.assert_called_once_with(
+            limit=6,
             actions=("reply", "review", "track"),
             newest_only=True,
             sort_mode="priority",
@@ -915,6 +943,29 @@ class TestDrive:
 
 
 class TestGmailExtensions:
+    @patch("inbox_server.gmail_thread")
+    def test_get_gmail_messages_uses_requested_account(self, mock_thread, client):
+        import inbox_server
+
+        other_svc = MagicMock()
+        requested_svc = MagicMock()
+        inbox_server.state.gmail_services = {
+            "other@gmail.com": other_svc,
+            "me@gmail.com": requested_svc,
+        }
+        mock_thread.return_value = [
+            Msg(sender="Alice", body="hello", ts=datetime(2026, 5, 6), is_me=False, source="gmail")
+        ]
+
+        resp = client.get(
+            "/messages/gmail/msg1",
+            params={"thread_id": "thread-1", "account": "me@gmail.com"},
+        )
+
+        assert resp.status_code == 200
+        assert resp.json()[0]["body"] == "hello"
+        mock_thread.assert_called_once_with(requested_svc, "msg1", "thread-1")
+
     @patch("inbox_server.gmail_search")
     def test_gmail_search(self, mock_search, client):
         import inbox_server
@@ -1018,7 +1069,7 @@ class TestSourceAdapters:
 
         fake_adapter = FakeGmailAdapter()
         inbox_server.state.gmail_services = {"fake@example.com": object()}
-        inbox_server.state.source_adapters.gmail = fake_adapter
+        cast(Any, inbox_server.state.source_adapters).gmail = fake_adapter
 
         resp = client.get(
             "/gmail/search",
@@ -1068,7 +1119,7 @@ class TestSourceAdapters:
 
         fake_adapter = FakeCalendarAdapter()
         inbox_server.state.cal_services = {"fake@example.com": object()}
-        inbox_server.state.source_adapters.calendar = fake_adapter
+        cast(Any, inbox_server.state.source_adapters).calendar = fake_adapter
 
         resp = client.get(
             "/calendar/events",

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1891,6 +1891,72 @@ class TestPhase4:
     @patch("inbox_server.gmail_search")
     @patch("inbox_server.tasks_list")
     @patch("inbox_server.calendar_events")
+    def test_needs_action_scopes_calendar_events_to_requested_account(
+        self, mock_events, mock_tasks, mock_gmail, client
+    ):
+        import inbox_server
+
+        inbox_server.state.index_store.list_threads = MagicMock(return_value=[])
+        inbox_server.state.gmail_services = {"me@gmail.com": MagicMock()}
+        inbox_server.state.tasks_services = {"me@gmail.com": MagicMock()}
+        inbox_server.state.cal_services = {
+            "me@gmail.com": MagicMock(),
+            "other@gmail.com": MagicMock(),
+        }
+        mock_gmail.return_value = []
+        mock_tasks.return_value = []
+        mock_events.return_value = [
+            CalendarEvent(
+                summary="Standup",
+                start=datetime.now(),
+                end=datetime.now() + timedelta(hours=1),
+                account="me@gmail.com",
+            )
+        ]
+
+        resp = client.get("/inbox/needs-action?account=me@gmail.com")
+
+        assert resp.status_code == 200
+        called_services = mock_events.call_args.args[0]
+        assert list(called_services) == ["me@gmail.com"]
+        assert resp.json()["events"][0]["account"] == "me@gmail.com"
+        mock_gmail.assert_not_called()
+
+    @patch("inbox_server.gmail_search")
+    @patch("inbox_server.tasks_list")
+    @patch("inbox_server.calendar_events")
+    def test_needs_action_includes_undated_needs_action_tasks(
+        self, mock_events, mock_tasks, mock_gmail, client
+    ):
+        import inbox_server
+
+        inbox_server.state.index_store.list_threads = MagicMock(return_value=[])
+        inbox_server.state.gmail_services = {"me@gmail.com": MagicMock()}
+        inbox_server.state.tasks_services = {"me@gmail.com": MagicMock()}
+        inbox_server.state.cal_services = {}
+        mock_gmail.return_value = []
+        mock_tasks.return_value = [
+            GoogleTask(
+                id="task-1",
+                title="Follow up",
+                status="needsAction",
+                list_id="@default",
+                list_title="Tasks",
+            )
+        ]
+        mock_events.return_value = []
+
+        resp = client.get("/inbox/needs-action?account=me@gmail.com")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert [task["id"] for task in data["tasks"]] == ["task-1"]
+        assert data["tasks"][0]["status"] == "needsAction"
+        mock_gmail.assert_not_called()
+
+    @patch("inbox_server.gmail_search")
+    @patch("inbox_server.tasks_list")
+    @patch("inbox_server.calendar_events")
     def test_needs_action_workflow_counts(self, mock_events, mock_tasks, mock_gmail, client):
         import inbox_server
 

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -941,8 +941,16 @@ def test_test_mode_blocks_extended_live_writes(monkeypatch):
         services.drive_create_folder(_WriteShouldNotRun(), "Test folder")
     with pytest.raises(LiveWriteBlocked, match="Google Sheet"):
         services.sheets_values_update(_WriteShouldNotRun(), "sheet-id", "A1", [["x"]])
+    with pytest.raises(LiveWriteBlocked, match="Google Sheet"):
+        services.sheets_rename_sheet(_WriteShouldNotRun(), "sheet-id", 123, "New name")
+    with pytest.raises(LiveWriteBlocked, match="Google Sheet"):
+        services.sheets_format(_WriteShouldNotRun(), "sheet-id", [{"repeatCell": {}}])
+    with pytest.raises(LiveWriteBlocked, match="Google Sheet"):
+        services.sheets_copy_to(_WriteShouldNotRun(), "sheet-id", 123, "dest-sheet-id")
     with pytest.raises(LiveWriteBlocked, match="Google Doc"):
         services.docs_create(_WriteShouldNotRun(), "Test doc")
+    with pytest.raises(LiveWriteBlocked, match="Google Doc"):
+        services.docs_insert_text(_WriteShouldNotRun(), "doc-id", "hello")
     with pytest.raises(LiveWriteBlocked, match="GitHub notification"):
         services.github_mark_read("notification-id")
     with pytest.raises(LiveWriteBlocked, match="desktop notification"):

--- a/tests/test_thread_classifier.py
+++ b/tests/test_thread_classifier.py
@@ -19,3 +19,39 @@ def test_classify_thread_preserves_otp_ignore_behavior():
     classification = classify_thread(latest=latest)
     assert classification.noise_class == "otp"
     assert classification.actionability == "ignore"
+
+
+def test_classify_thread_routes_direct_human_asks_to_reply():
+    latest = _row(
+        "Recruiter",
+        subject="Interview follow up",
+        body_text="Would you be open to a short call tomorrow?",
+    )
+    classification = classify_thread(latest=latest)
+    assert classification.actionability == "reply"
+    assert classification.needs_reply == 1
+
+
+def test_classify_thread_archives_newsletter_noise():
+    latest = _row(
+        "jobs@example.com",
+        subject="Weekly digest",
+        body_text="View in browser. Manage preferences or unsubscribe from this newsletter.",
+    )
+    classification = classify_thread(latest=latest)
+    assert classification.noise_class == "newsletter"
+    assert classification.actionability == "archive"
+
+
+def test_classify_thread_archives_short_acknowledgements():
+    latest = _row("Alice", subject="Re: Plan", body_text="Thanks, sounds good.")
+    classification = classify_thread(latest=latest)
+    assert classification.noise_class == "low-value-ack"
+    assert classification.actionability == "archive"
+
+
+def test_classify_thread_does_not_archive_ack_with_request():
+    latest = _row("Alice", subject="Re: Plan", body_text="Thanks. Can you send the notes?")
+    classification = classify_thread(latest=latest)
+    assert classification.noise_class == ""
+    assert classification.actionability == "reply"

--- a/thread_classifier.py
+++ b/thread_classifier.py
@@ -19,16 +19,20 @@ def classify_thread(*, latest: sqlite3.Row, sender_freq: float = 0.0) -> ThreadC
     subject = str(latest["subject"])
     body = str(latest["body_text"])
     sender = str(latest["sender"])
+    haystack = f"{subject}\n{body}"
 
     human_score = _human_score(latest_sender=sender, latest_subject=subject, latest_body=body)
     noise_class = _noise_class(latest_sender=sender, subject=subject, body=body)
     topic = _topic(subject=subject, body=body)
     urgency = _urgency(subject=subject, body=body)
+    direct_request = _has_direct_request(haystack)
     actionability = _actionability(
         human_score=human_score,
         noise_class=noise_class,
         urgency=urgency,
         topic=topic,
+        latest_sender=sender,
+        direct_request=direct_request,
         sender_freq=sender_freq,
     )
     needs_reply = int(actionability in {"reply", "review"} and sender != "Me")
@@ -58,13 +62,13 @@ def sender_freq_score(reply_count: int, thread_count: int) -> float:
 def _human_score(*, latest_sender: str, latest_subject: str, latest_body: str) -> float:
     sender = latest_sender.lower()
     haystack = f"{latest_subject}\n{latest_body}".lower()
-    score = 0.2
+    score = 0.15
     if latest_sender and latest_sender != "Me":
-        score += 0.3
+        score += 0.25
     if "noreply" not in sender and "no-reply" not in sender:
         score += 0.2
     if "unsubscribe" not in haystack and "verification code" not in haystack:
-        score += 0.2
+        score += 0.15
     if not sender.isdigit():
         score += 0.1
     return min(score, 1.0)
@@ -75,7 +79,21 @@ def _noise_class(*, latest_sender: str, subject: str, body: str) -> str:
     sender = latest_sender.lower()
     if "verification code" in haystack or "otp" in haystack:
         return "otp"
-    if "unsubscribe" in haystack or "job alert" in haystack:
+    if any(
+        token in haystack
+        for token in (
+            "unsubscribe",
+            "job alert",
+            "manage preferences",
+            "view in browser",
+            "weekly digest",
+            "daily digest",
+            "newsletter",
+            "promotion",
+            "limited time",
+            "webinar",
+        )
+    ):
         return "newsletter"
     if "appointment" in haystack or "your appt" in haystack:
         return "appointment"
@@ -87,6 +105,8 @@ def _noise_class(*, latest_sender: str, subject: str, body: str) -> str:
         return "security-alert"
     if "noreply" in sender or "no-reply" in sender:
         return "automated"
+    if _is_low_value_ack(haystack):
+        return "low-value-ack"
     return ""
 
 
@@ -115,19 +135,73 @@ def _urgency(*, subject: str, body: str) -> str:
 
 
 def _actionability(
-    *, human_score: float, noise_class: str, urgency: str, topic: str, sender_freq: float = 0.0
+    *,
+    human_score: float,
+    noise_class: str,
+    urgency: str,
+    topic: str,
+    latest_sender: str,
+    direct_request: bool,
+    sender_freq: float = 0.0,
 ) -> str:
     if noise_class in {"otp", "receipt", "survey"}:
         return "ignore"
-    if noise_class in {"newsletter", "automated"}:
+    if noise_class in {"newsletter", "automated", "low-value-ack"}:
         return "archive"
+    if latest_sender == "Me":
+        return "track" if topic in {"security", "health-admin", "opportunity"} else "archive"
     if topic in {"security", "health-admin"} and urgency in {"high", "medium"}:
         return "track"
-    if human_score >= 1.0 or sender_freq >= 0.5:
+    if direct_request and human_score >= 0.6:
+        return "reply"
+    if sender_freq >= 0.5 and human_score >= 0.6:
         return "reply"
     if topic == "opportunity":
         return "review"
+    if urgency == "high" and human_score >= 0.6:
+        return "review"
     return "track"
+
+
+def _has_direct_request(text: str) -> bool:
+    haystack = text.lower()
+    request_tokens = (
+        "can you",
+        "could you",
+        "would you",
+        "please",
+        "let me know",
+        "confirm",
+        "reply",
+        "respond",
+        "send",
+        "review",
+        "schedule",
+        "available",
+        "availability",
+        "open to",
+    )
+    return any(token in haystack for token in request_tokens)
+
+
+def _is_low_value_ack(haystack: str) -> bool:
+    compact = " ".join(haystack.split())
+    if len(compact) > 120:
+        return False
+    if _has_direct_request(compact):
+        return False
+    return any(
+        phrase in compact
+        for phrase in (
+            "thanks",
+            "thank you",
+            "got it",
+            "sounds good",
+            "looks good",
+            "ok",
+            "okay",
+        )
+    )
 
 
 def _open_loop(*, topic: str, actionability: str, latest: sqlite3.Row) -> str:

--- a/tui_tabs.py
+++ b/tui_tabs.py
@@ -24,8 +24,8 @@ TUI_TABS: tuple[TabMeta, ...] = (
         "mode": "message",
         "action": "action_filter_all",
         "command_id": "switch_all",
-        "command_name": "Switch to All",
-        "command_description": "Show all conversations",
+        "command_name": "Switch to Now",
+        "command_description": "Show high-signal indexed threads",
     },
     {
         "id": "actionable",

--- a/unsubscribe_all_newsletters.py
+++ b/unsubscribe_all_newsletters.py
@@ -182,23 +182,24 @@ def main():
     for item in result.get("results", []):
         msg_id = item["msg_id"]
         email = next((c for c in candidates if c["id"] == msg_id), None)
+        email_name = email["name"] if email is not None else msg_id
 
         if "error" in item:
             error_count += 1
-            by_status["error"].append((email["name"], item["error"]))
+            by_status["error"].append((email_name, item["error"]))
         else:
             method = item.get("method", "unknown")
             ok = item.get("ok", False)
             if method == "none":
                 no_header_count += 1
-                by_status["no_header"].append(email["name"])
+                by_status["no_header"].append(email_name)
             else:
                 if ok:
                     success_count += 1
-                    by_status["success"].append(email["name"])
+                    by_status["success"].append(email_name)
                 else:
                     error_count += 1
-                    by_status["error"].append((email["name"], "unsubscribe failed"))
+                    by_status["error"].append((email_name, "unsubscribe failed"))
 
     print(f"✓  {success_count:3d} successfully unsubscribed")
     print(f"⚠️  {no_header_count:3d} archived (no unsubscribe header)")

--- a/unsubscribe_bulk.py
+++ b/unsubscribe_bulk.py
@@ -66,18 +66,19 @@ def main():
     for item in result.get("results", []):
         msg_id = item["msg_id"]
         email = next((c for c in newsletters if c["id"] == msg_id), None)
+        email_name = email["name"] if email is not None else msg_id
 
         if "error" in item:
-            print(f"  ❌ {email['name'][:40]:40s} - {item['error']}")
+            print(f"  ❌ {email_name[:40]:40s} - {item['error']}")
             fail_count += 1
         else:
             method = item.get("method", "unknown")
             ok = item.get("ok", False)
             if method == "none":
-                print(f"  ⚠️  {email['name'][:40]:40s} - No unsubscribe header")
+                print(f"  ⚠️  {email_name[:40]:40s} - No unsubscribe header")
             else:
                 status = "✓" if ok else "⚠️"
-                print(f"  {status}  {email['name'][:40]:40s} - {method}")
+                print(f"  {status}  {email_name[:40]:40s} - {method}")
                 if ok:
                     success_count += 1
                 else:


### PR DESCRIPTION
## Summary
- preserve the local Now queue and clean repo typing work from the diverged local main
- rebase the work on current main after the merged inbox PRs
- keep it reviewable as a draft instead of leaving local main diverged
- scope `/inbox/needs-action?account=...` calendar events to the requested account
- include undated Google Tasks whose status is `needsAction` or `needs_action`

## Validation
- `uv run pytest` (`878 passed`, original package validation)
- `uv run pytest tests/test_server.py -q -k 'needs_action'` (`6 passed, 121 deselected`)
- `uv run ruff check inbox_server.py tests/test_server.py`
- `uv run pyright inbox_server.py tests/test_server.py` (`0 errors`)

## Notes
Draft PR because this was recovered local work and should get focused review before merge. The Now queue account/task blockers found during review are fixed on head `42eee2b`.