### PR TITLE
WP-154: Separate fixtures from runtime outputs

### DIFF
--- a/.factory/validation/README.md
+++ b/.factory/validation/README.md
@@ -1,0 +1,15 @@
+# Validation Fixtures
+
+This directory contains tracked evidence fixtures from prior factory validation
+runs. Keep these files small and deterministic so they can be reviewed in git.
+
+Runtime output from new local runs must not be written here by default. Use one
+of the ignored local output directories instead:
+
+- `.factory/runtime/`
+- `.factory/outputs/`
+- `.factory/runs/`
+- `.factory/missions/`
+
+Do not delete existing evidence fixtures unless the replacement preserves the
+same review value or the obsolete evidence is documented in the commit.

--- a/.gitignore
+++ b/.gitignore
@@ -34,13 +34,21 @@ htmlcov/
 # Server logs
 *.log
 
+# Local runtime output
+.inbox_index.sqlite3*
+.inbox_scheduler.sqlite3*
+.inbox_memory.sqlite3*
+.inbox_runtime/
+.factory/runtime/
+.factory/outputs/
+.factory/runs/
+.factory/missions/
+
 # llm-tldr cache
 .tldr/
 
 # Claude Code & local MCP memory
 .claude/
-.inbox_memory.sqlite3
-.inbox_scheduler.sqlite3
 
 # Batch auto-generated state (keep inputs, ignore outputs)
 batch/triage-output.tsv
@@ -55,4 +63,3 @@ batch/.batch-state.lock
 
 # Hook-generated temp files
 CLAUDE.md.new
-.inbox_index.sqlite3

--- a/tests/test_message_sync.py
+++ b/tests/test_message_sync.py
@@ -12,6 +12,35 @@ from message_index_store import IndexedItem, MessageIndexStore
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
 
+def test_runtime_output_defaults_are_gitignored():
+    from message_index_store import DEFAULT_INDEX_DB
+
+    ignored_paths = [
+        DEFAULT_INDEX_DB.relative_to(REPO_ROOT),
+        Path(f"{DEFAULT_INDEX_DB.relative_to(REPO_ROOT)}-wal"),
+        Path(f"{DEFAULT_INDEX_DB.relative_to(REPO_ROOT)}-shm"),
+        Path(".inbox_memory.sqlite3-wal"),
+        Path(".inbox_scheduler.sqlite3-shm"),
+        Path(".inbox_runtime/message-sync/run.json"),
+        Path(".factory/runtime/validation/run.json"),
+        Path(".factory/outputs/validation/run.json"),
+        Path(".factory/runs/local-run.json"),
+        Path(".factory/missions/local-run.json"),
+    ]
+    result = subprocess.run(
+        ["git", "check-ignore", "--stdin"],
+        cwd=REPO_ROOT,
+        input="\n".join(str(path) for path in ignored_paths),
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0
+    assert result.stderr == ""
+    assert result.stdout.splitlines() == [str(path) for path in ignored_paths]
+
+
 class _FakeRequest:
     def __init__(self, payload):
         self._payload = payload


### PR DESCRIPTION
## Summary
- Ignore local runtime SQLite sidecars and factory run output directories.
- Document .factory/validation as tracked evidence fixtures, not a default runtime output target.
- Add a focused regression test asserting runtime output defaults are gitignored.

## Validation
- INBOX_TEST_MODE=1 uv run pytest tests/test_connector_registry.py tests/test_services.py tests/test_message_sync.py -q --no-cov
- git diff --check

## Residual Risk
- This preserves existing tracked factory evidence and prevents new local defaults from dirtying git, but external factory tooling must still be configured to write new outputs under the documented ignored runtime directories.