### PR TITLE
[codex] Add compact Inbox Now read model

### DIFF
--- a/inbox.py
+++ b/inbox.py
@@ -63,6 +63,20 @@ def _format_request_error(action: str, exc: Exception) -> str:
     return f"{action} failed: {exc}"
 
 
+def _format_index_health_warning(health: Any) -> str:
+    if not isinstance(health, dict):
+        return ""
+    if health.get("healthy") is True and not health.get("stale"):
+        return ""
+    reasons = [str(reason) for reason in health.get("reasons", []) if reason]
+    reason_text = ", ".join(reasons) if reasons else "unknown"
+    if "no_sync_state" in reasons:
+        return f"Index has no sync state: {reason_text}"
+    if health.get("stale"):
+        return f"Index stale: {reason_text}"
+    return f"Index unhealthy: {reason_text}"
+
+
 def _now_item_key(item: dict) -> str:
     if item.get("now_id"):
         return str(item["now_id"])
@@ -2488,28 +2502,45 @@ class InboxApp(App):
         except Exception as exc:
             errors.append(_format_request_error("GitHub refresh", exc))
 
+        used_now_brief = False
         try:
-            result = self.client.needs_action()
-            now_threads = _normalize_needs_action(result) if isinstance(result, dict) else []
+            result = self.client.inbox_now(limit=20)
+            if isinstance(result, dict):
+                now_threads = result.get("now_items", []) or []
+                actionable_threads = result.get("actionable_threads", []) or []
+                waiting_threads = result.get("waiting_threads", []) or []
+                warning = _format_index_health_warning(result.get("index_health"))
+                if warning:
+                    errors.append(warning)
+                used_now_brief = True
+        except AttributeError:
+            pass
         except Exception as exc:
             errors.append(_format_request_error("Now refresh", exc))
+
+        if not used_now_brief:
             try:
-                result = self.client.index_view("now", limit=20)
-                now_threads = result.get("threads", []) if isinstance(result, dict) else []
-            except Exception:
-                pass
+                result = self.client.needs_action()
+                now_threads = _normalize_needs_action(result) if isinstance(result, dict) else []
+            except Exception as exc:
+                errors.append(_format_request_error("Now refresh", exc))
+                try:
+                    result = self.client.index_view("now", limit=20)
+                    now_threads = result.get("threads", []) if isinstance(result, dict) else []
+                except Exception:
+                    pass
 
-        try:
-            result = self.client.index_view("actionable", limit=20)
-            actionable_threads = result.get("threads", []) if isinstance(result, dict) else []
-        except Exception as exc:
-            errors.append(_format_request_error("Indexed actionable refresh", exc))
+            try:
+                result = self.client.index_view("actionable", limit=20)
+                actionable_threads = result.get("threads", []) if isinstance(result, dict) else []
+            except Exception as exc:
+                errors.append(_format_request_error("Indexed actionable refresh", exc))
 
