### PR TITLE
Add Gmail recipient parsing regression

### DIFF
--- a/message_sync.py
+++ b/message_sync.py
@@ -4,6 +4,7 @@ import argparse
 import hashlib
 import sqlite3
 from datetime import UTC, datetime
+from email.utils import getaddresses
 from pathlib import Path
 from typing import Any
 
@@ -59,7 +60,7 @@ def _gmail_recipients(headers: dict[str, str]) -> list[str]:
     to_raw = headers.get("To", "")
     if not to_raw:
         return []
-    return [part.strip() for part in to_raw.split(",") if part.strip()]
+    return [email or name for name, email in getaddresses([to_raw]) if email or name]
 
 
 def _gmail_item(account: str, message: dict[str, Any]) -> IndexedItem:

--- a/tests/test_message_sync.py
+++ b/tests/test_message_sync.py
@@ -1,3 +1,4 @@
+import json
 import sqlite3
 
 import pytest
@@ -84,6 +85,7 @@ def _gmail_message(
     *,
     thread_id: str | None = None,
     labels: list[str] | None = None,
+    to_header: str = "acct@example.com",
 ):
     return {
         "id": message_id,
@@ -94,7 +96,7 @@ def _gmail_message(
         "payload": {
             "headers": [
                 {"name": "From", "value": "Sender <sender@example.com>"},
-                {"name": "To", "value": "acct@example.com"},
+                {"name": "To", "value": to_header},
                 {"name": "Subject", "value": f"Subject {message_id}"},
             ],
             "parts": [],
@@ -230,6 +232,38 @@ def test_sync_gmail_bootstrap_records_history_cursor(tmp_path, monkeypatch):
     assert state["metadata"]["cursor_mode"] == "history"
     assert state["metadata"]["history_id"] == "9000"
     assert state["metadata"]["timestamp_checkpoint_ms"] == "300"
+
+
+def test_sync_gmail_bootstrap_parses_quoted_recipient_commas(tmp_path, monkeypatch):
+    store = MessageIndexStore(tmp_path / "index.sqlite3")
+    service = _FakeGmailService(
+        list_payloads={
+            "__first__": {
+                "messages": [{"id": "m1"}],
+            },
+        },
+        full_messages={
+            "m1": _gmail_message(
+                "m1",
+                300,
+                to_header='"Doe, Jane" <jane@example.com>, Bob <bob@example.com>',
+            ),
+        },
+    )
+    monkeypatch.setattr(
+        message_sync,
+        "google_auth_all",
+        lambda: ({"acct@example.com": service}, {}, {}, {}, {}, {}),
+    )
+
+    stats = message_sync.sync_gmail_bootstrap(store)
+    assert stats == {"acct@example.com": 1}
+
+    with sqlite3.connect(store.db_path) as conn:
+        recipients_json = conn.execute(
+            "SELECT recipients_json FROM items WHERE external_id = 'm1'"
+        ).fetchone()[0]
+    assert json.loads(recipients_json) == ["jane@example.com", "bob@example.com"]
 
 
 def test_sync_gmail_bootstrap_does_not_double_count_or_rewrite_items_on_resume(


### PR DESCRIPTION
## Summary
- Add a regression test for Gmail bootstrap indexing of To headers containing quoted display-name commas.
- Replace ad hoc comma splitting with email.utils.getaddresses so indexed recipients stay intact.

## Validation
- INBOX_TEST_MODE=1 uv run pytest tests/test_connector_registry.py tests/test_services.py tests/test_message_sync.py -q --no-cov -> 85 passed
- git diff --check -> passed

## Residual risk
- Low; recipient storage now normalizes parsed addresses to email addresses when present, which is more precise than the previous raw fragment list but may change downstream display if anything expected display-name strings in recipients_json.