### PR TITLE
Deepen connector search source handling

### DIFF
--- a/connector_registry.py
+++ b/connector_registry.py
@@ -17,6 +17,8 @@ from pathlib import Path
 from typing import Any
 
 DEFAULT_TIMEOUT_SECONDS = 12
+CONNECTOR_SOURCE_PREFIX = "connector:"
+CONNECTOR_ALL_SOURCE = "connectors"
 
 
 @dataclass(frozen=True)
@@ -194,6 +196,43 @@ def connectors_status() -> dict[str, Any]:
             ),
         },
     }
+
+
+def connector_source_ids() -> frozenset[str]:
+    return frozenset(connector.id for connector in CONNECTORS)
+
+
+def partition_search_sources(sources: list[str]) -> tuple[list[str], list[str]]:
+    built_in_sources: list[str] = []
+    connector_sources: list[str] = []
+    valid_connector_ids = connector_source_ids()
+
+    for source in sources:
+        if source == CONNECTOR_ALL_SOURCE:
+            connector_sources = ["all"]
+        elif source.startswith(CONNECTOR_SOURCE_PREFIX):
+            connector_id = source.removeprefix(CONNECTOR_SOURCE_PREFIX)
+            if connector_id in valid_connector_ids:
+                connector_sources.append(connector_id)
+        else:
+            built_in_sources.append(source)
+
+    return built_in_sources, connector_sources
+
+
+def merge_connector_search_results(
+    result: dict[str, Any],
+    connector_result: dict[str, Any],
+    *,
+    limit: int,
+) -> dict[str, Any]:
+    merged = dict(result)
+    merged_results = [*result.get("results", []), *connector_result.get("results", [])]
+    merged_results.sort(key=lambda item: item.get("timestamp", ""), reverse=True)
+    merged["results"] = merged_results[:limit]
+    merged["total"] = len(merged["results"])
+    merged["connector_errors"] = connector_result.get("errors", [])
+    return merged
 
 
 def _connector_by_id(connector_id: str) -> ConnectorDefinition | None:

--- a/inbox_server.py
+++ b/inbox_server.py
@@ -22,7 +22,13 @@ from pydantic import BaseModel
 
 import ambient_notes
 import google_account_resolution as _gacct
-from connector_registry import CONNECTORS, connector_sync_plan, connectors_status, search_connectors
+from connector_registry import (
+    connector_sync_plan,
+    connectors_status,
+    merge_connector_search_results,
+    partition_search_sources,
+    search_connectors,
+)
 from gmail_triage import (
     KIND_PREFIX as _KIND_PREFIX,
 )
@@ -214,9 +220,6 @@ PORT = 9849
 AUTH_TOKEN_ENV = "INBOX_SERVER_TOKEN"  # nosec: B105 - env var name, not a hardcoded credential
 AUTH_BYPASS_ENV = "INBOX_SERVER_ALLOW_UNAUTHENTICATED"
 AUTH_BYPASS_TRUE_VALUES = frozenset({"1", "true", "yes", "on"})
-CONNECTOR_SOURCE_PREFIX = "connector:"
-CONNECTOR_ALL_SOURCE = "connectors"
-CONNECTOR_SOURCE_IDS = frozenset(connector.id for connector in CONNECTORS)
 GOOGLE_SERVICE_SET = tuple[
     dict[str, object],
     dict[str, object],
@@ -3282,18 +3285,7 @@ async def connectors_sync_endpoint(connector_id: str, req: ConnectorSyncRequest)
 
 @app.post("/search")
 async def search_endpoint(req: SearchRequest):
-    built_in_sources: list[str] = []
-    connector_sources: list[str] = []
-    for source in req.sources:
-        if source == CONNECTOR_ALL_SOURCE:
-            connector_sources = ["all"]
-        elif source.startswith(CONNECTOR_SOURCE_PREFIX):
-            connector_id = source.removeprefix(CONNECTOR_SOURCE_PREFIX)
-            if connector_id in CONNECTOR_SOURCE_IDS:
-                connector_sources.append(connector_id)
-        else:
-            built_in_sources.append(source)
-
+    built_in_sources, connector_sources = partition_search_sources(req.sources)
     result = await asyncio.to_thread(
         search_all,
         query=req.q,
@@ -3314,11 +3306,7 @@ async def search_endpoint(req: SearchRequest):
             sources=connector_sources,
             limit=req.limit,
         )
-        merged_results = [*result.get("results", []), *connector_result.get("results", [])]
-        merged_results.sort(key=lambda item: item.get("timestamp", ""), reverse=True)
-        result["results"] = merged_results[: req.limit]
-        result["total"] = len(result["results"])
-        result["connector_errors"] = connector_result.get("errors", [])
+        result = merge_connector_search_results(result, connector_result, limit=req.limit)
     return result
 
 

--- a/tests/test_connector_registry.py
+++ b/tests/test_connector_registry.py
@@ -54,6 +54,41 @@ def test_search_connectors_normalizes_json_results():
     assert result["errors"] == []
 
 
+def test_partition_search_sources_hides_connector_markers_from_callers():
+    from connector_registry import partition_search_sources
+
+    built_in, connector = partition_search_sources(
+        ["gmail", "connector:whatsapp", "connector:missing", "connectors"]
+    )
+
+    assert built_in == ["gmail"]
+    assert connector == ["all"]
+
+
+def test_merge_connector_search_results_sorts_and_caps_results():
+    from connector_registry import merge_connector_search_results
+
+    result = {
+        "query": "hello",
+        "total": 1,
+        "results": [{"source": "gmail", "timestamp": "2026-05-12T00:00:00"}],
+    }
+    connector_result = {
+        "results": [
+            {"source": "whatsapp", "timestamp": "2026-05-12T02:00:00"},
+            {"source": "discord", "timestamp": "2026-05-12T01:00:00"},
+        ],
+        "errors": [{"source": "twitter", "error": "not_installed"}],
+    }
+
+    merged = merge_connector_search_results(result, connector_result, limit=2)
+
+    assert [item["source"] for item in merged["results"]] == ["whatsapp", "discord"]
+    assert merged["total"] == 2
+    assert merged["connector_errors"] == [{"source": "twitter", "error": "not_installed"}]
+    assert result["results"] == [{"source": "gmail", "timestamp": "2026-05-12T00:00:00"}]
+
+
 def test_sync_plan_defaults_to_dry_run():
     from connector_registry import connector_sync_plan
 


### PR DESCRIPTION
## Summary
- move connector source marker parsing and valid connector ID checks into connector_registry
- move connector result merging/sorting into connector_registry so the server caller carries less connector-specific knowledge
- add connector-registry interface tests for source partitioning and result merging

## Validation
- INBOX_TEST_MODE=1 uv run pytest tests/test_connector_registry.py tests/test_services.py tests/test_message_sync.py -q --no-cov
- INBOX_TEST_MODE=1 uv run pytest tests/test_server.py::TestConnectorEndpoints -q --no-cov
- uv run ruff check connector_registry.py inbox_server.py tests/test_connector_registry.py
- git diff --check