### PR TITLE
MAX-250: Require explicit Inbox API auth

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,7 +113,11 @@ oci_retry.sh                   — retry utility for OCI operations
 - Requires: labels to exist, server running, `gmail.settings.basic` scope (re-auth: Ctrl+Shift+A in TUI)
 
 ## Server authentication
-Optional token-based auth via `INBOX_SERVER_TOKEN` environment variable. If set, all requests must include `Authorization: Bearer <token>` header.
+`/health` is unauthenticated for local supervision. Every other endpoint requires
+`INBOX_SERVER_TOKEN` by default and must include `Authorization: Bearer <token>`
+or `X-API-Key: <token>`. For isolated dev/test work only, set
+`INBOX_SERVER_ALLOW_UNAUTHENTICATED=1` to bypass token auth on non-health
+endpoints.
 
 ## API endpoints (localhost:9849)
 ```

--- a/CODEX_WORKPAD.md
+++ b/CODEX_WORKPAD.md
@@ -1,46 +1,41 @@
-# MAX-7 Workpad
+# MAX-250 Workpad
 
 ## Issue
 
-- Linear: MAX-7
-- Title: Fix inbox CI/runtime mismatch for mac-only dependencies
+- Linear: `MAX-250`
+- Title: Inbox: require explicit API auth for personal-data and write endpoints
 - Repo: `/Users/jwalinshah/projects/inbox`
-- Worktree: `/Users/jwalinshah/projects/inbox-max-7`
-- Branch: `codex/MAX-7-inbox-ci-runtime`
-- Base: `origin/main` at `42a32a22f45b4641d5f06bbd5c5941c6bc5ec70f`
+- Worktree: `/Users/jwalinshah/projects/inbox-MAX-250`
+- Branch: `codex/MAX-250-inbox-api-auth-fail-closed`
+- Base: `origin/main` at `1327e97`
 
 ## Plan
 
-- Guard MLX and PyObjC dependencies so non-mac CI does not resolve mac-only runtime packages.
-- Add an explicit `mac` extra for the full macOS runtime dependency set.
-- Add a safe CI workflow that hydrates the locked environment, then runs the existing agent-safe validation wrapper.
-- Document local and CI validation commands in README and AGENTS.
+- Make `/health` the only unauthenticated endpoint by default.
+- Require `INBOX_SERVER_TOKEN` for all non-health endpoints unless an explicit dev/test bypass is enabled.
+- Add `INBOX_SERVER_ALLOW_UNAUTHENTICATED=1` as the named bypass for isolated development and tests.
+- Update auth tests to prove fail-closed, token success, X-API-Key success, and explicit dev bypass behavior.
+- Update README/CLAUDE/config docs for the new default.
 
 ## Validation
 
 ```bash
-uv lock --check
+uv run pytest tests/test_server.py::TestAuth -q --no-cov
+```
+
+Result: passed, 7 passed.
+
+```bash
+uv run pytest tests/test_server.py tests/test_server_endpoints.py tests/test_api_contract.py -q --no-cov
+```
+
+Result: passed, 186 passed.
+
+```bash
+uv run ruff check inbox_server.py tests/conftest.py tests/test_server.py
 ```
 
 Result: passed.
-
-```bash
-uv sync --frozen --all-groups --dry-run --python-platform x86_64-unknown-linux-gnu --no-progress
-```
-
-Result: passed. Linux dry run installs 98 packages and excludes MLX, PyObjC, Torch, and CUDA runtime artifacts.
-
-```bash
-INBOX_TEST_MODE=1 uv run pytest tests/test_inbox_test_mode.py tests/test_services.py -k "test_mode_blocks" -q --no-cov
-```
-
-Result: passed, 3 passed and 69 deselected.
-
-```bash
-scripts/validate_agent_safe.sh
-```
-
-Result: passed. Ruff passed, Bandit completed with existing warnings only, and safe pytest passed with 11 passed and 871 deselected.
 
 ```bash
 git diff --check
@@ -48,49 +43,38 @@ git diff --check
 
 Result: passed.
 
-Review rerun:
+```bash
+scripts/validate_agent_safe.sh
+```
+
+Result: passed. Ruff passed, Bandit completed with existing warnings only, and safe pytest passed with 11 passed and 874 deselected.
+
+Review rerun after PR #43 landed:
 
 ```bash
 uv lock --check
 ```
 
-Result: passed, resolved 130 packages.
+Result: passed.
 
 ```bash
-uv sync --frozen --all-groups --dry-run --python-platform x86_64-unknown-linux-gnu --no-progress
+INBOX_TEST_MODE=1 uv run pytest tests/test_server.py -q --no-cov
 ```
 
-Result: passed. Linux dry run excludes MLX, PyObjC, Torch, CUDA, and related mac/ML runtime artifacts.
-
-```bash
-INBOX_TEST_MODE=1 uv run pytest tests/test_inbox_test_mode.py tests/test_services.py -k "test_mode_blocks" -q --no-cov
-```
-
-Result: passed, 3 passed and 69 deselected.
+Result: passed, 126 passed.
 
 ```bash
 scripts/validate_agent_safe.sh
 ```
 