-        try:
-            result = self.client.index_view("waiting-on", limit=20)
-            waiting_threads = result.get("threads", []) if isinstance(result, dict) else []
-        except Exception as exc:
-            errors.append(_format_request_error("Indexed waiting refresh", exc))
+            try:
+                result = self.client.index_view("waiting-on", limit=20)
+                waiting_threads = result.get("threads", []) if isinstance(result, dict) else []
+            except Exception as exc:
+                errors.append(_format_request_error("Indexed waiting refresh", exc))
 
         return AuxiliaryDataSnapshot(
             events=events,

--- a/inbox_client.py
+++ b/inbox_client.py
@@ -143,6 +143,16 @@ class InboxClient:
         r.raise_for_status()
         return r.json()
 
+    def inbox_now(self, *, workflow: str = "", account: str = "", limit: int = 20) -> dict:
+        params: dict[str, str | int] = {"limit": limit}
+        if workflow:
+            params["workflow"] = workflow
+        if account:
+            params["account"] = account
+        r = self._client.get("/inbox/now", params=params)
+        r.raise_for_status()
+        return r.json()
+
     # ── Messages ─────────────────────────────────────────────────────────
 
     def messages(

--- a/inbox_server.py
+++ b/inbox_server.py
@@ -632,6 +632,21 @@ class IndexedThreadListOut(BaseModel):
     threads: list[GmailThreadSummaryOut]
 
 
+class InboxNowOut(BaseModel):
+    read_model: str = "inbox_now"
+    read_only: bool = True
+    raw_thread_provider_fetch: bool = False
+    write_actions: list[str] = []
+    index_health: IndexHealthOut
+    reasons: list[str]
+    now_items: list[dict[str, Any]]
+    actionable_threads: list[GmailThreadSummaryOut]
+    waiting_threads: list[GmailThreadSummaryOut]
+    commitments: list[dict[str, Any]]
+    source_refs: list[dict[str, str]]
+    workflow_counts: dict[str, int]
+
+
 class WorkflowFolderRequest(BaseModel):
     workflow: str
     name: str = ""
@@ -2914,6 +2929,158 @@ def _build_index_health(sync_states: list[dict[str, Any]]) -> IndexHealthOut:
     )
 
 
+def _thread_ref(thread: GmailThreadSummaryOut, reason: str) -> dict[str, str]:
+    return {
+        "kind": "thread",
+        "source": thread.source or "gmail",
+        "thread_id": thread.thread_id,
+        "external_id": thread.latest_external_id,
+        "account": thread.owning_account,
+        "reason": reason,
+    }
+
+
+def _task_ref(task: TaskOut, reason: str) -> dict[str, str]:
+    return {
+        "kind": "task",
+        "source": "google_tasks",
+        "id": task.id,
+        "list_id": task.list_id,
+        "account": task.account,
+        "reason": reason,
+    }
+
+
+def _event_ref(event: CalendarEventOut, reason: str) -> dict[str, str]:
+    return {
+        "kind": "event",
+        "source": "calendar",
+        "id": event.event_id,
+        "calendar_id": event.calendar_id,
+        "account": event.account,
+        "reason": reason,
+    }
+
+
+def _append_source_ref(refs: list[dict[str, str]], ref: dict[str, str]) -> None:
+    if ref not in refs:
+        refs.append(ref)
+
+
+def _thread_reason(thread: GmailThreadSummaryOut) -> str:
+    return (
+        thread.open_loop
+        or thread.actionability
+        or ("needs_reply" if thread.needs_reply else "")
+        or thread.workflow
+        or "indexed_thread"
+    )
+
+
+def _thread_now_item(thread: GmailThreadSummaryOut, reason: str) -> dict[str, Any]:
+    return {
+        "now_kind": "thread",
+        "kind": "thread",
+        "title": thread.subject or "Untitled thread",
+        "source": thread.source or "gmail",
+        "reason": reason,
+        "ref": _thread_ref(thread, reason),
+        "thread_id": thread.thread_id,
+        "owning_account": thread.owning_account,
+        "latest_external_id": thread.latest_external_id,
+        "participants": thread.participants,
+        "last_message_at": thread.last_message_at,
+        "summary": thread.summary,
+        "brief": thread.brief,
+        "open_loop": thread.open_loop,
+        "action_items": thread.action_items,
+        "needs_reply": thread.needs_reply,
+        "workflow": thread.workflow,
+        "actionability": thread.actionability,
+        "urgency": thread.urgency,
+        "now_meta": [
+            thread.source or "gmail",
+            thread.actionability,
+            thread.urgency,
+            thread.workflow,
+        ],
+    }
+
+
+def _task_now_item(task: TaskOut) -> dict[str, Any]:
+    reason = "overdue_task" if task.due else "needs_action_task"
+    return {
+        "now_kind": "task",
+        "kind": "task",
+        "title": task.title or "Untitled task",
+        "source": "google_tasks",
+        "reason": reason,
+        "ref": _task_ref(task, reason),
+        "id": task.id,
+        "list_id": task.list_id,
+        "list_title": task.list_title,
+        "account": task.account,
+        "status": task.status,
+        "due": task.due,
+        "notes": task.notes,
+        "workflow": task.workflow,
+        "summary": task.notes,
+        "actionability": "task",
+        "now_meta": [
+            "task",
+            task.due or "",
+            task.list_title,
+            task.workflow,
+        ],
+    }
+
+
+def _event_now_item(event: CalendarEventOut) -> dict[str, Any]:
+    reason = "upcoming_event"
+    return {
+        "now_kind": "event",
+        "kind": "event",
+        "title": event.summary or "Untitled event",
+        "source": "calendar",
+        "reason": reason,
+        "ref": _event_ref(event, reason),
+        "event_id": event.event_id,
+        "calendar_id": event.calendar_id,
+        "account": event.account,
+        "start": event.start,
+        "end": event.end,
+        "location": event.location,
+        "description": event.description,
+        "workflow": event.workflow,
+        "summary": event.description or event.location,
+        "actionability": "prep",
+        "now_meta": [
+            "calendar",
+            event.start,
+            event.location,
+            event.workflow,
+        ],
+    }
+
+
+def _thread_matches_inbox_now_filters(
+    thread: GmailThreadSummaryOut,
+    workflow: str,
+    account: str,
+) -> bool:
+    if workflow and thread.workflow != workflow:
+        return False
+    return not (account and thread.owning_account != account)
+
+
+def _index_health_reasons(index_health: IndexHealthOut) -> list[str]:
+    if index_health.healthy and not index_health.stale:
+        return []
+    if index_health.reasons:
+        return [f"index:{reason}" for reason in index_health.reasons]
+    return ["index:unhealthy"]
+
+
 def _preflight_google_write(
     kind: str,
     account: str = "",
@@ -3818,6 +3985,73 @@ async def get_needs_action(workflow: str = "", account: str = ""):
             counts[wf] = counts.get(wf, 0) + 1
 
     return NeedsActionOut(threads=threads, tasks=tasks, events=events, workflow_counts=counts)
+
+
+@app.get("/inbox/now", response_model=InboxNowOut)
+async def get_inbox_now(workflow: str = "", account: str = "", limit: int = 20):
+    """Compact Jarvis-facing read model for the current inbox state."""
+    index_health = _build_index_health(state.index_store.list_sync_states())
+    needs_action = await get_needs_action(workflow=workflow, account=account)
+
+    source_refs: list[dict[str, str]] = []
+    now_items: list[dict[str, Any]] = []
+    commitments: list[dict[str, Any]] = []
+
+    for thread in needs_action.threads[:limit]:
+        reason = _thread_reason(thread)
+        item = _thread_now_item(thread, reason)
+        now_items.append(item)
+        _append_source_ref(source_refs, item["ref"])
+
+    for task in needs_action.tasks[:limit]:
+        item = _task_now_item(task)
+        now_items.append(item)
+        commitments.append(item)
+        _append_source_ref(source_refs, item["ref"])
+
+    for event in needs_action.events[:limit]:
+        item = _event_now_item(event)
+        now_items.append(item)
+        _append_source_ref(source_refs, item["ref"])
+
+    actionable_threads = [
+        _indexed_thread_to_summary(row) for row in _index_view_rows("actionable", limit)
+    ]
+    actionable_threads = [
+        thread
+        for thread in actionable_threads
+        if _thread_matches_inbox_now_filters(thread, workflow, account)
+    ][:limit]
+    for thread in actionable_threads:
+        _append_source_ref(source_refs, _thread_ref(thread, _thread_reason(thread)))
+
+    waiting_threads = [
+        _indexed_thread_to_summary(row) for row in _index_view_rows("waiting-on", limit)
+    ]
+    waiting_threads = [
+        thread
+        for thread in waiting_threads
+        if _thread_matches_inbox_now_filters(thread, workflow, account)
+    ][:limit]
+    for thread in waiting_threads:
+        reason = _thread_reason(thread)
+        commitments.append(_thread_now_item(thread, reason))
+        _append_source_ref(source_refs, _thread_ref(thread, reason))
+
+    reasons = _index_health_reasons(index_health)
+    if not now_items and reasons:
+        reasons.append("now_empty_with_unhealthy_index")
+
+    return InboxNowOut(
+        index_health=index_health,
+        reasons=reasons,
+        now_items=now_items[:limit],
+        actionable_threads=actionable_threads,
+        waiting_threads=waiting_threads,
+        commitments=commitments[:limit],
+        source_refs=source_refs,
+        workflow_counts=needs_action.workflow_counts,
+    )
 
 
 @app.get("/index/threads", response_model=IndexStatusOut)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -133,6 +133,15 @@ class TestClientIndexedInbox:
             params={"workflow": "job_hunt", "account": "me@gmail.com"},
         )
 
+    def test_inbox_now(self, client):
+        client._client.get.return_value = _mock_response({"now_items": [], "index_health": {}})
+        result = client.inbox_now(workflow="job_hunt", account="me@gmail.com", limit=8)
+        assert result == {"now_items": [], "index_health": {}}
+        client._client.get.assert_called_once_with(
+            "/inbox/now",
+            params={"limit": 8, "workflow": "job_hunt", "account": "me@gmail.com"},
+        )
+
 
 # ── Messages ────────────────────────────────────────────────────────────────
 

--- a/tests/test_inbox_app.py
+++ b/tests/test_inbox_app.py
@@ -146,6 +146,36 @@ def test_collect_auxiliary_data_uses_needs_action_rollup_for_now_tab() -> None:
     ]
 
 
