### PR TITLE
Make local validation gate authoritative

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -338,6 +338,8 @@ uv run pyright                  # broad type check
 uv run pytest                   # broad unit test suite
 ```
 
+Run `scripts/validate_agent_safe.sh` before PR handoff; it is the local gate mirrored by CI.
+
 ## Agent Slash Commands
 
 The inbox skill provides first-class slash commands for agent workflows:

--- a/README.md
+++ b/README.md
@@ -158,10 +158,15 @@ ambient_daemon.py    — Background audio capture + ASR + extraction
 
 ## Development
 
+Default pre-handoff validation:
+
 ```bash
 scripts/validate_agent_safe.sh
-uv sync --frozen --all-groups && scripts/validate_agent_safe.sh
-INBOX_TEST_MODE=1 uv run pytest tests/test_inbox_test_mode.py tests/test_services.py -k "test_mode_blocks" -q --no-cov
+```
+
+Other local development commands:
+
+```bash
 uv run ruff check --fix .
 uv run pyright
 ```

--- a/docs/TESTING_FOR_AGENTS.md
+++ b/docs/TESTING_FOR_AGENTS.md
@@ -4,18 +4,18 @@ This repo contains personal-data integrations. Default agent runs must be determ
 
 ## Safe Commands
 
-Use the wrapper as the default read-only verification loop:
+Use the wrapper as the default pre-handoff verification loop:
 
 ```bash
 scripts/validate_agent_safe.sh
 ```
 
-The wrapper sets `INBOX_TEST_MODE=1`, points `UV_CACHE_DIR` at a writable temp cache, runs offline-only dependency hydration, and then runs:
+The wrapper sets `INBOX_TEST_MODE=1`, points `UV_CACHE_DIR` at a writable temp cache, checks that the locked offline environment is available, and then runs:
 
 ```bash
 uv run ruff check .
 uv run bandit -c pyproject.toml -r .
-INBOX_TEST_MODE=1 uv run pytest -m safe
+INBOX_TEST_MODE=1 uv run pytest tests/test_connector_registry.py tests/test_services.py tests/test_message_sync.py -q --no-cov
 ```
 
 The retired broad manual loop also included `uv run pyright`; do not use it as the default agent-safe gate unless the task explicitly asks for typechecking.
@@ -50,4 +50,4 @@ Do not run live-write tests unless explicitly instructed by the user.
 
 Do not run tests marked `local_data`, `live_write`, or live provider-specific integration tests unless the user asks for that class of verification by name.
 
-Do not replace `scripts/validate_agent_safe.sh` with broad `uv run pytest`, server startup, TUI startup, OAuth flows, provider clients, fix/format commands, or integrations against local personal data for default agent validation.
+Do not replace `scripts/validate_agent_safe.sh` with broad `uv run pytest`, marker-only subsets, server startup, TUI startup, OAuth flows, provider clients, fix/format commands, or integrations against local personal data for default agent validation.

--- a/scripts/validate_agent_safe.sh
+++ b/scripts/validate_agent_safe.sh
@@ -17,6 +17,11 @@ if ! command -v uv >/dev/null 2>&1; then
 fi
 
 UV_RUN=(uv run --offline --frozen --no-progress)
+PYTEST_GATE=(
+  tests/test_connector_registry.py
+  tests/test_services.py
+  tests/test_message_sync.py
+)
 
 is_dependency_blocker() {
   grep -Eiq \
@@ -82,4 +87,4 @@ PY
 
 run_uv "ruff check" ruff check --no-cache .
 run_uv "bandit scan" bandit -c pyproject.toml -r . -x .venv,tests,.factory,.claude -q
-run_uv "safe pytest lane" pytest -m safe -q --no-cov -p no:cacheprovider
+run_uv "authoritative pytest gate" pytest "${PYTEST_GATE[@]}" -q --no-cov -p no:cacheprovider

--- a/tests/test_inbox_test_mode.py
+++ b/tests/test_inbox_test_mode.py
@@ -74,7 +74,11 @@ def test_agent_safe_pytest_markers_are_registered(pytestconfig):
 def test_agent_testing_docs_define_safe_commands_and_opt_in_warnings():
     docs = Path("docs/TESTING_FOR_AGENTS.md").read_text()
 
-    assert "INBOX_TEST_MODE=1 uv run pytest -m safe" in docs
+    assert (
+        "INBOX_TEST_MODE=1 uv run pytest tests/test_connector_registry.py "
+        "tests/test_services.py tests/test_message_sync.py -q --no-cov"
+    ) in docs
     assert "uv run ruff check ." in docs
     assert "uv run pyright" in docs
+    assert "do not use it as the default agent-safe gate" in docs
     assert "Do not run live-write tests unless explicitly instructed" in docs


### PR DESCRIPTION
## Summary
- Make scripts/validate_agent_safe.sh run the explicit connector registry, services, and message sync pytest gate instead of a marker-only safe subset.
- Document scripts/validate_agent_safe.sh as the pre-handoff validation command mirrored by CI.

## Validation
- INBOX_TEST_MODE=1 uv run pytest tests/test_connector_registry.py tests/test_services.py tests/test_message_sync.py -q --no-cov: 84 passed
- scripts/validate_agent_safe.sh: passed (ruff, bandit with existing warnings, authoritative pytest gate 84 passed)
- git diff --check: passed

## Residual Risk
- Bandit still prints existing nosec/test-name warnings, but exits zero; this PR does not change that scan behavior.
- The wrapper intentionally remains offline/frozen, so a cold uv cache still reports a dependency/cache blocker until dependencies are hydrated.