-Result: passed. Ruff passed, Bandit completed with existing warnings only, and safe pytest passed with 11 passed and 871 deselected.
+Result: passed. Ruff passed, Bandit completed with existing warnings only, and safe pytest passed with 11 passed and 874 deselected.
 
 ```bash
 git diff --check
 ```
 
 Result: passed.
-
-Remote CI:
-
-- PR #43 `Safe validation`: passed.
-- Job: https://github.com/jwalin-shah/inbox/actions/runs/25645772647/job/75274274402
 
 ## Handoff
 
-- PR URL: https://github.com/jwalin-shah/inbox/pull/43
-- Latest implementation commit SHA: `f10b972f753f4a36705d088bf549cc45c7aaa92f`
-- Review evidence commit SHA: recorded in Linear after push.
-- Commits:
-  - `6d64c7f22c1ed210d6b30e676992e3a86b2cee4b` - Fix inbox mac-only dependency CI path
-  - `f10b972f753f4a36705d088bf549cc45c7aaa92f` - Fix CI workflow temp env
-- Blockers: none.
+Pending PR.

--- a/README.md
+++ b/README.md
@@ -50,7 +50,11 @@ uv run python inbox_server.py   # Runs on localhost:9849
 
 ## API Reference
 
-All endpoints available at `localhost:9849`. Optional token-based auth via `INBOX_SERVER_TOKEN` env var.
+All endpoints are available at `localhost:9849`. `/health` is unauthenticated for local
+supervision; every other endpoint requires `INBOX_SERVER_TOKEN` by default.
+Requests must send `Authorization: Bearer <token>` or `X-API-Key: <token>`.
+For isolated dev/test work only, set `INBOX_SERVER_ALLOW_UNAUTHENTICATED=1` to
+allow non-health requests without a token.
 
 **Conversations & Messages:**
 ```

--- a/config/inbox.env.example
+++ b/config/inbox.env.example
@@ -1,6 +1,8 @@
 # Private inbox backend
 INBOX_SERVER_URL=http://127.0.0.1:9849
 INBOX_SERVER_TOKEN=replace-with-a-long-random-token
+# Dev/test only. Leave unset or 0 for daily-driver and agent-facing servers.
+INBOX_SERVER_ALLOW_UNAUTHENTICATED=0
 
 # Public MCP gateway
 INBOX_MCP_TOKEN=replace-with-a-different-long-random-token

--- a/inbox_server.py
+++ b/inbox_server.py
@@ -211,6 +211,8 @@ _gmail_triage_reexports = (
 
 PORT = 9849
 AUTH_TOKEN_ENV = "INBOX_SERVER_TOKEN"  # nosec: B105 - env var name, not a hardcoded credential
+AUTH_BYPASS_ENV = "INBOX_SERVER_ALLOW_UNAUTHENTICATED"
+AUTH_BYPASS_TRUE_VALUES = frozenset({"1", "true", "yes", "on"})
 GOOGLE_SERVICE_SET = tuple[
     dict[str, object],
     dict[str, object],
@@ -1314,19 +1316,30 @@ def _auth_token() -> str:
     return os.getenv(AUTH_TOKEN_ENV, "").strip()
 
 
+def _auth_bypass_enabled() -> bool:
+    return os.getenv(AUTH_BYPASS_ENV, "").strip().lower() in AUTH_BYPASS_TRUE_VALUES
+
+
+def _non_health_auth_required() -> bool:
+    return bool(_auth_token()) or not _auth_bypass_enabled()
+
+
 def _is_authorized(request: Request) -> bool:
-    token = _auth_token()
-    if not token:
+    if request.url.path == "/health":
         return True
 
-    auth_header = request.headers.get("authorization", "")
-    if auth_header.lower().startswith("bearer "):
-        provided = auth_header[7:].strip()
-        if provided and compare_digest(provided, token):
-            return True
+    token = _auth_token()
+    if token:
+        auth_header = request.headers.get("authorization", "")
+        if auth_header.lower().startswith("bearer "):
+            provided = auth_header[7:].strip()
+            if provided and compare_digest(provided, token):
+                return True
 
-    api_key = request.headers.get("x-api-key", "").strip()
-    return bool(api_key) and compare_digest(api_key, token)
+        api_key = request.headers.get("x-api-key", "").strip()
+        return bool(api_key) and compare_digest(api_key, token)
+
+    return _auth_bypass_enabled()
 
 
 @app.middleware("http")
@@ -1354,6 +1367,9 @@ async def health():
         "drive_accounts": list(state.drive_services.keys()),
         "sheets_accounts": list(state.sheets_services.keys()),
         "github_configured": _github_token() is not None,
+        "api_auth_required": _non_health_auth_required(),
+        "api_auth_configured": bool(_auth_token()),
+        "api_auth_dev_bypass": _auth_bypass_enabled(),
     }
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,6 +21,13 @@ def _stub_module(name: str):
         sys.modules[name] = MagicMock()
 
 
+@pytest.fixture(autouse=True)
+def _allow_unauthenticated_server_for_existing_tests(monkeypatch):
+    """Existing endpoint tests use TestClient without auth unless they opt out."""
+    monkeypatch.setenv("INBOX_SERVER_TOKEN", "")
+    monkeypatch.setenv("INBOX_SERVER_ALLOW_UNAUTHENTICATED", "1")
+
+
 # These are hardware/ML deps that may not be present in CI
 for mod in [
     "mlx_lm",

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -369,11 +369,67 @@ class TestIndexEndpoints:
 
 
 class TestAuth:
-    def test_auth_not_required_when_token_unset(self, client):
+    def test_health_does_not_require_auth_when_token_unset(self, client):
         resp = client.get("/health")
         assert resp.status_code == 200
+        assert resp.json()["api_auth_required"] is False
 
-    def test_auth_required_when_token_set(self):
+    def test_health_does_not_require_auth_when_non_health_auth_is_fail_closed(self):
+        import inbox_server
+
+        with (
+            patch.dict(
+                os.environ,
+                {"INBOX_SERVER_TOKEN": "", "INBOX_SERVER_ALLOW_UNAUTHENTICATED": "0"},
+                clear=False,
+            ),
+            patch("inbox_server.init_contacts", return_value=0),
+            patch("inbox_server.google_auth_all", return_value=({}, {}, {}, {}, {}, {})),
+            TestClient(inbox_server.app, raise_server_exceptions=False) as client,
+        ):
+            resp = client.get("/health")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["api_auth_required"] is True
+        assert data["api_auth_configured"] is False
+        assert data["api_auth_dev_bypass"] is False
+
+    def test_non_health_auth_required_when_token_unset_without_dev_bypass(self):
+        import inbox_server
+
+        with (
+            patch.dict(
+                os.environ,
+                {"INBOX_SERVER_TOKEN": "", "INBOX_SERVER_ALLOW_UNAUTHENTICATED": "0"},
+                clear=False,
+            ),
+            patch("inbox_server.init_contacts", return_value=0),
+            patch("inbox_server.google_auth_all", return_value=({}, {}, {}, {}, {}, {})),
+            TestClient(inbox_server.app, raise_server_exceptions=False) as client,
+        ):
+            resp = client.get("/accounts")
+
+        assert resp.status_code == 401
+
+    def test_explicit_dev_bypass_allows_non_health_when_token_unset(self):
+        import inbox_server
+
+        with (
+            patch.dict(
+                os.environ,
+                {"INBOX_SERVER_TOKEN": "", "INBOX_SERVER_ALLOW_UNAUTHENTICATED": "1"},
+                clear=False,
+            ),
+            patch("inbox_server.init_contacts", return_value=0),
+            patch("inbox_server.google_auth_all", return_value=({}, {}, {}, {}, {}, {})),
+            TestClient(inbox_server.app, raise_server_exceptions=False) as client,
+        ):
+            resp = client.get("/accounts")
+
+        assert resp.status_code == 200
+
+    def test_non_health_auth_required_when_token_set(self):
         import inbox_server
 
         with (
@@ -382,7 +438,7 @@ class TestAuth:
             patch("inbox_server.google_auth_all", return_value=({}, {}, {}, {}, {}, {})),
             TestClient(inbox_server.app, raise_server_exceptions=False) as client,
         ):
-            resp = client.get("/health")
+            resp = client.get("/accounts")
         assert resp.status_code == 401
 
     def test_bearer_auth_allows_request(self):
@@ -394,7 +450,7 @@ class TestAuth:
             patch("inbox_server.google_auth_all", return_value=({}, {}, {}, {}, {}, {})),
             TestClient(inbox_server.app, raise_server_exceptions=False) as client,
         ):
-            resp = client.get("/health", headers={"Authorization": "Bearer secret-token"})
+            resp = client.get("/accounts", headers={"Authorization": "Bearer secret-token"})
         assert resp.status_code == 200
 
     def test_x_api_key_auth_allows_request(self):
@@ -406,7 +462,7 @@ class TestAuth:
             patch("inbox_server.google_auth_all", return_value=({}, {}, {}, {}, {}, {})),
             TestClient(inbox_server.app, raise_server_exceptions=False) as client,
         ):
-            resp = client.get("/health", headers={"X-API-Key": "secret-token"})
+            resp = client.get("/accounts", headers={"X-API-Key": "secret-token"})
         assert resp.status_code == 200
 
 


### PR DESCRIPTION
## Summary
- Make `/health` the only unauthenticated endpoint by default.
- Require `INBOX_SERVER_TOKEN` for every non-health endpoint unless `INBOX_SERVER_ALLOW_UNAUTHENTICATED=1` is explicitly set for isolated dev/test use.
- Support both `Authorization: Bearer <token>` and `X-API-Key: <token>` for authenticated requests.
- Expose auth posture in `/health` and update docs/config/test defaults.

## Validation
- `uv lock --check`
- `INBOX_TEST_MODE=1 uv run pytest tests/test_server.py -q --no-cov` (`126 passed`)
- `scripts/validate_agent_safe.sh` (`ruff`, `bandit`, safe pytest lane: `11 passed`)
- `git diff --check`

Linear: MAX-250