+def test_collect_auxiliary_data_uses_inbox_now_brief_and_surfaces_index_health() -> None:
+    client = MagicMock()
+    client.calendar_events.return_value = []
+    client.notes.return_value = []
+    client.reminders.return_value = []
+    client.reminder_lists.return_value = []
+    client.github_notifications.return_value = []
+    client.inbox_now.return_value = {
+        "now_items": [{"now_kind": "thread", "thread_id": "now-1", "title": "Reply"}],
+        "actionable_threads": [{"thread_id": "action-1"}],
+        "waiting_threads": [{"thread_id": "wait-1"}],
+        "index_health": {
+            "healthy": False,
+            "stale": True,
+            "reasons": ["no_sync_state"],
+        },
+    }
+    app = _make_app(client)
+
+    snapshot = app._collect_auxiliary_data()
+
+    assert snapshot.now_threads == [{"now_kind": "thread", "thread_id": "now-1", "title": "Reply"}]
+    assert snapshot.actionable_threads == [{"thread_id": "action-1"}]
+    assert snapshot.waiting_threads == [{"thread_id": "wait-1"}]
+    assert "Index has no sync state: no_sync_state" in snapshot.errors
+    client.inbox_now.assert_called_once_with(limit=20)
+    client.needs_action.assert_not_called()
+    client.index_view.assert_not_called()
+
+
 def test_collect_auxiliary_data_falls_back_to_now_index_view() -> None:
     client = MagicMock()
     client.calendar_events.return_value = []

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -2052,6 +2052,148 @@ class TestPhase4:
         assert data["raw_thread_provider_fetch"] is False
         mock_gmail.assert_not_called()
 
