### PR TITLE
WP-126: Add message sync CLI smoke contract

### DIFF
--- a/message_sync.py
+++ b/message_sync.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import argparse
 import hashlib
 import sqlite3
+import sys
 from datetime import UTC, datetime
 from email.utils import getaddresses
 from pathlib import Path
@@ -25,6 +26,7 @@ GMAIL_TIMESTAMP_CURSOR = "internalDateMs"
 IMESSAGE_PROGRESS_EVERY = 250
 WHATSAPP_PROGRESS_EVERY = 250
 _ATTACHMENT_TEXT = "(attachment)"
+CLI_MODES = ("bootstrap", "incremental", "rebuild", "summary")
 SyncScope = tuple[str, str]
 
 
@@ -747,14 +749,39 @@ def print_summary(store: MessageIndexStore, limit: int) -> None:
         )
 
 
-def main() -> None:
+def smoke_contract() -> dict[str, object]:
+    return {
+        "ok": True,
+        "entrypoint": "message_sync.py",
+        "modes": list(CLI_MODES),
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         description="Materialize raw inbox sources into a local index."
     )
-    parser.add_argument("mode", choices=["bootstrap", "incremental", "rebuild", "summary"])
+    parser.add_argument("mode", nargs="?", choices=CLI_MODES)
+    parser.add_argument(
+        "--smoke",
+        action="store_true",
+        help="Verify CLI imports and argument parsing without touching data stores or auth.",
+    )
     parser.add_argument("--db", default="", help="Override index database path.")
     parser.add_argument("--limit", type=int, default=20, help="Summary row limit.")
-    args = parser.parse_args()
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    if args.smoke:
+        print(_json(smoke_contract()))
+        return 0
+
+    if not args.mode:
+        parser.error("mode is required unless --smoke is provided")
 
     store = MessageIndexStore(Path(args.db).expanduser() if args.db else None)
     if args.mode == "bootstrap":
@@ -765,7 +792,8 @@ def main() -> None:
         print({"threads": rebuild_all_threads(store)})
     else:
         print_summary(store, args.limit)
+    return 0
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/scripts/validate_agent_safe.sh
+++ b/scripts/validate_agent_safe.sh
@@ -82,4 +82,5 @@ PY
 
 run_uv "ruff check" ruff check --no-cache .
 run_uv "bandit scan" bandit -c pyproject.toml -r . -x .venv,tests,.factory,.claude -q
+run_uv "message sync CLI smoke" python message_sync.py --smoke
 run_uv "safe pytest lane" pytest -m safe -q --no-cov -p no:cacheprovider

--- a/tests/test_message_sync.py
+++ b/tests/test_message_sync.py
@@ -1,10 +1,15 @@
 import json
 import sqlite3
+import subprocess
+import sys
+from pathlib import Path
 
 import pytest
 
 import message_sync
 from message_index_store import IndexedItem, MessageIndexStore
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
 
 
 class _FakeRequest:
@@ -140,6 +145,37 @@ def _thread_rows(store: MessageIndexStore) -> dict[tuple[str, str, str], sqlite3
     with store._connect() as conn:
         rows = conn.execute("SELECT * FROM threads").fetchall()
     return {(str(row["source"]), str(row["account"]), str(row["thread_id"])): row for row in rows}
+
+
+def test_message_sync_cli_smoke_is_no_secret_success_path():
+    result = subprocess.run(
+        [sys.executable, "message_sync.py", "--smoke"],
+        cwd=REPO_ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0
+    assert result.stderr == ""
+    assert json.loads(result.stdout) == {
+        "entrypoint": "message_sync.py",
+        "modes": ["bootstrap", "incremental", "rebuild", "summary"],
+        "ok": True,
+    }
+
+
+def test_message_sync_cli_bad_input_fails_clearly():
+    result = subprocess.run(
+        [sys.executable, "message_sync.py", "bogus"],
+        cwd=REPO_ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode != 0
+    assert "invalid choice: 'bogus'" in result.stderr
 
 
 def test_sync_gmail_bootstrap_resumes_from_saved_page_token(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- Add `message_sync.py --smoke` as a no-secret smoke path that verifies imports and argument parsing before opening data stores or auth clients.
- Add process-level tests for smoke success and bad-mode argparse failure reporting.
- Wire the smoke command into `scripts/validate_agent_safe.sh`.

## Validation
- `INBOX_TEST_MODE=1 uv run pytest tests/test_connector_registry.py tests/test_services.py tests/test_message_sync.py -q --no-cov`
- `git diff --check`
- `uv run ruff check message_sync.py tests/test_message_sync.py`
- `scripts/validate_agent_safe.sh`

## Residual Risk
- Existing Bandit warnings remain present in the safe validation wrapper output, but the wrapper exits successfully.