### PR TITLE
Harden connector search JSON boundary

### DIFF
--- a/CODEX_WORKPAD.md
+++ b/CODEX_WORKPAD.md
@@ -1,3 +1,42 @@
+# WP-182 Workpad
+
+## Issue
+
+- Work pack: `WP-182`
+- Title: Harden one error boundary
+- Repo: `/Users/jwalinshah/projects/inbox`
+- Worktree: `/Users/jwalinshah/projects/.workpack-runs/WP-182`
+- Branch: `codex/WP-182-error-boundary-hardening`
+
+## Plan
+
+- Harden the connector search adapter boundary.
+- Reject malformed JSON emitted by connector CLIs that are invoked with `--json`.
+- Preserve valid JSON normalization and empty-output behavior.
+- Cover the malformed-output path with a negative test.
+
+## Validation
+
+```bash
+INBOX_TEST_MODE=1 uv run pytest tests/test_connector_registry.py tests/test_services.py tests/test_message_sync.py -q --no-cov
+```
+
+Result: passed, `91 passed in 5.91s`.
+
+```bash
+git diff --check
+```
+
+Result: passed.
+
+## Handoff
+
+- PR: https://github.com/jwalin-shah/inbox/pull/59
+- Residual risk: connector search commands using `--json` now reject malformed
+  non-empty output instead of treating it as text.
+
+---
+
 # MAX-250 Workpad
 
 ## Issue

--- a/connector_registry.py
+++ b/connector_registry.py
@@ -244,16 +244,7 @@ def _normalize_search_results(connector_id: str, raw: str) -> list[dict[str, Any
     if parsed is None:
         if not raw:
             return []
-        return [
-            {
-                "source": connector_id,
-                "id": "",
-                "title": connector_id,
-                "snippet": raw[:500],
-                "timestamp": "",
-                "metadata": {"format": "text"},
-            }
-        ]
+        raise ValueError("malformed_json")
 
     if isinstance(parsed, dict):
         for key in ("results", "messages", "items", "data"):
@@ -348,7 +339,17 @@ def search_connectors(
                 }
             )
             continue
-        results.extend(_normalize_search_results(connector.id, stdout))
+        try:
+            results.extend(_normalize_search_results(connector.id, stdout))
+        except ValueError as exc:
+            errors.append(
+                {
+                    "source": connector.id,
+                    "error": str(exc),
+                    "detail": stdout[:1000],
+                }
+            )
+            continue
 
     results.sort(key=lambda item: item.get("timestamp", ""), reverse=True)
     results = results[:limit]

--- a/tests/test_connector_registry.py
+++ b/tests/test_connector_registry.py
@@ -54,6 +54,22 @@ def test_search_connectors_normalizes_json_results():
     assert result["errors"] == []
 
 
+def test_search_connectors_rejects_malformed_json_output():
+    from connector_registry import search_connectors
+
+    with (
+        patch("connector_registry.shutil.which", return_value="/usr/local/bin/wacli"),
+        patch("connector_registry._run", return_value=(0, "not json", "")),
+    ):
+        result = search_connectors("hello", sources=["whatsapp"], limit=5)
+
+    assert result["total"] == 0
+    assert result["results"] == []
+    assert result["errors"] == [
+        {"source": "whatsapp", "error": "malformed_json", "detail": "not json"}
+    ]
+
+
 def test_partition_search_sources_hides_connector_markers_from_callers():
     from connector_registry import partition_search_sources
 


### PR DESCRIPTION
## Summary
- reject malformed connector search JSON instead of converting it into a successful text result
- preserve valid JSON and empty-output behavior
- add a negative connector registry test and record WP-182 validation in CODEX_WORKPAD.md

## Validation
- INBOX_TEST_MODE=1 uv run pytest tests/test_connector_registry.py tests/test_services.py tests/test_message_sync.py -q --no-cov
- git diff --check

## Residual risk
- This assumes connector search commands that include --json should not fall back to text parsing when they emit malformed non-empty output.