+    @patch("inbox_server.gmail_search")
+    @patch("inbox_server.tasks_list")
+    @patch("inbox_server.calendar_events")
+    def test_inbox_now_compact_brief_includes_health_refs_and_waiting_items(
+        self, mock_events, mock_tasks, mock_gmail, client
+    ):
+        import inbox_server
+
+        action_row = {
+            "thread_id": "t-action",
+            "account": "me@gmail.com",
+            "source": "gmail",
+            "latest_external_id": "msg-action",
+            "participants_json": ["Recruiter"],
+            "latest_subject": "Interview follow up",
+            "latest_snippet": "Can you reply today?",
+            "latest_item_at": "2026-04-18T01:00:00+00:00",
+            "summary": "Recruiter needs a reply",
+            "open_loop": "Reply to recruiter",
+            "topic": "opportunity",
+            "needs_reply": 1,
+            "message_count": 2,
+            "latest_sender": "Recruiter",
+            "actionability": "reply",
+            "urgency": "high",
+        }
+        waiting_row = {
+            "thread_id": "t-wait",
+            "account": "me@gmail.com",
+            "source": "gmail",
+            "latest_external_id": "msg-wait",
+            "participants_json": ["Hiring Manager"],
+            "latest_subject": "Offer timing",
+            "latest_snippet": "We will get back to you",
+            "latest_item_at": "2026-04-17T01:00:00+00:00",
+            "summary": "Waiting for offer update",
+            "open_loop": "Track offer response",
+            "topic": "opportunity",
+            "needs_reply": 0,
+            "message_count": 4,
+            "latest_sender": "Me",
+            "actionability": "track",
+        }
+
+        def list_threads(**kwargs):
+            if kwargs.get("has_open_loop"):
+                return [waiting_row]
+            return [action_row]
+
+        inbox_server.state.index_store.list_threads = MagicMock(side_effect=list_threads)
+        inbox_server.state.index_store.list_sync_states = MagicMock(
+            return_value=[
+                {
+                    "source": "gmail",
+                    "account": "me@gmail.com",
+                    "checkpoint_type": "internalDateMs",
+                    "checkpoint_value": "123",
+                    "last_success_at": datetime.now(UTC).isoformat(),
+                    "last_full_sync_at": "2026-04-18T00:00:00+00:00",
+                    "status": "idle",
+                    "last_run_started_at": "2026-04-18T00:55:00+00:00",
+                    "last_error": "",
+                    "metadata": {},
+                }
+            ]
+        )
+        inbox_server.state.gmail_services = {"me@gmail.com": MagicMock()}
+        inbox_server.state.tasks_services = {"me@gmail.com": MagicMock()}
+        inbox_server.state.cal_services = {"me@gmail.com": MagicMock()}
+        mock_tasks.return_value = [
+            GoogleTask(
+                id="task-1",
+                title="Submit take-home",
+                status="needsAction",
+                list_id="@default",
+                list_title="My Tasks",
+                due=datetime.now() - timedelta(days=1),
+            )
+        ]
+        mock_events.return_value = [
+            CalendarEvent(
+                summary="Interview",
+                start=datetime.now(),
+                end=datetime.now() + timedelta(hours=1),
+                account="me@gmail.com",
+                event_id="event-1",
+            )
+        ]
+
+        resp = client.get("/inbox/now", params={"limit": 5})
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["read_model"] == "inbox_now"
+        assert data["read_only"] is True
+        assert data["raw_thread_provider_fetch"] is False
+        assert data["write_actions"] == []
+        assert data["index_health"]["healthy"] is True
+        assert data["reasons"] == []
+        assert [item["now_kind"] for item in data["now_items"]] == [
+            "thread",
+            "task",
+            "event",
+        ]
+        assert data["now_items"][0]["ref"]["thread_id"] == "t-action"
+        assert data["actionable_threads"][0]["thread_id"] == "t-action"
+        assert data["waiting_threads"][0]["thread_id"] == "t-wait"
+        assert {item["kind"] for item in data["commitments"]} == {"task", "thread"}
+        assert any(ref["reason"] == "Reply to recruiter" for ref in data["source_refs"])
+        assert any(ref["reason"] == "Track offer response" for ref in data["source_refs"])
+        mock_gmail.assert_not_called()
+
+    @patch("inbox_server.gmail_search")
+    @patch("inbox_server.tasks_list")
+    @patch("inbox_server.calendar_events")
+    def test_inbox_now_surfaces_no_index_state_when_empty(
+        self, mock_events, mock_tasks, mock_gmail, client
+    ):
+        import inbox_server
+
+        inbox_server.state.index_store.list_threads = MagicMock(return_value=[])
+        inbox_server.state.index_store.list_sync_states = MagicMock(return_value=[])
+        inbox_server.state.gmail_services = {"me@gmail.com": MagicMock()}
+        inbox_server.state.tasks_services = {}
+        inbox_server.state.cal_services = {}
+        mock_tasks.return_value = []
+        mock_events.return_value = []
+
+        resp = client.get("/inbox/now")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["now_items"] == []
+        assert data["index_health"]["healthy"] is False
+        assert data["index_health"]["stale"] is True
+        assert data["index_health"]["reasons"] == ["no_sync_state"]
+        assert data["reasons"] == [
+            "index:no_sync_state",
+            "now_empty_with_unhealthy_index",
+        ]
+        mock_gmail.assert_not_called()
+
     @patch("inbox_server.drive_create_folder")
     def test_workflow_folder_display_name(self, mock_create, client):
         import inbox_server


### PR DESCRIPTION
## Summary

Adds a compact read-only `/inbox/now` surface with client and TUI support so agents can inspect what needs attention without provider dumps or write automation.

This is stacked on PR #38 (`codex/package-now-queue-clean-repo-typing`) because the validated local branch was built on that existing queue-cleanup branch.

## Validation

- `UV_CACHE_DIR=/tmp/uv-cache INBOX_TEST_MODE=1 uv run pytest tests/test_server.py tests/test_client.py tests/test_inbox_app.py -q -k "now or needs_action or index_health"`
- `git diff --check`
- pre-commit passed on commit

## Run Evidence

- `/Users/jwalinshah/agent-runs/20260510-183559/batch-2/outputs/b2-w02-inbox-now.md`
- Commit: `9aa2ea5d17803e9b55688eff0cbfe617f62d1547`

Created as a draft because this is a supervised local handoff branch.