### PR TITLE
Add index-only daily brief endpoint

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,28 +1,16 @@
 {
   "mcpServers": {
     "inbox": {
-      "command": "uv",
+      "command": "bash",
       "args": [
-        "run",
-        "python",
-        "inbox_mcp_stdio.py"
-      ],
-      "env": {
-        "INBOX_SERVER_URL": "http://127.0.0.1:9849",
-        "INBOX_SERVER_TOKEN": "${INBOX_SERVER_TOKEN}"
-      }
+        "scripts/run_inbox_mcp_stdio.sh"
+      ]
     },
     "inbox-readonly": {
-      "command": "uv",
+      "command": "bash",
       "args": [
-        "run",
-        "python",
-        "inbox_mcp_readonly_stdio.py"
-      ],
-      "env": {
-        "INBOX_SERVER_URL": "http://127.0.0.1:9849",
-        "INBOX_SERVER_TOKEN": "${INBOX_SERVER_TOKEN}"
-      }
+        "scripts/run_inbox_mcp_stdio_readonly.sh"
+      ]
     }
   }
 }

--- a/CODEX_WORKPAD.md
+++ b/CODEX_WORKPAD.md
@@ -217,3 +217,74 @@ git diff --check
 ```
 
 Result: passed.
+
+---
+
+# Command Center Slice - 2026-05-27
+
+## Scope
+
+- Branch: `codex/inbox-safe-daily-brief-slice`
+- Added read-only command center endpoint for the "one place" Inbox surface.
+
+## Implemented
+
+- `GET /inbox/command-center`
+- `InboxClient.command_center(...)`
+- MCP/tool registry route `get_command_center`
+- TUI refresh prefers the command-center endpoint when available
+- `MessageIndexStore.source_counts()`
+- Source coverage for indexed sources such as Gmail, iMessage, WhatsApp, and
+  LinkedIn
+- Agent lanes for `capture`, `triage`, `draft`, and `browser_exec`
+
+## Validation
+
+Reported during implementation:
+
+```bash
+focused tests
+```
+
+Result: passed, 6 passed.
+
+```bash
+broader related slice
+```
+
+Result: passed, 61 passed.
+
+```bash
+ruff on touched files
+```
+
+Result: passed.
+
+Verified after restarting main server:
+
+```bash
+scripts/validate_agent_safe.sh
+```
+
+Result: passed. Ruff passed, Bandit completed with existing warnings only,
+message sync CLI smoke passed, and safe pytest passed with 20 passed and 945
+deselected.
+
+```bash
+curl -H "Authorization: Bearer $INBOX_SERVER_TOKEN" \
+  "http://127.0.0.1:9849/inbox/command-center?limit=3"
+```
+
+Result: returned `read_model: command_center`, six queues, source coverage,
+agent lanes, approval candidates, now items, and waiting threads.
+
+## Residual Risk
+
+- Live `/inbox/command-center?limit=3` on the main data set took about 41
+  seconds. The endpoint works, but performance should be improved before
+  treating it as a fast dashboard refresh path.
+
+## Next
+
+- Commit this branch as a preservation point.
+- Add a follow-up slice to make command-center refresh latency bounded.

--- a/CODEX_WORKPAD.md
+++ b/CODEX_WORKPAD.md
@@ -288,3 +288,107 @@ agent lanes, approval candidates, now items, and waiting threads.
 
 - Commit this branch as a preservation point.
 - Add a follow-up slice to make command-center refresh latency bounded.
+
+---
+
+# Command Center Latency Slice - 2026-05-27
+
+## Diagnosis
+
+`GET /inbox/command-center` delegated to `get_inbox_now(...)`, which can call
+live Google Tasks and Calendar services when accounts are configured. That made
+the command-center refresh path depend on broader provider reads instead of the
+bounded local index path.
+
+## Change
+
+- Kept command center read-only and `raw_provider_fetch: false`.
+- Built command-center `now`, queue, approval, source-ref, and workflow-count
+  data from indexed thread views instead of calling `get_inbox_now(...)`.
+- Added regression coverage so configured Tasks and Calendar services are not
+  called by the command-center endpoint.
+
+## Timing Evidence
+
+Temporary patched server:
+
+```bash
+INBOX_SERVER_PORT=9858 INBOX_SERVER_ALLOW_UNAUTHENTICATED=1 \
+  INBOX_START_SCHEDULER=0 INBOX_DISABLE_AMBIENT=1 \
+  INBOX_DISABLE_IMESSAGE_SYNC=1 uv run python inbox_server.py
+```
+
+Command-center timings:
+
+```bash
+curl http://127.0.0.1:9858/inbox/command-center?limit=3
+```
+
+Result: 1.343s, 1.272s, 1.303s across three runs. Payload returned
+`read_model: command_center`, six queues, source coverage, `now_items`,
+`waiting_threads`, and `raw_provider_fetch: false`.
+
+Live restarted server on port 9849:
+
+```bash
+curl -H "Authorization: Bearer $INBOX_SERVER_TOKEN" \
+  http://127.0.0.1:9849/inbox/command-center?limit=3
+```
+
+Result after `launchctl kickstart -k gui/$(id -u)/com.jwalin.inbox.backend`:
+2.886s cold, then 0.700s and 0.315s warm. Payload returned
+`read_model: command_center`, six queues, source coverage, `now_items`,
+`waiting_threads`, and `raw_provider_fetch: false`.
+
+Control timing:
+
+```bash
+curl http://127.0.0.1:9858/inbox/now?limit=3
+```
+
+Result: 4.898s on the same temporary process, confirming command center was
+paying for the broader now-rollup path before this slice.
+
+Previous reported live timing for the old command-center path:
+`/inbox/command-center?limit=3` took about 41 seconds on port 9849.
+
+## Validation
+
+```bash
+uv run pytest tests/test_server.py -k command_center -q --no-cov
+```
+
+Result: passed, 1 passed.
+
+```bash
+uv run pytest tests/test_client.py -k command_center -q --no-cov
+```
+
+Result: passed, 1 passed.
+
+```bash
+uv run pytest tests/test_tools_registry.py -q --no-cov
+```
+
+Result: passed, 12 passed.
+
+```bash
+uv run pytest tests/test_server.py tests/test_client.py \
+  -k 'command_center or daily_brief or inbox_now' -q --no-cov
+```
+
+Result: passed, 6 passed.
+
+```bash
+uv run ruff check inbox_server.py tests/test_server.py
+```
+
+Result: passed.
+
+```bash
+scripts/validate_agent_safe.sh
+```
+
+Result: passed. Ruff passed, Bandit completed with existing warnings only,
+message sync CLI smoke passed, and safe pytest passed with 20 passed and 945
+deselected.

--- a/CODEX_WORKPAD.md
+++ b/CODEX_WORKPAD.md
@@ -1,5 +1,23 @@
 # WP-182 Workpad
 
+## Local Dirty Preservation - 2026-05-28
+
+Current checkout contains a mixed local slice on branch
+`codex/inbox-safe-daily-brief-slice` at `cc9138f`.
+
+Preservation archive:
+
+```text
+/Users/jwalinshah/project-archives/inbox-dirty-preservation-20260528-142026
+```
+
+Archive contents include `tracked-changes.patch`, `git-diff-stat.txt`,
+`git-status-short.txt`, `untracked-files.txt`, and copied untracked files.
+
+Do not reset or broad-refactor this checkout before splitting the dirty surface
+into reviewable slices. Current dirty surface includes inbox auth/client/server
+changes, WhatsApp/message index sync changes, run scripts, and related tests.
+
 ## Issue
 
 - Work pack: `WP-182`

--- a/docs/LOCAL_CAPTURE_RUNBOOK.md
+++ b/docs/LOCAL_CAPTURE_RUNBOOK.md
@@ -1,0 +1,77 @@
+# Local Capture Runbook
+
+## iMessage
+
+Current state: Full Disk Access is working for the local terminal/Codex path.
+`~/Library/Messages/chat.db` can be opened read-only, and an incremental sync
+processed new iMessage rows on 2026-05-28.
+
+Live iMessage sync is controlled by:
+
+```bash
+INBOX_DISABLE_IMESSAGE_SYNC=0
+```
+
+The LaunchAgent path uses `scripts/run_index_incremental.sh`, which defaults to
+live iMessage sync enabled. To temporarily disable iMessage reads:
+
+```bash
+echo 'INBOX_DISABLE_IMESSAGE_SYNC=1' >> ~/.config/raycast/inbox-workflows.env
+launchctl kickstart -k "gui/$(id -u)/com.jwalin.inbox.index-sync"
+```
+
+Manual smoke:
+
+```bash
+cd /Users/jwalinshah/projects/inbox
+python3 - <<'PY'
+import sqlite3
+from pathlib import Path
+p = Path.home() / "Library/Messages/chat.db"
+conn = sqlite3.connect(f"file:{p}?mode=ro", uri=True)
+print(conn.execute("select max(rowid), count(*) from message").fetchone())
+conn.close()
+PY
+
+INBOX_DISABLE_IMESSAGE_SYNC=0 uv run python message_sync.py incremental
+```
+
+If the smoke fails with `operation not permitted`, add the app that launches the
+process to System Settings -> Privacy & Security -> Full Disk Access. This may
+need to be Codex, Terminal, iTerm, Raycast, or the specific launchd parent,
+depending on where the command runs from.
+
+## WhatsApp
+
+Current state: store exists, but body capture is thin. The scanner LaunchAgent
+requires a reachable browser tab with WhatsApp Web.
+
+Manual hydration:
+
+```bash
+cd /Users/jwalinshah/projects/inbox
+scripts/open_whatsapp_scanner_browser.sh
+# Log into WhatsApp Web if prompted.
+scripts/run_whatsapp_scan_once.sh
+```
+
+If launchd logs say `uv: command not found`, set:
+
+```bash
+echo 'INBOX_UV_BIN=/opt/homebrew/bin/uv' >> ~/.config/raycast/inbox-workflows.env
+```
+
+## Exports To Add / Process
+
+Highest priority:
+
+1. LinkedIn full archive: messages, connections, job applications.
+2. Google Takeout: contacts, calendar, Gmail metadata, Drive file lists, Chrome.
+3. OpenAI and Claude exports: project/work history and useful context.
+4. Meta/Facebook/Instagram: messages and contacts if relationship graph matters.
+5. Apple data export: only if needed beyond direct iMessage local sync.
+6. X/Reddit/Amazon/Netflix/Uber/TikTok: lower priority unless a specific task
+   needs that history.
+
+Do not upload raw personal exports to external providers. Process locally first
+and promote only source-backed rows into the ops queues.

--- a/docs/OPS_BRAIN.md
+++ b/docs/OPS_BRAIN.md
@@ -1,0 +1,35 @@
+# Ops Brain
+
+Inbox can now read the local ops kernel without depending on Codex.
+
+## Run
+
+```bash
+cd /Users/jwalinshah/projects/inbox
+OPS_KERNEL_PATH=/Users/jwalinshah/Documents/Codex/2026-05-26/can-we-please-do-a-review/ops_kernel uv run python inbox.py
+```
+
+Open the `Ops` tab from the tab bar or command palette. It renders local
+reconciliation queues read-only:
+
+- resume/interview evidence
+- live Gmail connector evidence already copied into local CSV
+- Gmail export reconciliation
+- LinkedIn reconciliation
+- Drive evidence
+
+## Adapter Contract
+
+The durable state lives in local CSV/Markdown ledgers. Providers are adapters:
+they can read queue rows, draft work, or write handoff evidence, but they are not
+the place where state lives.
+
+Machine-readable packet:
+
+```bash
+cd /Users/jwalinshah/projects/inbox
+OPS_KERNEL_PATH=/Users/jwalinshah/Documents/Codex/2026-05-26/can-we-please-do-a-review/ops_kernel uv run python ops_brain.py
+```
+
+The JSON packet is intentionally simple so Codex, Claude, local models, shell
+scripts, Pioneer, Adaption, or future workers can all consume the same queue.

--- a/inbox.py
+++ b/inbox.py
@@ -48,6 +48,7 @@ from command_palette import (
     resolve_nlp,
 )
 from inbox_client import InboxClient
+from ops_brain import load_ops_queue_rows, ops_brain_status
 from tui_tabs import TAB_BY_TEXTUAL_ID, TUI_TABS
 
 DEFAULT_POLL_INTERVAL = 10.0
@@ -143,6 +144,34 @@ def _index_health_signature(index_health: dict | None) -> tuple | None:
     )
 
 
+def _source_coverage_signature(source_coverage: list[dict]) -> tuple:
+    return tuple(
+        (
+            row.get("source"),
+            row.get("account"),
+            row.get("item_count"),
+            row.get("thread_count"),
+            row.get("latest_item_at"),
+            row.get("last_success_at"),
+            row.get("status"),
+            row.get("healthy"),
+            row.get("stale"),
+            tuple(row.get("reasons") or []),
+        )
+        for row in source_coverage
+        if isinstance(row, dict)
+    )
+
+
+def _source_display_name(source: str) -> str:
+    return {
+        "gmail": "Gmail",
+        "imessage": "iMessage",
+        "whatsapp": "WhatsApp",
+        "linkedin": "LinkedIn",
+    }.get(source, source.replace("_", " ").title() if source else "Source")
+
+
 @dataclass(frozen=True)
 class AuxiliaryDataSnapshot:
     events: list[dict]
@@ -154,6 +183,7 @@ class AuxiliaryDataSnapshot:
     actionable_threads: list[dict]
     waiting_threads: list[dict]
     index_health: dict | None
+    source_coverage: list[dict]
     capture_health: dict | None
     egress_status: dict | None
     errors: list[str]
@@ -171,6 +201,7 @@ class RefreshDataSnapshot:
     actionable_threads: list[dict]
     waiting_threads: list[dict]
     index_health: dict | None
+    source_coverage: list[dict]
     capture_health: dict | None
     egress_status: dict | None
     status: str | None
@@ -498,6 +529,73 @@ class CaptureHealthItem(ListItem):
         yield Static(t)
 
 
+class SourceCoverageItem(ListItem):
+    def __init__(self, data: dict) -> None:
+        super().__init__()
+        self.data = data
+
+    def compose(self) -> ComposeResult:
+        d = self.data
+        t = Text()
+        healthy = d.get("healthy") is True and not d.get("stale")
+        stale = d.get("stale") is True
+        status = str(d.get("status") or "missing")
+        if healthy:
+            icon, style = "OK", "green"
+        elif status == "error":
+            icon, style = "ERR", "red"
+        elif stale:
+            icon, style = "GAP", "yellow"
+        else:
+            icon, style = "--", "dim"
+        t.append(f"{icon} ", style=style)
+        t.append(_source_display_name(str(d.get("source") or "")), style="bold white")
+        account = str(d.get("account") or "")
+        if account:
+            t.append(f" · {account}", style="dim")
+
+        item_count = int(d.get("item_count") or 0)
+        thread_count = int(d.get("thread_count") or 0)
+        line2_parts = [f"{item_count} items", f"{thread_count} threads"]
+        latest = str(d.get("latest_item_at") or "")
+        if latest:
+            try:
+                line2_parts.append(datetime.fromisoformat(latest).strftime("%b %d %H:%M"))
+            except (ValueError, TypeError):
+                line2_parts.append(latest)
+        reasons = [str(reason).replace("_", " ") for reason in d.get("reasons") or []]
+        if reasons:
+            line2_parts.append(", ".join(reasons[:2]))
+        t.append(f"\n  {' · '.join(line2_parts)}", style="dim")
+        yield Static(t)
+
+
+class OpsQueueItem(ListItem):
+    def __init__(self, data: dict) -> None:
+        super().__init__()
+        self.data = data
+
+    def compose(self) -> ComposeResult:
+        d = self.data
+        t = Text()
+        priority = str(d.get("priority") or "P?")
+        style = {"P0": "bold red", "P1": "yellow", "P2": "cyan"}.get(priority, "dim")
+        t.append(f"{priority} ", style=style)
+        t.append(str(d.get("_ops_title") or "Untitled"), style="bold white")
+
+        meta_parts = [
+            str(d.get("_ops_queue_label") or ""),
+            str(d.get("lane") or d.get("bucket") or d.get("project_id") or ""),
+        ]
+        meta = " · ".join(part for part in meta_parts if part)
+        if meta:
+            t.append(f"\n  {meta}", style="dim")
+        summary = str(d.get("_ops_summary") or "")
+        if summary:
+            t.append(f"\n  {summary[:72]}", style="dim")
+        yield Static(t)
+
+
 class IndexedThreadItem(ListItem):
     def __init__(self, data: dict) -> None:
         super().__init__()
@@ -663,6 +761,36 @@ class DetailView(Static):
             if d.get("account"):
                 t.append(f"\n[{d['account']}]", style="dim italic")
 
+        elif "source" in d and "thread_count" in d and "reasons" in d:
+            source = str(d.get("source") or "")
+            t.append(f"{_source_display_name(source)} coverage\n", style="bold white")
+            t.append("─" * 40 + "\n", style="dim")
+            status = str(d.get("status") or "missing")
+            style = "green" if d.get("healthy") and not d.get("stale") else "yellow"
+            if status == "error":
+                style = "red"
+            t.append(f"Status: {status}\n", style=style)
+            if d.get("stale"):
+                t.append("Freshness: stale\n", style="yellow")
+            else:
+                t.append("Freshness: current\n", style="green")
+            if d.get("account"):
+                t.append(f"Account: {d['account']}\n", style="dim")
+            t.append(f"Items indexed: {d.get('item_count', 0)}\n", style="white")
+            t.append(f"Threads indexed: {d.get('thread_count', 0)}\n", style="white")
+            if d.get("latest_item_at"):
+                t.append(f"Latest indexed item: {d['latest_item_at']}\n", style="cyan")
+            if d.get("last_success_at"):
+                t.append(f"Last sync success: {d['last_success_at']}\n", style="green")
+            age = d.get("last_success_age_seconds")
+            if age is not None:
+                t.append(f"Sync age: {age}s\n", style="dim")
+            reasons = [str(reason).replace("_", " ") for reason in d.get("reasons") or []]
+            if reasons:
+                t.append("\nStale reasons / sync gaps\n", style="bold yellow")
+                for reason in reasons:
+                    t.append(f"  - {reason}\n", style="yellow")
+
         elif "source_id" in d and "coverage_notes" in d:
             t.append(f"{d.get('display_name', d.get('source_id', 'Source'))}\n", style="bold white")
             t.append("─" * 40 + "\n", style="dim")
@@ -688,6 +816,40 @@ class DetailView(Static):
                 t.append(f"\n{d['last_error']}\n", style="red")
             if d.get("coverage_notes"):
                 t.append(f"\n{d['coverage_notes']}\n", style="dim")
+
+        elif "_ops_queue_id" in d:
+            t.append(f"{d.get('_ops_title', 'Ops item')}\n", style="bold white")
+            t.append("─" * 40 + "\n", style="dim")
+            priority = str(d.get("priority") or "P?")
+            style = {"P0": "red", "P1": "yellow", "P2": "cyan"}.get(priority, "dim")
+            t.append(f"Priority: {priority}\n", style=style)
+            t.append(f"Queue: {d.get('_ops_queue_label', '')}\n", style="cyan")
+            t.append(f"Source file: {d.get('_ops_source_file', '')}\n", style="dim")
+            for key in (
+                "lane",
+                "bucket",
+                "project_id",
+                "email_ts",
+                "date",
+                "people",
+                "from",
+                "subject",
+                "evidence_role",
+                "attachments",
+                "display_url",
+                "evidence_command",
+            ):
+                value = d.get(key)
+                if value:
+                    label = key.replace("_", " ").title()
+                    t.append(f"{label}: {value}\n", style="white")
+            summary = d.get("_ops_summary") or d.get("candidate_action")
+            if summary:
+                t.append(f"\nNext action\n{summary}\n", style="yellow")
+            t.append(
+                "\nRead-only queue row. Promote, send, move, delete, or external actions only after explicit approval.\n",
+                style="dim",
+            )
 
         elif d.get("completed") is not None and "list_name" in d:
             # Reminder — identified by completed field + list_name
@@ -1396,6 +1558,7 @@ class InboxApp(App):
         self.actionable_threads: list[dict] = []
         self.waiting_threads: list[dict] = []
         self.index_health: dict | None = None
+        self.source_coverage: list[dict] = []
         self.capture_health: dict | None = None
         self.egress_status: dict | None = None
         self.events: list[dict] = []
@@ -1404,6 +1567,8 @@ class InboxApp(App):
         self.reminder_lists: list[dict] = []
         self.github_data: list[dict] = []
         self.drive_data: list[dict] = []
+        self.ops_queue_data: list[dict] = []
+        self.ops_status: dict[str, str | int] = {}
         self.active_conv: dict | None = None
         self.active_index_thread: dict | None = None
         self.active_event: dict | None = None
@@ -1411,6 +1576,7 @@ class InboxApp(App):
         self.active_notification: dict | None = None
         self.active_drive_file: dict | None = None
         self.active_capture_source: dict | None = None
+        self.active_ops_item: dict | None = None
         self._active_filter: str = "all"
         self._rem_list_filter: str = ""  # "" = all lists
         self._editing_reminder: dict | None = None
@@ -1633,6 +1799,9 @@ class InboxApp(App):
         elif tab_name == "health":
             state["active_capture_source"] = self.active_capture_source
             state["active_conv"] = None
+        elif tab_name == "ops":
+            state["active_ops_item"] = self.active_ops_item
+            state["active_conv"] = None
         self._tab_state[tab_name] = state
 
     def _restore_tab_state(self, tab_name: str) -> None:
@@ -1717,6 +1886,17 @@ class InboxApp(App):
             self.active_drive_file = None
             if self.active_capture_source:
                 self.query_one("#detail-view", DetailView).detail = self.active_capture_source
+        elif tab_name == "ops":
+            self.active_ops_item = state.get("active_ops_item")
+            self.active_conv = None
+            self.active_index_thread = None
+            self.active_event = None
+            self.active_reminder = None
+            self.active_notification = None
+            self.active_drive_file = None
+            self.active_capture_source = None
+            if self.active_ops_item:
+                self.query_one("#detail-view", DetailView).detail = self.active_ops_item
         else:
             # For tabs without saved state, just clear active selections
             self.active_conv = None
@@ -1744,6 +1924,8 @@ class InboxApp(App):
         # Auto-load drive files when switching to Drive tab
         if new_filter == "drive" and not self.drive_data:
             self._load_drive_files()
+        if new_filter == "ops":
+            self._load_ops_queues()
 
     def _toggle_views(self) -> None:
         tab = next((t for t in TUI_TABS if t["id"] == self._active_filter), None)
@@ -1763,6 +1945,8 @@ class InboxApp(App):
                 compose_input.placeholder = "Search Drive files… (Enter)"
             elif self._active_filter == "health":
                 compose_input.placeholder = "Capture health is read-only"
+            elif self._active_filter == "ops":
+                compose_input.placeholder = "Ops queues are read-only"
             else:
                 compose_input.placeholder = ""
         else:
@@ -1917,10 +2101,39 @@ class InboxApp(App):
 
         if self._active_filter == "health":
             capture = self.capture_health or {}
+            coverage = self.source_coverage
+            if coverage:
+                current = sum(
+                    1
+                    for source in coverage
+                    if source.get("healthy") is True and source.get("stale") is not True
+                )
+                gaps = sum(
+                    1 for source in coverage if source.get("stale") is True or source.get("reasons")
+                )
+                lv.append(
+                    ListItem(
+                        Static(
+                            Text(
+                                f"  Source coverage {current}/{len(coverage)} current",
+                                style="bold cyan",
+                            )
+                        )
+                    )
+                )
+                for source in coverage:
+                    lv.append(SourceCoverageItem(source))
+            else:
+                gaps = 0
             sources = capture.get("sources", []) if isinstance(capture, dict) else []
             if not sources:
-                lv.append(ListItem(Static(Text("  No capture health yet", style="dim yellow"))))
+                if not coverage:
+                    lv.append(
+                        ListItem(Static(Text("  No source coverage yet", style="dim yellow")))
+                    )
             else:
+                if coverage:
+                    lv.append(ListItem(Static(Text("  Capture probes", style="bold dim"))))
                 for source in sources:
                     lv.append(CaptureHealthItem(source))
             summary = capture.get("summary", {}) if isinstance(capture, dict) else {}
@@ -1929,7 +2142,16 @@ class InboxApp(App):
             missing = summary.get("not_configured", 0)
             total = summary.get("total", len(sources))
             status_style = "green" if capture.get("healthy") else "yellow"
-            status = f"[{status_style}]{ok}/{total} sources ok[/]"
+            if coverage:
+                current = len(coverage) - gaps
+                cov_style = "green" if gaps == 0 else "yellow"
+                status = f"[{cov_style}]{current}/{len(coverage)} coverage current[/]"
+                if gaps:
+                    status += f"  [yellow]{gaps} sync gap[/]"
+                if total:
+                    status += f"  [{status_style}]{ok}/{total} probes ok[/]"
+            else:
+                status = f"[{status_style}]{ok}/{total} sources ok[/]"
             if errors:
                 status += f"  [red]{errors} error[/]"
             if missing:
@@ -1937,6 +2159,27 @@ class InboxApp(App):
             egress = self.egress_status or {}
             local_only = "on" if egress.get("local_only") else "off"
             status += f"  [dim]local-only:{local_only}[/]"
+            self._update_sidebar_status(status)
+            return
+
+        if self._active_filter == "ops":
+            if not self.ops_queue_data:
+                lv.append(ListItem(Static(Text("  No ops queue rows found", style="dim yellow"))))
+            else:
+                last_label = ""
+                for row in self.ops_queue_data:
+                    label = str(row.get("_ops_queue_label") or "Ops")
+                    if label != last_label:
+                        lv.append(ListItem(Static(Text(f"  {label}", style="bold cyan"))))
+                        last_label = label
+                    lv.append(OpsQueueItem(row))
+            status_info = self.ops_status or {}
+            total = int(status_info.get("queue_rows") or len(self.ops_queue_data))
+            p0 = int(status_info.get("p0_rows") or 0)
+            status = f"[cyan]{total} ops rows[/]"
+            if p0:
+                status += f"  [red]{p0} P0[/]"
+            status += "  [dim]local brain · provider adapters underneath · read-only[/]"
             self._update_sidebar_status(status)
             return
 
@@ -2013,6 +2256,18 @@ class InboxApp(App):
             status += f"  [dim]{tab_label}[/]"
         self._update_sidebar_status(status)
 
+    def _load_ops_queues(self) -> None:
+        try:
+            self.ops_queue_data = load_ops_queue_rows()
+            self.ops_status = ops_brain_status()
+        except Exception as exc:
+            self.ops_queue_data = []
+            self.ops_status = {}
+            self.query_one("#status", Static).update(f"[red]Ops queue load failed: {exc}[/]")
+            return
+        if self._active_filter == "ops":
+            self._render_sidebar()
+
     def _restore_sidebar_selection(self) -> None:
         """After _render_sidebar populates the ListView, restore the
         previously selected item (if any) for the active tab."""
@@ -2066,10 +2321,30 @@ class InboxApp(App):
                 if isinstance(child, DriveItem) and child.data.get("id") == file_id:
                     target_index = i
                     break
+        elif self._active_filter == "ops" and self.active_ops_item:
+            source_file = self.active_ops_item.get("_ops_source_file")
+            rank = self.active_ops_item.get("_ops_rank")
+            for i, child in enumerate(lv.children):
+                if (
+                    isinstance(child, OpsQueueItem)
+                    and child.data.get("_ops_source_file") == source_file
+                    and child.data.get("_ops_rank") == rank
+                ):
+                    target_index = i
+                    break
         elif self._active_filter == "health" and self.active_capture_source:
             source_key = self.active_capture_source.get("key")
+            source_name = self.active_capture_source.get("source")
+            source_account = self.active_capture_source.get("account", "")
             for i, child in enumerate(lv.children):
                 if isinstance(child, CaptureHealthItem) and child.data.get("key") == source_key:
+                    target_index = i
+                    break
+                if (
+                    isinstance(child, SourceCoverageItem)
+                    and child.data.get("source") == source_name
+                    and child.data.get("account", "") == source_account
+                ):
                     target_index = i
                     break
 
@@ -2114,6 +2389,9 @@ class InboxApp(App):
 
     def action_filter_health(self) -> None:
         self._activate_tab("health")
+
+    def action_filter_ops(self) -> None:
+        self._activate_tab("ops")
 
     def action_filter_actionable(self) -> None:
         self._activate_tab("actionable")
@@ -2449,6 +2727,7 @@ class InboxApp(App):
                     snapshot.actionable_threads,
                     snapshot.waiting_threads,
                     snapshot.index_health,
+                    snapshot.source_coverage,
                     snapshot.capture_health,
                     snapshot.egress_status,
                     status_override,
@@ -2459,6 +2738,7 @@ class InboxApp(App):
             self.actionable_threads = snapshot.actionable_threads
             self.waiting_threads = snapshot.waiting_threads
             self.index_health = snapshot.index_health
+            self.source_coverage = snapshot.source_coverage
             self.capture_health = snapshot.capture_health
             self.egress_status = snapshot.egress_status
             self.call_from_thread(self.query_one("#status", Static).update, status_override)
@@ -2481,6 +2761,7 @@ class InboxApp(App):
                 snapshot.actionable_threads,
                 snapshot.waiting_threads,
                 snapshot.index_health,
+                snapshot.source_coverage,
                 snapshot.capture_health,
                 snapshot.egress_status,
                 status_override,
@@ -2492,6 +2773,7 @@ class InboxApp(App):
         self.actionable_threads = snapshot.actionable_threads
         self.waiting_threads = snapshot.waiting_threads
         self.index_health = snapshot.index_health
+        self.source_coverage = snapshot.source_coverage
         self.capture_health = snapshot.capture_health
         self.egress_status = snapshot.egress_status
         if self._poll_had_error:
@@ -2513,6 +2795,7 @@ class InboxApp(App):
             snapshot.actionable_threads,
             snapshot.waiting_threads,
             snapshot.index_health,
+            snapshot.source_coverage,
             snapshot.capture_health,
             snapshot.egress_status,
             snapshot.status,
@@ -2530,6 +2813,7 @@ class InboxApp(App):
         actionable_threads: list[dict] | None = None,
         waiting_threads: list[dict] | None = None,
         index_health: dict | None = None,
+        source_coverage: list[dict] | None = None,
         capture_health: dict | None = None,
         egress_status: dict | None = None,
         status_override: str | None = None,
@@ -2567,6 +2851,8 @@ class InboxApp(App):
             self.waiting_threads = waiting_threads
         if index_health is not None:
             self.index_health = index_health
+        if source_coverage is not None:
+            self.source_coverage = source_coverage
         if capture_health is not None:
             self.capture_health = capture_health
         if egress_status is not None:
@@ -2603,6 +2889,7 @@ class InboxApp(App):
         actionable_threads = self.actionable_threads
         waiting_threads = self.waiting_threads
         index_health = self.index_health
+        source_coverage = self.source_coverage
         capture_health = self.capture_health
         egress_status = self.egress_status
         errors: list[str] = []
@@ -2655,6 +2942,9 @@ class InboxApp(App):
                 waiting_threads = result.get("waiting_threads", []) or []
                 if isinstance(result.get("index_health"), dict):
                     index_health = result["index_health"]
+                raw_source_coverage = result.get("source_coverage")
+                if isinstance(raw_source_coverage, list):
+                    source_coverage = [row for row in raw_source_coverage if isinstance(row, dict)]
                 warning = _format_index_health_warning(index_health)
                 if warning:
                     errors.append(warning)
@@ -2718,6 +3008,7 @@ class InboxApp(App):
             actionable_threads=actionable_threads,
             waiting_threads=waiting_threads,
             index_health=index_health,
+            source_coverage=source_coverage,
             capture_health=capture_health,
             egress_status=egress_status,
             errors=errors,
@@ -2747,6 +3038,7 @@ class InboxApp(App):
             actionable_threads=auxiliary.actionable_threads,
             waiting_threads=auxiliary.waiting_threads,
             index_health=auxiliary.index_health,
+            source_coverage=auxiliary.source_coverage,
             capture_health=auxiliary.capture_health,
             egress_status=auxiliary.egress_status,
             status=self._merge_status_errors(errors),
@@ -2769,6 +3061,7 @@ class InboxApp(App):
                 actionable_threads=self.actionable_threads,
                 waiting_threads=self.waiting_threads,
                 index_health=self.index_health,
+                source_coverage=self.source_coverage,
                 capture_health=self.capture_health,
                 egress_status=self.egress_status,
                 status=self._merge_status_errors([_format_request_error("Auto-refresh", exc)]),
@@ -2794,6 +3087,8 @@ class InboxApp(App):
             new_wait_ids = [t.get("thread_id") for t in auxiliary.waiting_threads]
             old_health = _index_health_signature(self.index_health)
             new_health = _index_health_signature(auxiliary.index_health)
+            old_source_coverage = _source_coverage_signature(self.source_coverage)
+            new_source_coverage = _source_coverage_signature(auxiliary.source_coverage)
             old_capture = _index_health_signature(self.capture_health)
             new_capture = _index_health_signature(auxiliary.capture_health)
             old_egress = (
@@ -2811,6 +3106,7 @@ class InboxApp(App):
                 or old_action_ids != new_action_ids
                 or old_wait_ids != new_wait_ids
                 or old_health != new_health
+                or old_source_coverage != new_source_coverage
                 or old_capture != new_capture
                 or old_egress != new_egress
             )
@@ -2826,6 +3122,7 @@ class InboxApp(App):
                 actionable_threads=auxiliary.actionable_threads,
                 waiting_threads=auxiliary.waiting_threads,
                 index_health=auxiliary.index_health,
+                source_coverage=auxiliary.source_coverage,
                 capture_health=auxiliary.capture_health,
                 egress_status=auxiliary.egress_status,
                 status=self._merge_status_errors(auxiliary.errors),
@@ -2843,6 +3140,7 @@ class InboxApp(App):
             actionable_threads=auxiliary.actionable_threads,
             waiting_threads=auxiliary.waiting_threads,
             index_health=auxiliary.index_health,
+            source_coverage=auxiliary.source_coverage,
             capture_health=auxiliary.capture_health,
             egress_status=auxiliary.egress_status,
             status=self._merge_status_errors(auxiliary.errors),
@@ -2994,6 +3292,21 @@ class InboxApp(App):
     def on_item_selected(self, event: ListView.Selected) -> None:
         item = event.item
 
+        if isinstance(item, SourceCoverageItem):
+            self.active_capture_source = item.data
+            self.active_event = None
+            self.active_reminder = None
+            self.active_notification = None
+            self.active_drive_file = None
+            self.active_conv = None
+            self.query_one("#detail-view", DetailView).detail = item.data
+            name = _source_display_name(str(item.data.get("source") or ""))
+            status = item.data.get("status", "missing")
+            self.query_one("#status", Static).update(
+                f"[bold]{name}[/]  [dim]source coverage · {status}[/]"
+            )
+            return
+
         if isinstance(item, CaptureHealthItem):
             self.active_capture_source = item.data
             self.active_event = None
@@ -3030,6 +3343,23 @@ class InboxApp(App):
             acct = d.get("account", "")
             tag = f" · {acct.split(chr(64))[0]}" if acct else ""
             self.query_one("#status", Static).update(f"[bold]{name}[/]  [dim]drive{tag}[/]")
+            return
+
+        if isinstance(item, OpsQueueItem):
+            self.active_ops_item = item.data
+            self.active_capture_source = None
+            self.active_drive_file = None
+            self.active_notification = None
+            self.active_reminder = None
+            self.active_event = None
+            self.active_index_thread = None
+            self.active_conv = None
+            self.query_one("#detail-view", DetailView).detail = item.data
+            title = item.data.get("_ops_title", "Ops item")
+            queue = item.data.get("_ops_queue_label", "ops")
+            self.query_one("#status", Static).update(
+                f"[bold]{title}[/]  [dim]{queue} · local queue[/]"
+            )
             return
 
         if isinstance(item, NotificationItem):

--- a/inbox.py
+++ b/inbox.py
@@ -2648,7 +2648,7 @@ class InboxApp(App):
 
         used_now_brief = False
         try:
-            result = self.client.inbox_now(limit=20)
+            result = self.client.command_center(limit=20)
             if isinstance(result, dict):
                 now_threads = result.get("now_items", []) or []
                 actionable_threads = result.get("actionable_threads", []) or []
@@ -2659,6 +2659,24 @@ class InboxApp(App):
                 if warning:
                     errors.append(warning)
                 used_now_brief = True
+        except AttributeError:
+            pass
+        except Exception as exc:
+            errors.append(_format_request_error("Command center refresh", exc))
+
+        try:
+            if not used_now_brief:
+                result = self.client.inbox_now(limit=20)
+                if isinstance(result, dict):
+                    now_threads = result.get("now_items", []) or []
+                    actionable_threads = result.get("actionable_threads", []) or []
+                    waiting_threads = result.get("waiting_threads", []) or []
+                    if isinstance(result.get("index_health"), dict):
+                        index_health = result["index_health"]
+                    warning = _format_index_health_warning(index_health)
+                    if warning:
+                        errors.append(warning)
+                    used_now_brief = True
         except AttributeError:
             pass
         except Exception as exc:

--- a/inbox_client.py
+++ b/inbox_client.py
@@ -140,6 +140,16 @@ class InboxClient:
         r.raise_for_status()
         return r.json()
 
+    def command_center(self, *, workflow: str = "", account: str = "", limit: int = 10) -> dict:
+        params: dict[str, str | int] = {"limit": limit}
+        if workflow:
+            params["workflow"] = workflow
+        if account:
+            params["account"] = account
+        r = self._client.get("/inbox/command-center", params=params)
+        r.raise_for_status()
+        return r.json()
+
     # ── Messages ─────────────────────────────────────────────────────────
 
     def messages(

--- a/inbox_client.py
+++ b/inbox_client.py
@@ -158,10 +158,13 @@ class InboxClient:
         conv_id: str,
         thread_id: str = "",
         limit: int = 50,
+        account: str = "",
     ) -> list[dict]:
         params: dict = {"limit": limit}
         if thread_id:
             params["thread_id"] = thread_id
+        if account:
+            params["account"] = account
         r = self._client.get(f"/messages/{source}/{conv_id}", params=params)
         r.raise_for_status()
         return r.json()
@@ -223,6 +226,46 @@ class InboxClient:
         r.raise_for_status()
         return r.json()
 
+    def gmail_thread(
+        self,
+        message_id: str,
+        thread_id: str = "",
+        account: str = "",
+        limit: int = 50,
+    ) -> list[dict]:
+        return self.messages(
+            "gmail",
+            message_id,
+            thread_id=thread_id,
+            account=account,
+            limit=limit,
+        )
+
+    def gmail_search(
+        self,
+        q: str = "",
+        limit: int = 20,
+        label: str = "",
+        account: str = "",
+        from_filter: str = "",
+        subject_filter: str = "",
+        after: str = "",
+        before: str = "",
+    ) -> list[dict]:
+        params = {
+            "q": q,
+            "limit": limit,
+            "label": label,
+            "account": account,
+            "from_filter": from_filter,
+            "subject_filter": subject_filter,
+            "after": after,
+            "before": before,
+        }
+        r = self._client.get("/gmail/search", params=params)
+        r.raise_for_status()
+        return r.json()
+
     def gmail_compose(self, to: str, subject: str, body: str, account: str = "") -> bool:
         r = self._client.post(
             "/messages/compose",
@@ -230,6 +273,27 @@ class InboxClient:
         )
         r.raise_for_status()
         return r.json().get("ok", False)
+
+    def gmail_create_draft(
+        self,
+        to: str,
+        subject: str,
+        body: str,
+        account: str = "",
+        thread_id: str = "",
+    ) -> dict:
+        r = self._client.post(
+            "/messages/gmail/drafts",
+            json={
+                "to": to,
+                "subject": subject,
+                "body": body,
+                "account": account,
+                "thread_id": thread_id,
+            },
+        )
+        r.raise_for_status()
+        return r.json()
 
     def gmail_conversations_by_label(
         self, label: str = "INBOX", limit: int = 50, account: str = ""

--- a/inbox_server.py
+++ b/inbox_server.py
@@ -699,6 +699,24 @@ class InboxNowOut(BaseModel):
     workflow_counts: dict[str, int]
 
 
+class DailyBriefSectionOut(BaseModel):
+    key: str
+    title: str
+    threads: list[GmailThreadSummaryOut]
+
+
+class DailyBriefOut(BaseModel):
+    read_model: str = "daily_brief"
+    read_only: bool = True
+    raw_provider_fetch: bool = False
+    write_actions: list[str] = []
+    index_health: IndexHealthOut
+    reasons: list[str]
+    sections: list[DailyBriefSectionOut]
+    source_refs: list[dict[str, str]]
+    workflow_counts: dict[str, int]
+
+
 class WorkflowFolderRequest(BaseModel):
     workflow: str
     name: str = ""
@@ -3598,6 +3616,23 @@ def _thread_matches_inbox_now_filters(
     return not (account and thread.owning_account != account)
 
 
+def _brief_threads(
+    view: str, limit: int, workflow: str, account: str
+) -> list[GmailThreadSummaryOut]:
+    threads = [_indexed_thread_to_summary(row) for row in _index_view_rows(view, limit)]
+    return [
+        thread for thread in threads if _thread_matches_inbox_now_filters(thread, workflow, account)
+    ][:limit]
+
+
+def _brief_section(
+    key: str,
+    title: str,
+    threads: list[GmailThreadSummaryOut],
+) -> DailyBriefSectionOut:
+    return DailyBriefSectionOut(key=key, title=title, threads=threads)
+
+
 def _inbox_now_health_reasons(index_health: IndexHealthOut) -> list[str]:
     if index_health.healthy and not index_health.stale:
         return []
@@ -4641,6 +4676,41 @@ async def get_inbox_now(workflow: str = "", account: str = "", limit: int = 20):
         commitments=commitments[:limit],
         source_refs=source_refs,
         workflow_counts=needs_action.workflow_counts,
+    )
+
+
+@app.get("/inbox/daily-brief", response_model=DailyBriefOut)
+async def get_daily_brief(workflow: str = "", account: str = "", limit: int = 10):
+    """Index-only daily brief for agent-safe read paths."""
+    index_health = _build_index_health(state.index_store.list_sync_states())
+    section_specs = [
+        ("actionable", "Needs reply or review"),
+        ("waiting-on", "Waiting loops"),
+        ("recent", "Recent changes"),
+    ]
+
+    source_refs: list[dict[str, str]] = []
+    workflow_counts: dict[str, int] = {}
+    sections: list[DailyBriefSectionOut] = []
+
+    for key, title in section_specs:
+        threads = _brief_threads(key, limit, workflow, account)
+        sections.append(_brief_section(key, title, threads))
+        for thread in threads:
+            if thread.workflow:
+                workflow_counts[thread.workflow] = workflow_counts.get(thread.workflow, 0) + 1
+            _append_source_ref(source_refs, _thread_ref(thread, _thread_reason(thread)))
+
+    reasons = _inbox_now_health_reasons(index_health)
+    if all(not section.threads for section in sections):
+        reasons.append("daily_brief_empty")
+
+    return DailyBriefOut(
+        index_health=index_health,
+        reasons=reasons,
+        sections=sections,
+        source_refs=source_refs,
+        workflow_counts=workflow_counts,
     )
 
 

--- a/inbox_server.py
+++ b/inbox_server.py
@@ -18,7 +18,7 @@ from typing import Any
 from fastapi import FastAPI, File, HTTPException, Request, UploadFile, status
 from fastapi.responses import JSONResponse
 from loguru import logger
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict, Field
 
 import ambient_notes
 import egress_audit
@@ -65,7 +65,7 @@ from gmail_triage import (
 from memory_store import MemoryStore
 from message_index_store import MessageIndexStore
 from message_sync import bootstrap as index_bootstrap_sync
-from message_sync import incremental as index_incremental_sync
+from message_sync import incremental_without_imessage as index_incremental_sync
 from scheduler import SchedulerStore
 from services import (
     IMSG_DB,
@@ -140,6 +140,7 @@ from services import (
     gmail_compose_send,
     gmail_contacts,
     gmail_contacts_by_label,
+    gmail_create_draft,
     gmail_create_filter,
     gmail_delete,
     gmail_filter_audit,
@@ -246,19 +247,26 @@ GOOGLE_SERVICE_SET = tuple[
 
 
 class ConversationOut(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
     id: str
+    message_id: str = ""
     name: str
     source: str
     snippet: str
+    subject: str = ""
     unread: int
     last_ts: str
+    timestamp: str = ""
     guid: str = ""
     is_group: bool = False
     members: list[str] = []
     reply_to: str = ""
+    from_: str = Field(default="", alias="from")
     thread_id: str = ""
     message_id_header: str = ""
     gmail_account: str = ""
+    account: str = ""
 
 
 class MessageOut(BaseModel):
@@ -810,6 +818,10 @@ class ComposeRequest(BaseModel):
     account: str = ""
 
 
+class GmailDraftRequest(ComposeRequest):
+    thread_id: str = ""
+
+
 class GmailReplyRequest(BaseModel):
     msg_id: str
     body: str
@@ -976,20 +988,26 @@ def _empty_google_services() -> GOOGLE_SERVICE_SET:
 
 
 def _contact_to_out(c: Contact) -> ConversationOut:
+    ts = c.last_ts.isoformat()
     return ConversationOut(
         id=c.id,
+        message_id=c.id,
         name=c.name,
         source=c.source,
         snippet=c.snippet,
+        subject=c.snippet if c.source == "gmail" else "",
         unread=c.unread,
-        last_ts=c.last_ts.isoformat(),
+        last_ts=ts,
+        timestamp=ts,
         guid=c.guid,
         is_group=c.is_group,
         members=c.members,
         reply_to=c.reply_to,
+        from_=c.reply_to or c.name,
         thread_id=c.thread_id,
         message_id_header=c.message_id_header,
         gmail_account=c.gmail_account,
+        account=c.gmail_account,
     )
 
 
@@ -1918,7 +1936,9 @@ async def _fetch_conversations(source: str, limit: int, account: str = "") -> li
     fetch_tasks: list[asyncio.Task[list[Contact]]] = []
 
     if source in ("all", "imessage"):
-        fetch_tasks.append(asyncio.create_task(asyncio.to_thread(imsg_contacts, limit=limit)))
+        fetch_tasks.append(
+            asyncio.create_task(asyncio.to_thread(_indexed_imessage_contacts, limit))
+        )
 
     if source in ("all", "gmail"):
         targets = (
@@ -1932,10 +1952,30 @@ async def _fetch_conversations(source: str, limit: int, account: str = "") -> li
             )
 
     if source in ("all", "linkedin"):
-        fetch_tasks.append(asyncio.create_task(asyncio.to_thread(linkedin_contacts, limit=limit)))
+        fetch_tasks.append(
+            asyncio.create_task(
+                asyncio.to_thread(
+                    _indexed_contacts,
+                    "linkedin",
+                    "brave-cdp",
+                    limit,
+                    lambda: linkedin_contacts(limit=limit),
+                )
+            )
+        )
 
     if source in ("all", "whatsapp"):
-        fetch_tasks.append(asyncio.create_task(asyncio.to_thread(whatsapp_contacts, limit=limit)))
+        fetch_tasks.append(
+            asyncio.create_task(
+                asyncio.to_thread(
+                    _indexed_contacts,
+                    "whatsapp",
+                    "brave-cdp",
+                    limit,
+                    lambda: whatsapp_contacts(limit=limit),
+                )
+            )
+        )
 
     if not fetch_tasks:
         return []
@@ -1946,6 +1986,129 @@ async def _fetch_conversations(source: str, limit: int, account: str = "") -> li
         results.extend(contacts)
 
     return results
+
+
+def _indexed_imessage_contacts(limit: int = 30) -> list[Contact]:
+    """Return iMessage conversations from the local index.
+
+    Reading ~/Library/Messages/chat.db from the long-running launchd server is brittle under
+    macOS TCC. The index is the normal read model for agent-facing views; the sync job owns
+    raw database access.
+    """
+    if os.environ.get("INBOX_TEST_MODE"):
+        return imsg_contacts(limit=limit)
+    rows = state.index_store.list_threads(
+        limit=limit,
+        source="imessage",
+        account="local",
+        sort_mode="recent",
+    )
+    if not rows:
+        return imsg_contacts(limit=limit)
+    contacts: list[Contact] = []
+    for row in rows:
+        participants = row.get("participants_json")
+        members = [str(value) for value in participants] if isinstance(participants, list) else []
+        name = ", ".join(members[:3]) if members else str(row.get("latest_sender") or "iMessage")
+        if len(members) > 3:
+            name += f" +{len(members) - 3}"
+        last_ts = _parse_index_timestamp(str(row.get("latest_item_at") or ""))
+        contacts.append(
+            Contact(
+                id=str(row.get("thread_id") or ""),
+                name=name,
+                source="imessage",
+                snippet=str(row.get("latest_snippet") or "")[:60],
+                unread=int(row.get("unread_count") or 0),
+                last_ts=last_ts,
+                guid=str(row.get("thread_id") or ""),
+                is_group=len(members) > 1,
+                members=members,
+            )
+        )
+    return contacts
+
+
+def _indexed_contacts(
+    source: str,
+    account: str,
+    limit: int,
+    fallback: Callable[[], list[Contact]],
+) -> list[Contact]:
+    if os.environ.get("INBOX_TEST_MODE"):
+        return fallback()
+    rows = state.index_store.list_threads(
+        limit=limit,
+        source=source,
+        account=account,
+        sort_mode="recent",
+    )
+    if not rows:
+        return fallback()
+    contacts: list[Contact] = []
+    for row in rows:
+        participants = row.get("participants_json")
+        members = [str(value) for value in participants] if isinstance(participants, list) else []
+        thread_id = str(row.get("thread_id") or "")
+        subject = str(row.get("latest_subject") or "")
+        latest_sender = str(row.get("latest_sender") or "")
+        name = subject or (", ".join(members[:3]) if members else latest_sender) or thread_id
+        if len(members) > 3 and not subject:
+            name += f" +{len(members) - 3}"
+        contacts.append(
+            Contact(
+                id=thread_id,
+                name=name,
+                source=source,
+                snippet=str(row.get("latest_snippet") or "")[:60],
+                unread=int(row.get("unread_count") or 0),
+                last_ts=_parse_index_timestamp(str(row.get("latest_item_at") or "")),
+                guid=thread_id,
+                is_group=len(members) > 1,
+                members=members,
+                reply_to=account,
+                thread_id=thread_id,
+            )
+        )
+    return contacts
+
+
+def _indexed_thread_messages(
+    source: str,
+    account: str,
+    thread_id: str,
+    limit: int,
+) -> list[Msg]:
+    if os.environ.get("INBOX_TEST_MODE"):
+        return []
+    rows = state.index_store.list_thread_items(
+        source=source,
+        account=account,
+        thread_id=thread_id,
+        limit=limit,
+    )
+    return [
+        Msg(
+            sender=str(row.get("sender") or ""),
+            body=str(row.get("body_text") or row.get("snippet") or ""),
+            ts=_parse_index_timestamp(str(row.get("created_at") or "")),
+            is_me=str(row.get("sender") or "") == "Me",
+            source=source,
+            message_id=str(row.get("external_id") or ""),
+        )
+        for row in rows
+        if str(row.get("body_text") or row.get("snippet") or "")
+    ]
+
+
+def _parse_index_timestamp(value: str) -> datetime:
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return datetime.now(UTC)
+    if parsed.tzinfo is None:
+        return parsed
+    return parsed.astimezone(UTC).replace(tzinfo=None)
 
 
 @app.get("/conversations", response_model=list[ConversationOut])
@@ -1974,24 +2137,34 @@ async def list_conversations(source: str = "all", limit: int = 50, account: str 
 
 
 @app.get("/messages/{source}/{conv_id}", response_model=list[MessageOut])
-async def get_messages(source: str, conv_id: str, thread_id: str = "", limit: int = 50):
+async def get_messages(
+    source: str,
+    conv_id: str,
+    thread_id: str = "",
+    limit: int = 50,
+    account: str = "",
+):
     if source == "imessage":
-        msgs = await asyncio.to_thread(imsg_thread, conv_id, limit=limit)
+        msgs = await asyncio.to_thread(
+            _indexed_thread_messages, "imessage", "local", conv_id, limit
+        )
+        if not msgs:
+            msgs = await asyncio.to_thread(imsg_thread, conv_id, limit=limit)
     elif source == "gmail":
-        # Find the right service
+        _, svc = _get_gmail_service_for_message(conv_id, thread_id, account)
         contact = state.conv_cache.get(_cache_key("gmail", conv_id))
-        if contact and contact.gmail_account in state.gmail_services:
-            svc = state.gmail_services[contact.gmail_account]
-        elif state.gmail_services:
-            svc = next(iter(state.gmail_services.values()))
-        else:
-            raise HTTPException(404, "No Gmail service available")
         tid = thread_id or (contact.thread_id if contact else "")
         msgs = await asyncio.to_thread(gmail_thread, svc, conv_id, tid)
     elif source == "linkedin":
-        msgs = await asyncio.to_thread(linkedin_thread, conv_id, limit=limit)
+        acct = account or "brave-cdp"
+        msgs = await asyncio.to_thread(_indexed_thread_messages, "linkedin", acct, conv_id, limit)
+        if not msgs:
+            msgs = await asyncio.to_thread(linkedin_thread, conv_id, limit=limit)
     elif source == "whatsapp":
-        msgs = await asyncio.to_thread(whatsapp_thread, conv_id, limit=limit)
+        acct = account or "brave-cdp"
+        msgs = await asyncio.to_thread(_indexed_thread_messages, "whatsapp", acct, conv_id, limit)
+        if not msgs:
+            msgs = await asyncio.to_thread(whatsapp_thread, conv_id, limit=limit)
     else:
         raise HTTPException(400, f"Unknown source: {source}")
 
@@ -2143,6 +2316,26 @@ async def compose_email(req: ComposeRequest):
     _, svc = _get_gmail_service_for_account(req.account)
     ok = await asyncio.to_thread(gmail_compose_send, svc, req.to, req.subject, req.body)
     return {"ok": ok}
+
+
+@app.post("/messages/gmail/drafts")
+async def create_gmail_draft(req: GmailDraftRequest):
+    acct, svc = _get_gmail_service_for_account(req.account)
+    draft = await asyncio.to_thread(
+        gmail_create_draft,
+        svc,
+        req.to,
+        req.subject,
+        req.body,
+        req.thread_id,
+    )
+    return {
+        "ok": bool(draft),
+        "account": acct,
+        "draft_id": draft.get("id", ""),
+        "message_id": draft.get("message_id", ""),
+        "thread_id": draft.get("thread_id", req.thread_id),
+    }
 
 
 @app.post("/messages/gmail/reply")
@@ -2988,24 +3181,15 @@ async def get_whatsapp_messages_full(chat_name: str, max_loads: int = 10, limit:
 
 @app.get("/whatsapp/contacts", response_model=list[ConversationOut])
 async def list_whatsapp_contacts(limit: int = 20):
-    """List WhatsApp conversations via macOS Accessibility API (read-only).
-    WhatsApp app must be running. Returns empty list if app is not running or AX tree inspection fails.
-    """
-    contacts = await asyncio.to_thread(whatsapp_contacts, limit)
-    return [
-        ConversationOut(
-            id=c.id,
-            name=c.name,
-            source=c.source,
-            snippet=c.snippet,
-            unread=c.unread,
-            last_ts=c.last_ts.isoformat(),
-            guid=c.guid,
-            is_group=c.is_group,
-            members=c.members,
-        )
-        for c in contacts
-    ]
+    """List WhatsApp conversations from the normalized index, with source fallback."""
+    contacts = await asyncio.to_thread(
+        _indexed_contacts,
+        "whatsapp",
+        "brave-cdp",
+        limit,
+        lambda: whatsapp_contacts(limit=limit),
+    )
+    return [_contact_to_out(c) for c in contacts]
 
 
 @app.get("/whatsapp/messages/{chat_name}", response_model=list[MessageOut])
@@ -3015,19 +3199,12 @@ async def get_whatsapp_messages(chat_name: str, limit: int = 50):
     limit: Max messages to return.
     Placeholder: returns empty list pending AX tree navigation implementation.
     """
-    messages = await asyncio.to_thread(whatsapp_thread, chat_name, limit)
-    return [
-        MessageOut(
-            sender=m.sender,
-            body=m.body,
-            ts=m.ts.isoformat(),
-            is_me=m.is_me,
-            source=m.source,
-            attachments=m.attachments,
-            message_id=m.message_id,
-        )
-        for m in messages
-    ]
+    messages = await asyncio.to_thread(
+        _indexed_thread_messages, "whatsapp", "brave-cdp", chat_name, limit
+    )
+    if not messages:
+        messages = await asyncio.to_thread(whatsapp_thread, chat_name, limit)
+    return [_msg_to_out(m) for m in messages]
 
 
 # ── LinkedIn ─────────────────────────────────────────────────────────────────
@@ -3035,13 +3212,23 @@ async def get_whatsapp_messages(chat_name: str, limit: int = 50):
 
 @app.get("/linkedin/contacts", response_model=list[ConversationOut])
 async def list_linkedin_contacts(limit: int = 20):
-    contacts = await asyncio.to_thread(linkedin_contacts, limit)
+    contacts = await asyncio.to_thread(
+        _indexed_contacts,
+        "linkedin",
+        "brave-cdp",
+        limit,
+        lambda: linkedin_contacts(limit),
+    )
     return [_contact_to_out(c) for c in contacts]
 
 
 @app.get("/linkedin/messages/{thread_id}", response_model=list[MessageOut])
 async def get_linkedin_messages(thread_id: str, limit: int = 50):
-    messages = await asyncio.to_thread(linkedin_thread, thread_id, limit)
+    messages = await asyncio.to_thread(
+        _indexed_thread_messages, "linkedin", "brave-cdp", thread_id, limit
+    )
+    if not messages:
+        messages = await asyncio.to_thread(linkedin_thread, thread_id, limit)
     return [_msg_to_out(m) for m in messages]
 
 

--- a/inbox_server.py
+++ b/inbox_server.py
@@ -3755,6 +3755,18 @@ def _queue(
     return CommandCenterQueueOut(key=key, title=title, items=items[:limit])
 
 
+def _dedupe_threads(threads: list[GmailThreadSummaryOut]) -> list[GmailThreadSummaryOut]:
+    seen: set[tuple[str, str, str]] = set()
+    deduped: list[GmailThreadSummaryOut] = []
+    for thread in threads:
+        key = (_thread_source(thread), thread.owning_account, thread.thread_id)
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(thread)
+    return deduped
+
+
 def _dedupe_queue_items(items: list[dict[str, Any]]) -> list[dict[str, Any]]:
     seen: set[tuple[str, str, str]] = set()
     deduped: list[dict[str, Any]] = []
@@ -4905,20 +4917,23 @@ async def get_daily_brief(workflow: str = "", account: str = "", limit: int = 10
 async def get_command_center(workflow: str = "", account: str = "", limit: int = 10):
     """One read-only control-plane payload for agents and the TUI."""
     index_health = _build_index_health(state.index_store.list_sync_states())
-    inbox_now = await get_inbox_now(workflow=workflow, account=account, limit=limit)
 
-    source_refs = list(inbox_now.source_refs)
-    actionable_threads = [
-        thread
-        for thread in inbox_now.actionable_threads
-        if _thread_matches_inbox_now_filters(thread, workflow, account)
-    ][:limit]
-    waiting_threads = [
-        thread
-        for thread in inbox_now.waiting_threads
-        if _thread_matches_inbox_now_filters(thread, workflow, account)
-    ][:limit]
+    source_refs: list[dict[str, str]] = []
+    actionable_threads = _brief_threads("actionable", limit, workflow, account)
+    waiting_threads = _brief_threads("waiting-on", limit, workflow, account)
     recent_threads = _brief_threads("recent", limit * 2, workflow, account)
+    now_items = [_thread_now_item(thread, _thread_reason(thread)) for thread in actionable_threads][
+        :limit
+    ]
+    commitments = [_thread_now_item(thread, _thread_reason(thread)) for thread in waiting_threads][
+        :limit
+    ]
+
+    workflow_counts: dict[str, int] = {}
+    for thread in _dedupe_threads(actionable_threads + waiting_threads + recent_threads):
+        if thread.workflow:
+            workflow_counts[thread.workflow] = workflow_counts.get(thread.workflow, 0) + 1
+        _append_source_ref(source_refs, _thread_ref(thread, _thread_reason(thread)))
 
     people_items = _dedupe_queue_items(
         [
@@ -4943,14 +4958,13 @@ async def get_command_center(workflow: str = "", account: str = "", limit: int =
         ]
         + [
             item
-            for item in inbox_now.now_items
+            for item in now_items
             if item.get("workflow") in {"legal", "medical", "finance", "personal_admin"}
-            or item.get("now_kind") in {"task", "event"}
         ]
     )
     waiting_items = _dedupe_queue_items(
         [_thread_queue_item(thread, _thread_reason(thread)) for thread in waiting_threads]
-        + list(inbox_now.commitments)
+        + commitments
     )
 
     approval_queue: list[dict[str, Any]] = []
@@ -4966,9 +4980,7 @@ async def get_command_center(workflow: str = "", account: str = "", limit: int =
                 ref=_thread_ref(thread, reason),
             )
         )
-    for item in inbox_now.now_items:
-        if item.get("now_kind") in {"task", "event"}:
-            continue
+    for item in now_items:
         actionability = str(item.get("actionability") or "")
         if actionability in {"reply", "review"}:
             approval_queue.append(
@@ -4982,7 +4994,7 @@ async def get_command_center(workflow: str = "", account: str = "", limit: int =
             )
 
     queues = [
-        _queue("now", "Now", list(inbox_now.now_items), limit),
+        _queue("now", "Now", now_items, limit),
         _queue("people", "People To Reply / Track", people_items, limit),
         _queue("jobs", "Jobs / Outreach", job_items, limit),
         _queue("admin", "Admin / Legal / Medical / Finance", admin_items, limit),
@@ -4997,14 +5009,14 @@ async def get_command_center(workflow: str = "", account: str = "", limit: int =
     return CommandCenterOut(
         index_health=index_health,
         source_coverage=_source_coverage(index_health),
-        now_items=list(inbox_now.now_items)[:limit],
+        now_items=now_items,
         actionable_threads=actionable_threads,
         waiting_threads=waiting_threads,
         queues=queues,
         approval_queue=approval_queue[:limit],
         agent_work=_agent_work_items(),
         source_refs=source_refs,
-        workflow_counts=inbox_now.workflow_counts,
+        workflow_counts=workflow_counts,
         reasons=reasons,
     )
 

--- a/inbox_server.py
+++ b/inbox_server.py
@@ -230,6 +230,7 @@ _gmail_triage_reexports = (
 PORT = 9849
 AUTH_TOKEN_ENV = "INBOX_SERVER_TOKEN"  # nosec: B105 - env var name, not a hardcoded credential
 AUTH_BYPASS_ENV = "INBOX_SERVER_ALLOW_UNAUTHENTICATED"
+SCHEDULER_AUTOSTART_ENV = "INBOX_START_SCHEDULER"
 AUTH_BYPASS_TRUE_VALUES = frozenset({"1", "true", "yes", "on"})
 GOOGLE_SERVICE_SET = tuple[
     dict[str, object],
@@ -715,6 +716,44 @@ class DailyBriefOut(BaseModel):
     sections: list[DailyBriefSectionOut]
     source_refs: list[dict[str, str]]
     workflow_counts: dict[str, int]
+
+
+class SourceCoverageOut(BaseModel):
+    source: str
+    account: str = ""
+    item_count: int = 0
+    thread_count: int = 0
+    latest_item_at: str = ""
+    last_success_at: str = ""
+    last_success_age_seconds: int | None = None
+    status: str = "unknown"
+    healthy: bool = False
+    stale: bool = True
+    reasons: list[str] = []
+
+
+class CommandCenterQueueOut(BaseModel):
+    key: str
+    title: str
+    items: list[dict[str, Any]]
+
+
+class CommandCenterOut(BaseModel):
+    read_model: str = "command_center"
+    read_only: bool = True
+    raw_provider_fetch: bool = False
+    write_actions: list[str] = []
+    index_health: IndexHealthOut
+    source_coverage: list[SourceCoverageOut]
+    now_items: list[dict[str, Any]]
+    actionable_threads: list[GmailThreadSummaryOut]
+    waiting_threads: list[GmailThreadSummaryOut]
+    queues: list[CommandCenterQueueOut]
+    approval_queue: list[dict[str, Any]]
+    agent_work: list[dict[str, Any]]
+    source_refs: list[dict[str, str]]
+    workflow_counts: dict[str, int]
+    reasons: list[str]
 
 
 class WorkflowFolderRequest(BaseModel):
@@ -1363,8 +1402,13 @@ def make_lifespan(runtime: InboxServerRuntime | None = None):
                 logger.warning("Ambient autostart failed (non-fatal)")
 
         scheduler_task = None
-        if runtime.start_scheduler:
+        start_scheduler = runtime.start_scheduler and os.environ.get(
+            SCHEDULER_AUTOSTART_ENV, "1"
+        ).strip().lower() not in ("0", "false", "no")
+        if start_scheduler:
             scheduler_task = asyncio.create_task(_scheduler_loop())
+        else:
+            print(f"[scheduler] Autostart disabled by {SCHEDULER_AUTOSTART_ENV}=0")
 
         try:
             yield
@@ -3641,6 +3685,149 @@ def _inbox_now_health_reasons(index_health: IndexHealthOut) -> list[str]:
     return ["index:unhealthy"]
 
 
+def _source_coverage(index_health: IndexHealthOut) -> list[SourceCoverageOut]:
+    source_rows = state.index_store.source_counts()
+    sync_by_key = {(sync.source, sync.account): sync for sync in index_health.sync_states}
+    keys = set(sync_by_key) | {
+        (str(row.get("source") or ""), str(row.get("account") or "")) for row in source_rows
+    }
+    indexed_by_key = {
+        (str(row.get("source") or ""), str(row.get("account") or "")): row for row in source_rows
+    }
+    for source in ("gmail", "imessage", "whatsapp", "linkedin"):
+        if not any(key[0] == source for key in keys):
+            keys.add((source, ""))
+
+    coverage: list[SourceCoverageOut] = []
+    for source, account in sorted(keys):
+        row = indexed_by_key.get((source, account), {})
+        sync = sync_by_key.get((source, account))
+        reasons = list(sync.reasons) if sync is not None else []
+        if sync is None:
+            reasons.append("no_sync_state")
+        coverage.append(
+            SourceCoverageOut(
+                source=source,
+                account=account,
+                item_count=int(row.get("item_count") or 0),
+                thread_count=int(row.get("thread_count") or 0),
+                latest_item_at=str(row.get("latest_item_at") or ""),
+                last_success_at=sync.last_success_at if sync is not None else "",
+                last_success_age_seconds=(
+                    sync.last_success_age_seconds if sync is not None else None
+                ),
+                status=sync.status if sync is not None else "missing",
+                healthy=bool(sync and sync.healthy),
+                stale=True if sync is None else sync.stale,
+                reasons=reasons,
+            )
+        )
+    return coverage
+
+
+def _thread_queue_item(thread: GmailThreadSummaryOut, reason: str) -> dict[str, Any]:
+    return {
+        "kind": "thread",
+        "title": thread.subject or thread.summary or "Untitled thread",
+        "source": _thread_source(thread),
+        "reason": reason,
+        "ref": _thread_ref(thread, reason),
+        "thread_id": thread.thread_id,
+        "owning_account": thread.owning_account,
+        "participants": thread.participants,
+        "last_message_at": thread.last_message_at,
+        "summary": thread.summary,
+        "brief": thread.brief,
+        "needs_reply": thread.needs_reply,
+        "workflow": thread.workflow,
+        "rank": thread.rank,
+        "action_items": thread.action_items,
+        "rich_data": thread.rich_data,
+    }
+
+
+def _queue(
+    key: str,
+    title: str,
+    items: list[dict[str, Any]],
+    limit: int,
+) -> CommandCenterQueueOut:
+    return CommandCenterQueueOut(key=key, title=title, items=items[:limit])
+
+
+def _dedupe_queue_items(items: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    seen: set[tuple[str, str, str]] = set()
+    deduped: list[dict[str, Any]] = []
+    for item in items:
+        ref = item.get("ref") if isinstance(item.get("ref"), dict) else {}
+        key = (
+            str(item.get("kind") or ""),
+            str(ref.get("source") or item.get("source") or ""),
+            str(
+                ref.get("thread_id")
+                or ref.get("id")
+                or item.get("thread_id")
+                or item.get("id")
+                or ""
+            ),
+        )
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(item)
+    return deduped
+
+
+def _approval_candidate(
+    *,
+    source: str,
+    action: str,
+    title: str,
+    reason: str,
+    ref: dict[str, str],
+    sensitivity: str = "external_communication",
+) -> dict[str, Any]:
+    return {
+        "kind": "approval_candidate",
+        "source": source,
+        "action": action,
+        "title": title,
+        "reason": reason,
+        "sensitivity": sensitivity,
+        "status": "needs_human_approval",
+        "ref": ref,
+    }
+
+
+def _agent_work_items() -> list[dict[str, Any]]:
+    return [
+        {
+            "lane": "capture",
+            "title": "Refresh source coverage and index freshness",
+            "permission": "read_only",
+            "next_action": "Run incremental sync or scanner only when explicitly requested.",
+        },
+        {
+            "lane": "triage",
+            "title": "Classify today, jobs, admin, people, and waiting queues",
+            "permission": "read_only",
+            "next_action": "Draft queue changes; do not archive, label, send, or submit.",
+        },
+        {
+            "lane": "draft",
+            "title": "Prepare replies, job packets, and admin scripts",
+            "permission": "draft_only",
+            "next_action": "Place exact outbound actions in approval_queue.",
+        },
+        {
+            "lane": "browser_exec",
+            "title": "Operate portals and messaging UIs after approval",
+            "permission": "approval_required",
+            "next_action": "Stop before submit/send unless the exact action is approved.",
+        },
+    ]
+
+
 def _preflight_google_write(
     kind: str,
     account: str = "",
@@ -4711,6 +4898,114 @@ async def get_daily_brief(workflow: str = "", account: str = "", limit: int = 10
         sections=sections,
         source_refs=source_refs,
         workflow_counts=workflow_counts,
+    )
+
+
+@app.get("/inbox/command-center", response_model=CommandCenterOut)
+async def get_command_center(workflow: str = "", account: str = "", limit: int = 10):
+    """One read-only control-plane payload for agents and the TUI."""
+    index_health = _build_index_health(state.index_store.list_sync_states())
+    inbox_now = await get_inbox_now(workflow=workflow, account=account, limit=limit)
+
+    source_refs = list(inbox_now.source_refs)
+    actionable_threads = [
+        thread
+        for thread in inbox_now.actionable_threads
+        if _thread_matches_inbox_now_filters(thread, workflow, account)
+    ][:limit]
+    waiting_threads = [
+        thread
+        for thread in inbox_now.waiting_threads
+        if _thread_matches_inbox_now_filters(thread, workflow, account)
+    ][:limit]
+    recent_threads = _brief_threads("recent", limit * 2, workflow, account)
+
+    people_items = _dedupe_queue_items(
+        [
+            _thread_queue_item(thread, _thread_reason(thread))
+            for thread in actionable_threads + waiting_threads + recent_threads
+            if thread.participants
+        ]
+    )
+    job_items = _dedupe_queue_items(
+        [
+            _thread_queue_item(thread, _thread_reason(thread))
+            for thread in actionable_threads + waiting_threads + recent_threads
+            if thread.workflow == "job_hunt"
+            or "opportunity" in " ".join([thread.subject, thread.summary, thread.brief]).lower()
+        ]
+    )
+    admin_items = _dedupe_queue_items(
+        [
+            _thread_queue_item(thread, _thread_reason(thread))
+            for thread in actionable_threads + waiting_threads + recent_threads
+            if thread.workflow in {"legal", "medical", "finance", "personal_admin"}
+        ]
+        + [
+            item
+            for item in inbox_now.now_items
+            if item.get("workflow") in {"legal", "medical", "finance", "personal_admin"}
+            or item.get("now_kind") in {"task", "event"}
+        ]
+    )
+    waiting_items = _dedupe_queue_items(
+        [_thread_queue_item(thread, _thread_reason(thread)) for thread in waiting_threads]
+        + list(inbox_now.commitments)
+    )
+
+    approval_queue: list[dict[str, Any]] = []
+    for thread in actionable_threads:
+        reason = _thread_reason(thread)
+        action = "send_reply" if thread.needs_reply else "review_external_action"
+        approval_queue.append(
+            _approval_candidate(
+                source=_thread_source(thread),
+                action=action,
+                title=thread.subject or thread.summary or "Thread action",
+                reason=reason,
+                ref=_thread_ref(thread, reason),
+            )
+        )
+    for item in inbox_now.now_items:
+        if item.get("now_kind") in {"task", "event"}:
+            continue
+        actionability = str(item.get("actionability") or "")
+        if actionability in {"reply", "review"}:
+            approval_queue.append(
+                _approval_candidate(
+                    source=str(item.get("source") or ""),
+                    action="approve_prepared_action",
+                    title=str(item.get("title") or "Action item"),
+                    reason=str(item.get("reason") or actionability),
+                    ref=item.get("ref") if isinstance(item.get("ref"), dict) else {},
+                )
+            )
+
+    queues = [
+        _queue("now", "Now", list(inbox_now.now_items), limit),
+        _queue("people", "People To Reply / Track", people_items, limit),
+        _queue("jobs", "Jobs / Outreach", job_items, limit),
+        _queue("admin", "Admin / Legal / Medical / Finance", admin_items, limit),
+        _queue("waiting", "Waiting On", waiting_items, limit),
+        _queue("approval", "Approval Queue", approval_queue, limit),
+    ]
+
+    reasons = _inbox_now_health_reasons(index_health)
+    if not any(queue.items for queue in queues):
+        reasons.append("command_center_empty")
+
+    return CommandCenterOut(
+        index_health=index_health,
+        source_coverage=_source_coverage(index_health),
+        now_items=list(inbox_now.now_items)[:limit],
+        actionable_threads=actionable_threads,
+        waiting_threads=waiting_threads,
+        queues=queues,
+        approval_queue=approval_queue[:limit],
+        agent_work=_agent_work_items(),
+        source_refs=source_refs,
+        workflow_counts=inbox_now.workflow_counts,
+        reasons=reasons,
     )
 
 

--- a/message_index_store.py
+++ b/message_index_store.py
@@ -593,6 +593,8 @@ class MessageIndexStore:
         self,
         *,
         limit: int = 25,
+        source: str | None = None,
+        account: str | None = None,
         actionable_only: bool = False,
         newest_only: bool = False,
         actions: tuple[str, ...] | None = None,
@@ -603,6 +605,12 @@ class MessageIndexStore:
     ) -> list[dict[str, object]]:
         predicates: list[str] = []
         params: list[object] = []
+        if source:
+            predicates.append("source = ?")
+            params.append(source)
+        if account:
+            predicates.append("account = ?")
+            params.append(account)
         if actionable_only:
             predicates.append("actionability IN ('reply', 'review', 'track')")
         if newest_only:
@@ -637,6 +645,38 @@ class MessageIndexStore:
             _q = f"SELECT * FROM threads {where_clause} ORDER BY {order_clause} LIMIT ?"  # nosec B608
             rows = conn.execute(_q, params).fetchall()
         return [self._thread_row_to_dict(row) for row in rows]
+
+    def list_thread_items(
+        self,
+        *,
+        source: str,
+        account: str,
+        thread_id: str,
+        limit: int = 50,
+    ) -> list[dict[str, object]]:
+        with self._connect() as conn:
+            rows = conn.execute(
+                """
+                SELECT *
+                FROM (
+                    SELECT *
+                    FROM items
+                    WHERE source = ?
+                      AND account = ?
+                      AND thread_id = ?
+                      AND is_deleted = 0
+                    ORDER BY created_at DESC, id DESC
+                    LIMIT ?
+                )
+                ORDER BY created_at ASC, id ASC
+                """,
+                (source, account, thread_id, limit),
+            ).fetchall()
+        return [self._item_row_to_dict(row) for row in rows]
+
+    def _item_row_to_dict(self, row: sqlite3.Row) -> dict[str, object]:
+        keys = list(row.keys())
+        return {key: (_json_loads(row[key]) if key.endswith("_json") else row[key]) for key in keys}
 
     def _thread_row_to_dict(self, row: sqlite3.Row) -> dict[str, object]:
         keys = list(row.keys())

--- a/message_index_store.py
+++ b/message_index_store.py
@@ -361,6 +361,33 @@ class MessageIndexStore:
             threads = conn.execute("SELECT COUNT(*) FROM threads").fetchone()[0]
         return {"items": int(items), "threads": int(threads)}
 
+    def source_counts(self) -> list[dict[str, object]]:
+        with self._connect() as conn:
+            rows = conn.execute(
+                """
+                SELECT
+                    source,
+                    account,
+                    COUNT(*) AS item_count,
+                    COUNT(DISTINCT thread_id) AS thread_count,
+                    MAX(created_at) AS latest_item_at
+                FROM items
+                WHERE is_deleted = 0
+                GROUP BY source, account
+                ORDER BY source, account
+                """
+            ).fetchall()
+        return [
+            {
+                "source": str(row["source"]),
+                "account": str(row["account"]),
+                "item_count": int(row["item_count"] or 0),
+                "thread_count": int(row["thread_count"] or 0),
+                "latest_item_at": str(row["latest_item_at"] or ""),
+            }
+            for row in rows
+        ]
+
     def _sync_row_to_dict(self, row: sqlite3.Row) -> dict[str, Any]:
         data = dict(row)
         data["metadata"] = _json_loads(str(data.get("metadata_json") or "{}"))

--- a/message_sync.py
+++ b/message_sync.py
@@ -29,7 +29,18 @@ IMESSAGE_PROGRESS_EVERY = 250
 WHATSAPP_PROGRESS_EVERY = 250
 LINKEDIN_PROGRESS_EVERY = 250
 _ATTACHMENT_TEXT = "(attachment)"
-CLI_MODES = ("bootstrap", "incremental", "rebuild", "summary")
+CLI_MODES = (
+    "bootstrap",
+    "incremental",
+    "incremental-no-imessage",
+    "imessage-incremental",
+    "whatsapp-bootstrap",
+    "whatsapp-incremental",
+    "linkedin-bootstrap",
+    "linkedin-incremental",
+    "rebuild",
+    "summary",
+)
 SyncScope = tuple[str, str]
 
 
@@ -909,6 +920,68 @@ def incremental(store: MessageIndexStore) -> dict[str, dict[str, int]]:
     return result
 
 
+def incremental_without_imessage(store: MessageIndexStore) -> dict[str, dict[str, int]]:
+    gmail_stats = _sync_or_record_error(store, "gmail", "all", sync_gmail_incremental)
+    whatsapp_stats = _sync_or_record_error(
+        store, "whatsapp", "brave-cdp", sync_whatsapp_incremental
+    )
+    linkedin_stats = _sync_or_record_error(
+        store, "linkedin", "brave-cdp", sync_linkedin_incremental
+    )
+    result = {
+        "gmail": gmail_stats,
+        "imessage": {},
+        "whatsapp": whatsapp_stats,
+        "linkedin": linkedin_stats,
+    }
+    rebuild_changed_threads(
+        store,
+        _changed_scopes("gmail", gmail_stats)
+        | _changed_scopes("whatsapp", whatsapp_stats)
+        | _changed_scopes("linkedin", linkedin_stats),
+    )
+    return result
+
+
+def imessage_incremental(store: MessageIndexStore) -> dict[str, dict[str, int]]:
+    imessage_stats = _sync_or_record_error(store, "imessage", "local", sync_imessage_incremental)
+    result = {"imessage": imessage_stats}
+    rebuild_changed_threads(store, _changed_scopes("imessage", imessage_stats))
+    return result
+
+
+def whatsapp_bootstrap(store: MessageIndexStore) -> dict[str, dict[str, int]]:
+    whatsapp_stats = _sync_or_record_error(store, "whatsapp", "brave-cdp", sync_whatsapp_bootstrap)
+    result = {"whatsapp": whatsapp_stats}
+    rebuild_changed_threads(store, _changed_scopes("whatsapp", whatsapp_stats))
+    return result
+
+
+def whatsapp_incremental(store: MessageIndexStore) -> dict[str, dict[str, int]]:
+    whatsapp_stats = _sync_or_record_error(
+        store, "whatsapp", "brave-cdp", sync_whatsapp_incremental
+    )
+    result = {"whatsapp": whatsapp_stats}
+    rebuild_changed_threads(store, _changed_scopes("whatsapp", whatsapp_stats))
+    return result
+
+
+def linkedin_bootstrap(store: MessageIndexStore) -> dict[str, dict[str, int]]:
+    linkedin_stats = _sync_or_record_error(store, "linkedin", "brave-cdp", sync_linkedin_bootstrap)
+    result = {"linkedin": linkedin_stats}
+    rebuild_changed_threads(store, _changed_scopes("linkedin", linkedin_stats))
+    return result
+
+
+def linkedin_incremental(store: MessageIndexStore) -> dict[str, dict[str, int]]:
+    linkedin_stats = _sync_or_record_error(
+        store, "linkedin", "brave-cdp", sync_linkedin_incremental
+    )
+    result = {"linkedin": linkedin_stats}
+    rebuild_changed_threads(store, _changed_scopes("linkedin", linkedin_stats))
+    return result
+
+
 def print_summary(store: MessageIndexStore, limit: int) -> None:
     for row in store.list_threads(limit=limit, actionable_only=True, newest_only=True):
         print(
@@ -956,6 +1029,18 @@ def main(argv: list[str] | None = None) -> int:
         print(bootstrap(store))
     elif args.mode == "incremental":
         print(incremental(store))
+    elif args.mode == "incremental-no-imessage":
+        print(incremental_without_imessage(store))
+    elif args.mode == "imessage-incremental":
+        print(imessage_incremental(store))
+    elif args.mode == "whatsapp-bootstrap":
+        print(whatsapp_bootstrap(store))
+    elif args.mode == "whatsapp-incremental":
+        print(whatsapp_incremental(store))
+    elif args.mode == "linkedin-bootstrap":
+        print(linkedin_bootstrap(store))
+    elif args.mode == "linkedin-incremental":
+        print(linkedin_incremental(store))
     elif args.mode == "rebuild":
         print({"threads": rebuild_all_threads(store)})
     else:

--- a/message_sync.py
+++ b/message_sync.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 import hashlib
+import os
 import sqlite3
 import sys
 from datetime import UTC, datetime
@@ -30,6 +31,10 @@ LINKEDIN_PROGRESS_EVERY = 250
 _ATTACHMENT_TEXT = "(attachment)"
 CLI_MODES = ("bootstrap", "incremental", "rebuild", "summary")
 SyncScope = tuple[str, str]
+
+
+def _env_truthy(name: str) -> bool:
+    return os.environ.get(name, "").strip().lower() in {"1", "true", "yes", "on"}
 
 
 def _iso_from_ms(value: int | str | None) -> str:
@@ -105,6 +110,19 @@ def _json(value: object) -> str:
     import json
 
     return json.dumps(value, sort_keys=True)
+
+
+def _sync_or_record_error(
+    store: MessageIndexStore,
+    source: str,
+    account: str,
+    sync_func: Any,
+) -> dict[str, int]:
+    try:
+        return sync_func(store)
+    except Exception as exc:
+        store.record_sync_error(source=source, account=account, error=str(exc))
+        return {}
 
 
 def _fetch_gmail_full_message(service: Any, message_id: str) -> dict[str, Any]:
@@ -519,6 +537,20 @@ def _sync_imessage_from_local_store(store: MessageIndexStore, *, full_sync: bool
     checkpoint_rowid = int(state.get("checkpoint_value", "0") or 0)
     highest_rowid = checkpoint_rowid
     count = 0
+    if _env_truthy("INBOX_DISABLE_IMESSAGE_SYNC"):
+        store.set_sync_state(
+            source="imessage",
+            account="local",
+            checkpoint_type="rowid",
+            checkpoint_value=str(checkpoint_rowid),
+            status="idle",
+            metadata={
+                "disabled": True,
+                "reason": "INBOX_DISABLE_IMESSAGE_SYNC",
+                "messages_processed": 0,
+            },
+        )
+        return {"local": 0}
     store.mark_sync_started(
         source="imessage",
         account="local",
@@ -832,10 +864,10 @@ def rebuild_all_threads(store: MessageIndexStore) -> int:
 
 
 def bootstrap(store: MessageIndexStore) -> dict[str, dict[str, int]]:
-    gmail_stats = sync_gmail_bootstrap(store)
-    imessage_stats = sync_imessage_bootstrap(store)
-    whatsapp_stats = sync_whatsapp_bootstrap(store)
-    linkedin_stats = sync_linkedin_bootstrap(store)
+    gmail_stats = _sync_or_record_error(store, "gmail", "all", sync_gmail_bootstrap)
+    imessage_stats = _sync_or_record_error(store, "imessage", "local", sync_imessage_bootstrap)
+    whatsapp_stats = _sync_or_record_error(store, "whatsapp", "brave-cdp", sync_whatsapp_bootstrap)
+    linkedin_stats = _sync_or_record_error(store, "linkedin", "brave-cdp", sync_linkedin_bootstrap)
     result = {
         "gmail": gmail_stats,
         "imessage": imessage_stats,
@@ -853,10 +885,14 @@ def bootstrap(store: MessageIndexStore) -> dict[str, dict[str, int]]:
 
 
 def incremental(store: MessageIndexStore) -> dict[str, dict[str, int]]:
-    gmail_stats = sync_gmail_incremental(store)
-    imessage_stats = sync_imessage_incremental(store)
-    whatsapp_stats = sync_whatsapp_incremental(store)
-    linkedin_stats = sync_linkedin_incremental(store)
+    gmail_stats = _sync_or_record_error(store, "gmail", "all", sync_gmail_incremental)
+    imessage_stats = _sync_or_record_error(store, "imessage", "local", sync_imessage_incremental)
+    whatsapp_stats = _sync_or_record_error(
+        store, "whatsapp", "brave-cdp", sync_whatsapp_incremental
+    )
+    linkedin_stats = _sync_or_record_error(
+        store, "linkedin", "brave-cdp", sync_linkedin_incremental
+    )
     result = {
         "gmail": gmail_stats,
         "imessage": imessage_stats,

--- a/ops_brain.py
+++ b/ops_brain.py
@@ -1,0 +1,137 @@
+"""Provider-agnostic bridge for the local ops kernel."""
+
+from __future__ import annotations
+
+import csv
+import json
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+DEFAULT_OPS_KERNEL = Path(
+    "/Users/jwalinshah/Documents/Codex/2026-05-26/can-we-please-do-a-review/ops_kernel"
+)
+
+
+@dataclass(frozen=True)
+class OpsQueueSpec:
+    id: str
+    label: str
+    filename: str
+    priority: str = ""
+    limit: int = 12
+
+
+OPS_QUEUE_SPECS: tuple[OpsQueueSpec, ...] = (
+    OpsQueueSpec("resume", "Resume evidence", "resume_interview_evidence_queue.csv", limit=8),
+    OpsQueueSpec("connector_gmail", "Live Gmail evidence", "connector_gmail_evidence_queue.csv"),
+    OpsQueueSpec("gmail", "Gmail export queue", "gmail_reconciliation_queue.csv", "P0"),
+    OpsQueueSpec("linkedin", "LinkedIn queue", "linkedin_reconciliation_queue.csv", "P0"),
+    OpsQueueSpec("drive", "Drive evidence", "drive_evidence_queue.csv", "P0"),
+    OpsQueueSpec(
+        "data_exports",
+        "Data export processing",
+        "data_export_processing_queue.csv",
+        "P0",
+    ),
+    OpsQueueSpec(
+        "apple_admin",
+        "Apple admin evidence",
+        "../parsed/apple/admin_reconciliation_queue.csv",
+        "P0",
+        limit=8,
+    ),
+)
+
+
+def ops_kernel_path() -> Path:
+    """Return the configured local ops kernel path."""
+    return Path(os.environ.get("OPS_KERNEL_PATH", str(DEFAULT_OPS_KERNEL))).expanduser()
+
+
+def _read_csv(path: Path) -> list[dict[str, str]]:
+    if not path.exists():
+        return []
+    with path.open(newline="", encoding="utf-8") as f:
+        return list(csv.DictReader(f))
+
+
+def _title_for_row(row: dict[str, str]) -> str:
+    for key in (
+        "subject",
+        "subject_or_sender",
+        "people",
+        "project_id",
+        "name",
+        "evidence_role",
+        "bucket",
+    ):
+        if row.get(key):
+            return str(row[key])
+    return "Untitled"
+
+
+def _summary_for_row(row: dict[str, str]) -> str:
+    for key in (
+        "candidate_action",
+        "resume_use",
+        "evidence_role",
+        "matched_terms",
+        "evidence_excerpt",
+        "snippet",
+    ):
+        if row.get(key):
+            return str(row[key])
+    return ""
+
+
+def load_ops_queue_rows(kernel: Path | None = None) -> list[dict[str, str]]:
+    """Load a compact read-only work queue from local ops reconciliation CSVs."""
+    root = kernel or ops_kernel_path()
+    reconciliation = root / "reconciliation"
+    rows: list[dict[str, str]] = []
+
+    for spec in OPS_QUEUE_SPECS:
+        source_rows = _read_csv(reconciliation / spec.filename)
+        if spec.priority:
+            source_rows = [row for row in source_rows if row.get("priority") == spec.priority]
+        for index, row in enumerate(source_rows[: spec.limit], start=1):
+            normalized = dict(row)
+            normalized["_ops_queue_id"] = spec.id
+            normalized["_ops_queue_label"] = spec.label
+            normalized["_ops_source_file"] = spec.filename
+            normalized["_ops_rank"] = str(index)
+            normalized["_ops_title"] = _title_for_row(row)
+            normalized["_ops_summary"] = _summary_for_row(row)
+            rows.append(normalized)
+    return rows
+
+
+def ops_brain_status(kernel: Path | None = None) -> dict[str, str | int]:
+    """Summarize the local brain/control-plane state for CLIs, TUIs, and agents."""
+    root = kernel or ops_kernel_path()
+    rows = load_ops_queue_rows(root)
+    queues = len({row.get("_ops_queue_id", "") for row in rows})
+    p0 = sum(1 for row in rows if row.get("priority") == "P0")
+    return {
+        "kernel": str(root),
+        "queue_rows": len(rows),
+        "queues": queues,
+        "p0_rows": p0,
+        "interface": "local-cli-tui",
+        "provider_policy": "providers are replaceable adapters; local ledgers are truth",
+    }
+
+
+def main() -> None:
+    """Print the local ops brain packet for shell scripts and provider adapters."""
+    root = ops_kernel_path()
+    packet = {
+        "status": ops_brain_status(root),
+        "rows": load_ops_queue_rows(root),
+    }
+    print(json.dumps(packet, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/build_data_export_processing_queue.py
+++ b/scripts/build_data_export_processing_queue.py
@@ -1,0 +1,244 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import zipfile
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+DEFAULT_EXPORT_ROOT = Path("/Users/jwalinshah/Documents/inbox-data-exports")
+DEFAULT_CONTEXT_ROOT = Path(
+    "/Users/jwalinshah/Documents/Codex/2026-05-26/can-we-please-do-a-review"
+)
+DEFAULT_OPS_KERNEL = DEFAULT_CONTEXT_ROOT / "ops_kernel"
+
+
+@dataclass(frozen=True)
+class ProviderRule:
+    priority: str
+    action: str
+    rationale: str
+
+
+PROVIDER_RULES = {
+    "apple": ProviderRule(
+        "P0",
+        "extract_contacts_notes_calendars_reminders_bookmarks",
+        "High-value local context for people, todos, appointments, and notes.",
+    ),
+    "linkedin": ProviderRule(
+        "P0",
+        "reconcile_parsed_threads_connections_warm_intros",
+        "Highest leverage for job search, recruiting, and warm intro graph.",
+    ),
+    "openai": ProviderRule(
+        "P1",
+        "extract_project_and_interview_context",
+        "Useful for reconstructing project history and resume/interview evidence.",
+    ),
+    "x": ProviderRule(
+        "P2",
+        "extract_relationship_or_outreach_history_if_needed",
+        "Lower priority unless a target person/company history matters.",
+    ),
+    "spotify": ProviderRule(
+        "P3",
+        "defer_unless_personal_analytics_needed",
+        "Low direct value for job/admin command center work.",
+    ),
+}
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Build local processing manifest and reconciliation queue for personal data exports."
+    )
+    parser.add_argument("--export-root", default=str(DEFAULT_EXPORT_ROOT))
+    parser.add_argument("--context-root", default=str(DEFAULT_CONTEXT_ROOT))
+    parser.add_argument("--ops-kernel", default=str(DEFAULT_OPS_KERNEL))
+    return parser.parse_args()
+
+
+def zip_summary(path: Path) -> dict[str, Any]:
+    with zipfile.ZipFile(path) as archive:
+        names = archive.namelist()
+        samples = [name for name in names[:12]]
+    return {
+        "zip_entry_count": len(names),
+        "sample_entries": " | ".join(samples),
+    }
+
+
+def provider_for_path(path: Path, export_root: Path) -> str:
+    try:
+        return path.relative_to(export_root).parts[0]
+    except (ValueError, IndexError):
+        return "unknown"
+
+
+def local_archive_rows(export_root: Path) -> list[dict[str, str]]:
+    rows: list[dict[str, str]] = []
+    for path in sorted(export_root.rglob("*.zip")):
+        provider = provider_for_path(path, export_root)
+        rule = PROVIDER_RULES.get(
+            provider,
+            ProviderRule("P2", "inspect_and_classify", "No provider-specific rule yet."),
+        )
+        try:
+            summary = zip_summary(path)
+            status = "zip_verified"
+            error = ""
+        except zipfile.BadZipFile as exc:
+            summary = {"zip_entry_count": 0, "sample_entries": ""}
+            status = "zip_error"
+            error = str(exc)
+        rows.append(
+            {
+                "source_type": "local_zip",
+                "provider": provider,
+                "priority": rule.priority,
+                "status": status,
+                "path_or_id": str(path),
+                "name": path.name,
+                "size_bytes": str(path.stat().st_size),
+                "modified": datetime.fromtimestamp(path.stat().st_mtime).isoformat(
+                    timespec="seconds"
+                ),
+                "zip_entry_count": str(summary["zip_entry_count"]),
+                "sample_entries": str(summary["sample_entries"]),
+                "recommended_action": rule.action,
+                "rationale": rule.rationale,
+                "error": error,
+            }
+        )
+    return rows
+
+
+def drive_rows(context_root: Path) -> list[dict[str, str]]:
+    manifest = context_root / "drive_export_manifest.csv"
+    if not manifest.exists():
+        return []
+    rows: list[dict[str, str]] = []
+    with manifest.open(newline="", encoding="utf-8") as f:
+        for item in csv.DictReader(f):
+            terms = (item.get("matched_terms") or "").lower()
+            name = item.get("name") or ""
+            if any(term in terms for term in ("facebook", "meta")):
+                provider = "meta"
+                priority = "P0"
+                action = "download_or_parse_drive_resident_meta_export"
+                rationale = "Meta export appears already transferred to Drive."
+            elif "takeout" in terms or name.lower().startswith("takeout-"):
+                provider = "google_takeout"
+                priority = "P0"
+                action = "process_takeout_batch_selectively"
+                rationale = (
+                    "Google Takeout contains high-value Gmail/Drive/Contacts/Calendar context."
+                )
+            elif "archive" in terms:
+                provider = "drive_archive"
+                priority = "P1"
+                action = "inspect_drive_archive_candidate"
+                rationale = "Drive export-like artifact needs provider classification."
+            else:
+                continue
+            rows.append(
+                {
+                    "source_type": "drive_manifest",
+                    "provider": provider,
+                    "priority": priority,
+                    "status": "drive_resident_not_localized",
+                    "path_or_id": item.get("id") or "",
+                    "name": name,
+                    "size_bytes": item.get("size") or "",
+                    "modified": item.get("modified") or "",
+                    "zip_entry_count": "",
+                    "sample_entries": item.get("web_link") or "",
+                    "recommended_action": action,
+                    "rationale": rationale,
+                    "error": "",
+                }
+            )
+    return rows
+
+
+def write_csv(path: Path, rows: list[dict[str, str]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fieldnames = [
+        "source_type",
+        "provider",
+        "priority",
+        "status",
+        "path_or_id",
+        "name",
+        "size_bytes",
+        "modified",
+        "zip_entry_count",
+        "sample_entries",
+        "recommended_action",
+        "rationale",
+        "error",
+    ]
+    with path.open("w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def write_summary(path: Path, rows: list[dict[str, str]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    by_provider: dict[str, int] = {}
+    by_priority: dict[str, int] = {}
+    for row in rows:
+        by_provider[row["provider"]] = by_provider.get(row["provider"], 0) + 1
+        by_priority[row["priority"]] = by_priority.get(row["priority"], 0) + 1
+    path.write_text(
+        json.dumps(
+            {
+                "generated_at": datetime.now().isoformat(timespec="seconds"),
+                "row_count": len(rows),
+                "by_provider": by_provider,
+                "by_priority": by_priority,
+            },
+            indent=2,
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+
+
+def main() -> int:
+    args = parse_args()
+    export_root = Path(args.export_root).expanduser()
+    context_root = Path(args.context_root).expanduser()
+    ops_kernel = Path(args.ops_kernel).expanduser()
+    rows = local_archive_rows(export_root) + drive_rows(context_root)
+    rows.sort(key=lambda row: (row["priority"], row["provider"], row["name"]))
+
+    parsed_dir = ops_kernel / "parsed" / "data_exports"
+    reconciliation_dir = ops_kernel / "reconciliation"
+    write_csv(parsed_dir / "archive_manifest.csv", rows)
+    write_csv(reconciliation_dir / "data_export_processing_queue.csv", rows)
+    write_summary(parsed_dir / "summary.json", rows)
+
+    print(
+        json.dumps(
+            {
+                "archive_manifest": str(parsed_dir / "archive_manifest.csv"),
+                "processing_queue": str(reconciliation_dir / "data_export_processing_queue.csv"),
+                "summary": str(parsed_dir / "summary.json"),
+                "rows": len(rows),
+            },
+            indent=2,
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/import_wacli_to_openhuman.py
+++ b/scripts/import_wacli_to_openhuman.py
@@ -1,0 +1,257 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import sqlite3
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_SOURCE_DB = Path.home() / ".wacli" / "wacli.db"
+DEFAULT_DEST_DB = (
+    Path.home()
+    / ".openhuman"
+    / "users"
+    / "local"
+    / "workspace"
+    / "whatsapp_data"
+    / "whatsapp_data.db"
+)
+
+
+def init_dest_db(db_path: Path) -> None:
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    with sqlite3.connect(db_path) as conn:
+        conn.executescript(
+            """
+            PRAGMA journal_mode=WAL;
+            CREATE TABLE IF NOT EXISTS wa_chats (
+                account_id TEXT NOT NULL,
+                chat_id TEXT NOT NULL,
+                display_name TEXT NOT NULL DEFAULT '',
+                is_group INTEGER NOT NULL DEFAULT 0,
+                last_message_ts INTEGER NOT NULL DEFAULT 0,
+                message_count INTEGER NOT NULL DEFAULT 0,
+                updated_at INTEGER NOT NULL DEFAULT 0,
+                PRIMARY KEY (account_id, chat_id)
+            );
+            CREATE TABLE IF NOT EXISTS wa_messages (
+                account_id TEXT NOT NULL,
+                chat_id TEXT NOT NULL,
+                message_id TEXT NOT NULL,
+                sender TEXT NOT NULL DEFAULT '',
+                sender_jid TEXT,
+                from_me INTEGER NOT NULL DEFAULT 0,
+                body TEXT NOT NULL DEFAULT '',
+                timestamp INTEGER NOT NULL DEFAULT 0,
+                message_type TEXT,
+                source TEXT NOT NULL DEFAULT '',
+                ingested_at INTEGER NOT NULL DEFAULT 0,
+                PRIMARY KEY (account_id, chat_id, message_id)
+            );
+            CREATE INDEX IF NOT EXISTS idx_wa_msg_ts
+                ON wa_messages(account_id, chat_id, timestamp);
+            CREATE INDEX IF NOT EXISTS idx_wa_msg_body
+                ON wa_messages(account_id, body);
+            """
+        )
+
+
+def non_placeholder(value: object) -> str:
+    text = str(value or "").strip()
+    if text.lower() in {"", "(message)", "message"}:
+        return ""
+    return text
+
+
+def message_body(row: sqlite3.Row) -> str:
+    for key in ("text", "media_caption", "filename", "display_text"):
+        value = non_placeholder(row[key])
+        if value:
+            return value
+    return ""
+
+
+def message_type(row: sqlite3.Row) -> str:
+    media_type = non_placeholder(row["media_type"])
+    return media_type or "chat"
+
+
+def import_wacli(
+    source_db: Path,
+    dest_db: Path,
+    *,
+    account_id: str,
+    dry_run: bool,
+) -> dict[str, int]:
+    if not source_db.exists():
+        raise FileNotFoundError(f"wacli database not found: {source_db}")
+
+    init_dest_db(dest_db)
+    now = int(time.time())
+
+    source = sqlite3.connect(f"file:{source_db}?mode=ro", uri=True)
+    source.row_factory = sqlite3.Row
+    dest = sqlite3.connect(dest_db)
+    try:
+        chats = source.execute(
+            """
+            SELECT
+                c.jid,
+                c.kind,
+                COALESCE(NULLIF(c.name, ''), c.jid) AS display_name,
+                COALESCE(c.last_message_ts, 0) AS last_message_ts,
+                COALESCE(m.message_count, 0) AS message_count,
+                COALESCE(m.last_ts, 0) AS last_ts
+            FROM chats c
+            LEFT JOIN (
+                SELECT chat_jid, COUNT(*) AS message_count, MAX(ts) AS last_ts
+                FROM messages
+                GROUP BY chat_jid
+            ) m ON m.chat_jid = c.jid
+            ORDER BY c.jid
+            """
+        ).fetchall()
+        messages = source.execute(
+            """
+            SELECT
+                chat_jid,
+                chat_name,
+                msg_id,
+                sender_jid,
+                sender_name,
+                ts,
+                from_me,
+                text,
+                display_text,
+                media_type,
+                media_caption,
+                filename
+            FROM messages
+            ORDER BY chat_jid, ts, msg_id
+            """
+        ).fetchall()
+
+        text_messages = 0
+        if not dry_run:
+            for chat in chats:
+                last_ts = int(chat["last_ts"] or chat["last_message_ts"] or 0)
+                dest.execute(
+                    """
+                    INSERT INTO wa_chats (
+                        account_id, chat_id, display_name, is_group, last_message_ts,
+                        message_count, updated_at
+                    )
+                    VALUES (?, ?, ?, ?, ?, ?, ?)
+                    ON CONFLICT(account_id, chat_id) DO UPDATE SET
+                        display_name=excluded.display_name,
+                        is_group=excluded.is_group,
+                        last_message_ts=MAX(wa_chats.last_message_ts, excluded.last_message_ts),
+                        message_count=excluded.message_count,
+                        updated_at=excluded.updated_at
+                    """,
+                    (
+                        account_id,
+                        chat["jid"],
+                        chat["display_name"],
+                        1 if str(chat["kind"] or "") == "group" else 0,
+                        last_ts,
+                        int(chat["message_count"] or 0),
+                        now,
+                    ),
+                )
+
+            for row in messages:
+                body = message_body(row)
+                if body:
+                    text_messages += 1
+                sender = "Me" if int(row["from_me"] or 0) else non_placeholder(row["sender_name"])
+                if not sender:
+                    sender = non_placeholder(row["sender_jid"]) or non_placeholder(row["chat_name"])
+                dest.execute(
+                    """
+                    INSERT INTO wa_messages (
+                        account_id, chat_id, message_id, sender, sender_jid, from_me,
+                        body, timestamp, message_type, source, ingested_at
+                    )
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    ON CONFLICT(account_id, chat_id, message_id) DO UPDATE SET
+                        sender=excluded.sender,
+                        sender_jid=excluded.sender_jid,
+                        from_me=excluded.from_me,
+                        body=CASE
+                            WHEN excluded.body != '' THEN excluded.body
+                            ELSE wa_messages.body
+                        END,
+                        timestamp=excluded.timestamp,
+                        message_type=excluded.message_type,
+                        source=excluded.source,
+                        ingested_at=excluded.ingested_at
+                    """,
+                    (
+                        account_id,
+                        row["chat_jid"],
+                        row["msg_id"],
+                        sender,
+                        non_placeholder(row["sender_jid"]) or None,
+                        int(row["from_me"] or 0),
+                        body,
+                        int(row["ts"] or 0),
+                        message_type(row),
+                        "wacli",
+                        now,
+                    ),
+                )
+            dest.commit()
+        else:
+            text_messages = sum(1 for row in messages if message_body(row))
+
+        return {
+            "source_chats": len(chats),
+            "source_messages": len(messages),
+            "source_text_messages": text_messages,
+            "dry_run": 1 if dry_run else 0,
+        }
+    finally:
+        source.close()
+        dest.close()
+
+
+def sync_index() -> None:
+    subprocess.run(
+        ["uv", "run", "python", "message_sync.py", "whatsapp-bootstrap"],
+        cwd=ROOT,
+        check=True,
+    )
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Import the local wacli WhatsApp archive into OpenHuman's WhatsApp store."
+    )
+    parser.add_argument("--source-db", type=Path, default=DEFAULT_SOURCE_DB)
+    parser.add_argument("--dest-db", type=Path, default=DEFAULT_DEST_DB)
+    parser.add_argument("--account-id", default="wacli")
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--sync-index", action="store_true")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    stats = import_wacli(
+        args.source_db.expanduser(),
+        args.dest_db.expanduser(),
+        account_id=args.account_id,
+        dry_run=args.dry_run,
+    )
+    print(stats)
+    if args.sync_index and not args.dry_run:
+        sync_index()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/inbox_refresh_doctor.sh
+++ b/scripts/inbox_refresh_doctor.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+ENV_FILE="${INBOX_WORKFLOWS_ENV:-$HOME/.config/raycast/inbox-workflows.env}"
+if [[ -f "$ENV_FILE" ]]; then
+  set -a
+  # shellcheck source=/dev/null
+  . "$ENV_FILE"
+  set +a
+fi
+
+INBOX_SERVER_URL="${INBOX_SERVER_URL:-http://127.0.0.1:9849}"
+INBOX_SERVER_TOKEN="${INBOX_SERVER_TOKEN:-}"
+AUTH_ARGS=()
+if [[ -n "$INBOX_SERVER_TOKEN" ]]; then
+  AUTH_ARGS=(-H "Authorization: Bearer $INBOX_SERVER_TOKEN")
+fi
+
+section() {
+  printf '\n== %s ==\n' "$1"
+}
+
+section "LaunchAgents"
+launchctl list | rg 'com\.jwalin\.inbox' || true
+
+section "Backend Health"
+curl -fsS --max-time 5 "$INBOX_SERVER_URL/health" || true
+printf '\n'
+
+section "Index Health"
+curl -fsS --max-time 10 "${AUTH_ARGS[@]}" "$INBOX_SERVER_URL/index/health" || true
+printf '\n'
+
+section "Index Status"
+curl -fsS --max-time 10 "${AUTH_ARGS[@]}" "$INBOX_SERVER_URL/index/status" || true
+printf '\n'
+
+section "Local Index Counts"
+sqlite3 -header -column "$ROOT_DIR/.inbox_index.sqlite3" \
+  "select source, count(*) as items, max(created_at) as latest from items group by source order by items desc;" \
+  2>/dev/null || true
+
+section "Sync State"
+sqlite3 -header -column "$ROOT_DIR/.inbox_index.sqlite3" \
+  "select source, account, status, last_success_at, substr(last_error,1,120) as last_error from sync_state order by source, account;" \
+  2>/dev/null || true
+
+section "WhatsApp Store"
+WA_DB="${INBOX_OPENHUMAN_WHATSAPP_DB:-$HOME/.openhuman/users/local/workspace/whatsapp_data/whatsapp_data.db}"
+sqlite3 -header -column "$WA_DB" \
+  "select 'chats' as metric, count(*) as value from wa_chats union all select 'messages', count(*) from wa_messages union all select 'nonempty_bodies', count(*) from wa_messages where length(coalesce(body,'')) > 0;" \
+  2>/dev/null || true
+
+section "LinkedIn Store"
+LI_DB="${INBOX_OPENHUMAN_LINKEDIN_DB:-$HOME/.openhuman/users/local/workspace/linkedin_data/linkedin_data.db}"
+sqlite3 -header -column "$LI_DB" \
+  "select 'threads' as metric, count(*) as value from li_threads union all select 'messages', count(*) from li_messages;" \
+  2>/dev/null || true
+
+section "Recent Refresh Errors"
+tail -n 40 "$HOME/Library/Logs/inbox/index-sync.err.log" 2>/dev/null || true
+tail -n 40 "$HOME/Library/Logs/inbox/whatsapp-scan.err.log" 2>/dev/null || true

--- a/scripts/linkedin_web_scanner.py
+++ b/scripts/linkedin_web_scanner.py
@@ -57,9 +57,11 @@ SCAN_JS = r"""
     return match ? decodeURIComponent(match[1]) : "";
   };
   const activeHeader =
-    document.querySelector("main h2") ||
-    document.querySelector("main header h2") ||
+    document.querySelector(".msg-entity-lockup__entity-title") ||
+    document.querySelector(".msg-thread__link-to-profile") ||
     document.querySelector('[data-test-conversation-header]') ||
+    document.querySelector("main header h2:not(.visually-hidden)") ||
+    document.querySelector("main h2:not(.visually-hidden)") ||
     document.querySelector("main header");
   const activeName = (textOf(activeHeader).split("\n")[0] || "").trim();
   const activeProfileUrl = normalizeUrl(
@@ -202,20 +204,91 @@ def evaluate_scan(conn: CdpConnection) -> dict[str, Any]:
     return value
 
 
-def click_visible_thread(conn: CdpConnection, index: int) -> None:
+def click_visible_thread(conn: CdpConnection, index: int) -> bool:
     expression = f"""
     (() => {{
       const rows = Array.from(document.querySelectorAll(
         'a[href*="/messaging/thread/"], li.msg-conversation-listitem, [data-control-name="conversation_card"]'
-      )).filter((row) => (row.innerText || '').trim());
+      )).filter((row) => {{
+        const rect = row.getBoundingClientRect();
+        return (row.innerText || '').trim() &&
+          rect.width > 20 &&
+          rect.height > 20 &&
+          rect.bottom > 120 &&
+          rect.top < window.innerHeight - 20;
+      }});
       const row = rows[{index}];
       if (!row) return false;
-      row.scrollIntoView({{block: 'center'}});
-      row.click();
-      return true;
+      const rect = row.getBoundingClientRect();
+      return {{
+        x: Math.round(rect.left + Math.min(rect.width * 0.5, 180)),
+        y: Math.round(rect.top + rect.height * 0.5),
+      }};
     }})()
     """
-    conn.command("Runtime.evaluate", {"expression": expression, "returnByValue": True})
+    result = conn.command("Runtime.evaluate", {"expression": expression, "returnByValue": True})
+    point = result.get("result", {}).get("value")
+    if not isinstance(point, dict):
+        return False
+    x = int(point.get("x") or 0)
+    y = int(point.get("y") or 0)
+    if not x or not y:
+        return False
+    conn.command("Input.dispatchMouseEvent", {"type": "mouseMoved", "x": x, "y": y})
+    conn.command(
+        "Input.dispatchMouseEvent",
+        {"type": "mousePressed", "x": x, "y": y, "button": "left", "clickCount": 1},
+    )
+    conn.command(
+        "Input.dispatchMouseEvent",
+        {"type": "mouseReleased", "x": x, "y": y, "button": "left", "clickCount": 1},
+    )
+    return True
+
+
+def scroll_thread_list(conn: CdpConnection) -> bool:
+    expression = """
+    (() => {
+      const candidates = [
+        document.querySelector('.msg-conversations-container__conversations-list'),
+        document.querySelector('.msg-conversations-container__conversations-list-container'),
+        document.querySelector('ul.msg-conversations-container__conversations-list'),
+        document.querySelector('[aria-label*="conversation" i]'),
+      ].filter(Boolean);
+      const scrollers = candidates.concat(Array.from(document.querySelectorAll('aside, section, div')))
+        .filter((el) => el && el.scrollHeight > el.clientHeight + 100)
+        .sort((a, b) => (b.scrollHeight - b.clientHeight) - (a.scrollHeight - a.clientHeight));
+      const el = scrollers[0];
+      if (!el) return false;
+      const before = el.scrollTop;
+      el.scrollTop = Math.min(el.scrollHeight, el.scrollTop + Math.max(el.clientHeight * 0.85, 500));
+      return el.scrollTop !== before;
+    })()
+    """
+    result = conn.command("Runtime.evaluate", {"expression": expression, "returnByValue": True})
+    return bool(result.get("result", {}).get("value"))
+
+
+def scroll_active_thread(conn: CdpConnection) -> bool:
+    expression = """
+    (() => {
+      const candidates = [
+        document.querySelector('.msg-s-message-list--scroll-buffer'),
+        document.querySelector('.msg-s-message-list'),
+        document.querySelector('main .scrollable'),
+      ].filter(Boolean);
+      const scrollers = candidates.concat(Array.from(document.querySelectorAll('main div')))
+        .filter((el) => el && el.scrollHeight > el.clientHeight + 80)
+        .sort((a, b) => (b.scrollHeight - b.clientHeight) - (a.scrollHeight - a.clientHeight));
+      const el = scrollers[0];
+      if (!el) return false;
+      const before = el.scrollTop;
+      el.scrollTop = Math.max(0, el.scrollTop - Math.max(el.clientHeight * 0.9, 500));
+      return el.scrollTop !== before;
+    })()
+    """
+    result = conn.command("Runtime.evaluate", {"expression": expression, "returnByValue": True})
+    return bool(result.get("result", {}).get("value"))
 
 
 def init_db(db_path: Path) -> None:
@@ -443,6 +516,18 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--click-visible", type=int, default=0, help="Click and scan the first N visible threads."
     )
+    parser.add_argument(
+        "--scroll-pages",
+        type=int,
+        default=0,
+        help="Scroll the LinkedIn conversation list and scan/click visible threads after each page.",
+    )
+    parser.add_argument(
+        "--scroll-active-pages",
+        type=int,
+        default=0,
+        help="Scroll the currently open conversation upward and scan after each page.",
+    )
     parser.add_argument("--delay", type=float, default=1.0, help="Delay after clicking a thread.")
     parser.add_argument(
         "--sync-index", action="store_true", help="Also ingest the DB into .inbox_index.sqlite3."
@@ -464,14 +549,33 @@ def main() -> int:
     page = find_linkedin_page(args.cdp_url)
     db_path = Path(args.db).expanduser() if args.db else default_db_path()
     total = {"threads": 0, "messages": 0}
+    clicked = 0
+    scrolls = 0
     with CdpConnection(page.websocket_url, timeout=10) as conn:
         first_scan = evaluate_scan(conn)
         if first_scan.get("loginRequired"):
             print("LinkedIn is not signed in. Sign in through Brave, then rerun.")
             return 2
         scans = [first_scan]
-        for index in range(max(args.click_visible, 0)):
-            click_visible_thread(conn, index)
+        for _active_page in range(max(args.scroll_active_pages, 0)):
+            if not scroll_active_thread(conn):
+                break
+            time.sleep(max(args.delay, 0))
+            scans.append(evaluate_scan(conn))
+        for _page in range(max(args.scroll_pages, 0) + 1):
+            for index in range(max(args.click_visible, 0)):
+                if click_visible_thread(conn, index):
+                    clicked += 1
+                    time.sleep(max(args.delay, 0))
+                    for _active_page in range(max(args.scroll_active_pages, 0)):
+                        if not scroll_active_thread(conn):
+                            break
+                        time.sleep(max(args.delay, 0))
+                        scans.append(evaluate_scan(conn))
+                    scans.append(evaluate_scan(conn))
+            if not scroll_thread_list(conn):
+                break
+            scrolls += 1
             time.sleep(max(args.delay, 0))
             scans.append(evaluate_scan(conn))
         for scan in scans:
@@ -480,7 +584,12 @@ def main() -> int:
             total["messages"] += written["messages"]
     if args.sync_index:
         run_index_sync()
-    print(json.dumps({"db_path": str(db_path), **total}, sort_keys=True))
+    print(
+        json.dumps(
+            {"clicked": clicked, "db_path": str(db_path), "scrolls": scrolls, **total},
+            sort_keys=True,
+        )
+    )
     return 0
 
 

--- a/scripts/messaging_coverage.py
+++ b/scripts/messaging_coverage.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+INDEX_DB = ROOT / ".inbox_index.sqlite3"
+WA_DB = (
+    Path.home()
+    / ".openhuman"
+    / "users"
+    / "local"
+    / "workspace"
+    / "whatsapp_data"
+    / "whatsapp_data.db"
+)
+LI_DB = (
+    Path.home()
+    / ".openhuman"
+    / "users"
+    / "local"
+    / "workspace"
+    / "linkedin_data"
+    / "linkedin_data.db"
+)
+
+
+def scalar(db: Path, sql: str) -> int:
+    if not db.exists():
+        return 0
+    with sqlite3.connect(db) as conn:
+        value = conn.execute(sql).fetchone()[0]
+    return int(value or 0)
+
+
+def main() -> int:
+    report = {
+        "whatsapp": {
+            "source_chats": scalar(WA_DB, "SELECT COUNT(*) FROM wa_chats"),
+            "source_chats_with_message_rows": scalar(
+                WA_DB, "SELECT COUNT(DISTINCT chat_id) FROM wa_messages"
+            ),
+            "source_chats_with_text": scalar(
+                WA_DB,
+                "SELECT COUNT(DISTINCT chat_id) FROM wa_messages WHERE LENGTH(TRIM(body)) > 0",
+            ),
+            "source_text_messages": scalar(
+                WA_DB, "SELECT COUNT(*) FROM wa_messages WHERE LENGTH(TRIM(body)) > 0"
+            ),
+            "indexed_threads": scalar(
+                INDEX_DB, "SELECT COUNT(*) FROM threads WHERE source = 'whatsapp'"
+            ),
+            "indexed_messages": scalar(
+                INDEX_DB, "SELECT COUNT(*) FROM items WHERE source = 'whatsapp'"
+            ),
+        },
+        "linkedin": {
+            "source_threads": scalar(LI_DB, "SELECT COUNT(*) FROM li_threads"),
+            "source_threads_with_message_rows": scalar(
+                LI_DB, "SELECT COUNT(DISTINCT thread_id) FROM li_messages"
+            ),
+            "source_threads_with_text": scalar(
+                LI_DB,
+                "SELECT COUNT(DISTINCT thread_id) FROM li_messages WHERE LENGTH(TRIM(body)) > 0",
+            ),
+            "source_text_messages": scalar(
+                LI_DB, "SELECT COUNT(*) FROM li_messages WHERE LENGTH(TRIM(body)) > 0"
+            ),
+            "indexed_threads": scalar(
+                INDEX_DB, "SELECT COUNT(*) FROM threads WHERE source = 'linkedin'"
+            ),
+            "indexed_messages": scalar(
+                INDEX_DB, "SELECT COUNT(*) FROM items WHERE source = 'linkedin'"
+            ),
+        },
+    }
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/open_ready_export_links.py
+++ b/scripts/open_ready_export_links.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import argparse
 import base64
+import html
 import json
 import os
 import re
@@ -20,7 +21,7 @@ from typing import Any
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
-from request_personal_data_exports import DEFAULT_STATE_PATH, load_state, save_state
+from request_personal_data_exports import DEFAULT_STATE_PATH, better_status, load_state, save_state
 from track_data_export_browser import CdpConnection
 
 from services import google_auth_all
@@ -35,20 +36,58 @@ class ReadyProvider:
     account: str
     query: str
     preferred_domains: tuple[str, ...]
+    required_url_terms: tuple[str, ...] = ()
 
 
 READY_PROVIDERS: tuple[ReadyProvider, ...] = (
     ReadyProvider(
+        key="linkedin",
+        account="jwalinshah13@gmail.com",
+        query='from:(LinkedIn) ("ready" OR "download") newer_than:30d',
+        preferred_domains=("linkedin.com",),
+        required_url_terms=("download",),
+    ),
+    ReadyProvider(
+        key="openai",
+        account="jwalinshah13@gmail.com",
+        query='(from:(OpenAI) OR from:(ChatGPT)) ("ready" OR "export" OR "download") newer_than:30d',
+        preferred_domains=("openai.com", "chatgpt.com"),
+        required_url_terms=("backend-api/estuary/content", ".zip"),
+    ),
+    ReadyProvider(
         key="claude",
         account="jwalinshah13@gmail.com",
-        query='from:(Anthropic) "Your data is ready for download" newer_than:7d',
+        query='from:(Anthropic) "Your data is ready for download" newer_than:30d',
         preferred_domains=("claude.ai",),
+        required_url_terms=("/export/", "/download/"),
     ),
     ReadyProvider(
         key="github",
         account="jwalinshah13@gmail.com",
-        query='from:(GitHub) "Your data export is ready to download" newer_than:7d',
+        query='from:(GitHub) "Your data export is ready to download" newer_than:30d',
         preferred_domains=("github.com",),
+        required_url_terms=("migration/download",),
+    ),
+    ReadyProvider(
+        key="google",
+        account="jwalinshah13@gmail.com",
+        query='("Your Google data has been exported" OR "Google data" OR "Takeout") newer_than:30d',
+        preferred_domains=("takeout.google.com", "drive.google.com", "google.com"),
+        required_url_terms=("takeout",),
+    ),
+    ReadyProvider(
+        key="spotify",
+        account="jwalinshah13@gmail.com",
+        query='from:(Spotify) ("ready to download" OR "download") newer_than:30d',
+        preferred_domains=("spotify.com",),
+        required_url_terms=("download",),
+    ),
+    ReadyProvider(
+        key="apple",
+        account="jwalinsshah@gmail.com",
+        query='from:(Apple) ("ready" OR "download" OR "preparing your data") newer_than:30d',
+        preferred_domains=("privacy.apple.com", "apple.com"),
+        required_url_terms=("account/archive",),
     ),
 )
 
@@ -79,7 +118,17 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--cdp-url", default=DEFAULT_CDP_URL)
     parser.add_argument("--download-dir", default=str(DEFAULT_DOWNLOAD_DIR))
     parser.add_argument("--state-path", default=str(DEFAULT_STATE_PATH))
+    parser.add_argument("--include-urls", action="store_true")
+    parser.add_argument(
+        "--write-links",
+        help="Write a local Markdown checklist containing private ready download links.",
+    )
     parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument(
+        "--open",
+        action="store_true",
+        help="Actually open ready links and allow browser downloads. Default only reports links.",
+    )
     return parser.parse_args()
 
 
@@ -118,12 +167,16 @@ def domain_for(url: str) -> str:
     return (parsed.hostname or "").lower()
 
 
-def keep_link(url: str, preferred_domains: tuple[str, ...]) -> bool:
+def keep_link(url: str, provider: ReadyProvider) -> bool:
     lower = url.lower()
-    if any(term in lower for term in ("unsubscribe", "privacy", "terms", "preferences")):
+    if any(term in lower for term in ("unsubscribe", "terms", "preferences")):
         return False
     host = domain_for(url)
-    return any(host == domain or host.endswith(f".{domain}") for domain in preferred_domains)
+    if not any(
+        host == domain or host.endswith(f".{domain}") for domain in provider.preferred_domains
+    ):
+        return False
+    return all(term.lower() in lower for term in provider.required_url_terms)
 
 
 def ready_provider_map() -> dict[str, ReadyProvider]:
@@ -193,8 +246,9 @@ def collect_ready_links(provider: ReadyProvider) -> list[dict[str, str]]:
         msg_id = str(msg_ref.get("id") or "")
         full = svc.users().messages().get(userId="me", id=msg_id, format="full").execute()
         headers = {h["name"]: h["value"] for h in full.get("payload", {}).get("headers", [])}
-        for url in extract_links(full.get("payload", {})):
-            if url in seen_urls or not keep_link(url, provider.preferred_domains):
+        for raw_url in extract_links(full.get("payload", {})):
+            url = html.unescape(raw_url).rstrip(").,")
+            if url in seen_urls or not keep_link(url, provider):
                 continue
             seen_urls.add(url)
             found.append(
@@ -209,6 +263,43 @@ def collect_ready_links(provider: ReadyProvider) -> list[dict[str, str]]:
     return found
 
 
+def render_links_markdown(ready_links: list[dict[str, str]], download_dir: Path) -> str:
+    generated_at = datetime.now().isoformat(timespec="seconds")
+    lines = [
+        "# Personal Data Export Download Links",
+        "",
+        f"Generated: {generated_at}",
+        "",
+        "These links are private signed/account-bound export links from Gmail. Open them in your normal logged-in browser, then save the downloaded archives into:",
+        "",
+        f"`{download_dir}`",
+        "",
+    ]
+    if not ready_links:
+        lines.extend(["No ready download links found.", ""])
+        return "\n".join(lines)
+
+    for index, item in enumerate(ready_links, start=1):
+        lines.extend(
+            [
+                f"## {index}. {item['provider']}",
+                "",
+                f"- Subject: {item['subject']}",
+                f"- Gmail message id: `{item['message_id']}`",
+                f"- Domain: `{item['domain']}`",
+                f"- Link: {item['url']}",
+                "- Done: [ ] downloaded into `_downloads`",
+                "",
+            ]
+        )
+    return "\n".join(lines)
+
+
+def write_links(path: Path, ready_links: list[dict[str, str]], download_dir: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(render_links_markdown(ready_links, download_dir), encoding="utf-8")
+
+
 def update_state(path: Path, opened: list[dict[str, str]], download_dir: Path) -> None:
     if not opened:
         return
@@ -217,6 +308,8 @@ def update_state(path: Path, opened: list[dict[str, str]], download_dir: Path) -
     now = datetime.now().isoformat(timespec="seconds")
     for item in opened:
         provider = providers.setdefault(item["provider"], {})
+        old_status = str(provider.get("status") or "not_started")
+        provider["status"] = better_status(old_status, "download_link_opened")
         provider["last_download_opened_at"] = now
         provider["download_dir"] = str(download_dir)
         events = provider.setdefault("download_open_events", [])
@@ -255,6 +348,7 @@ def main() -> int:
                     "message_id": item["message_id"],
                     "subject": item["subject"],
                     "domain": item["domain"],
+                    **({"url": item["url"]} if args.include_urls else {}),
                 }
                 for item in ready_links
             ],
@@ -262,7 +356,9 @@ def main() -> int:
             sort_keys=True,
         )
     )
-    if args.dry_run or not ready_links:
+    if args.write_links:
+        write_links(Path(os.path.expanduser(args.write_links)), ready_links, download_dir)
+    if args.dry_run or not args.open or not ready_links:
         return 0
 
     set_download_dir(args.cdp_url, download_dir)

--- a/scripts/parse_apple_export_for_ops.py
+++ b/scripts/parse_apple_export_for_ops.py
@@ -1,0 +1,277 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import re
+import zipfile
+from datetime import datetime
+from pathlib import Path
+
+DEFAULT_APPLE_ROOT = Path("/Users/jwalinshah/Documents/inbox-data-exports/apple/2026-05-24")
+DEFAULT_OUTPUT_ROOT = Path(
+    "/Users/jwalinshah/Documents/Codex/2026-05-26/can-we-please-do-a-review/ops_kernel/parsed/apple"
+)
+
+TODO_TERMS = (
+    "todo",
+    "to do",
+    "pay",
+    "call",
+    "email",
+    "follow up",
+    "follow-up",
+    "question",
+    "insurance",
+    "bill",
+    "stanford",
+    "united",
+    "credit",
+    "resume",
+    "interview",
+    "doctor",
+    "pharmacy",
+)
+
+ADMIN_TERMS = (
+    "stanford",
+    "insurance",
+    "united",
+    "bill",
+    "claim",
+    "doctor",
+    "pharmacy",
+    "lawsuit",
+    "continuation of care",
+    "alameda alliance",
+    "car crash",
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Parse high-value Apple export files into ops-kernel review CSVs."
+    )
+    parser.add_argument("--apple-root", default=str(DEFAULT_APPLE_ROOT))
+    parser.add_argument("--output-root", default=str(DEFAULT_OUTPUT_ROOT))
+    return parser.parse_args()
+
+
+def first_value(lines: list[str], prefix: str) -> str:
+    for line in lines:
+        if line.upper().startswith(prefix):
+            return line.split(":", 1)[-1].strip()
+    return ""
+
+
+def parse_vcard(text: str) -> dict[str, str]:
+    lines = [line.strip() for line in text.replace("\r\n", "\n").splitlines()]
+    emails = [line.split(":", 1)[-1].strip() for line in lines if line.upper().startswith("EMAIL")]
+    phones = [line.split(":", 1)[-1].strip() for line in lines if line.upper().startswith("TEL")]
+    org = first_value(lines, "ORG")
+    return {
+        "name": first_value(lines, "FN:"),
+        "emails": "; ".join(emails[:5]),
+        "phones": "; ".join(phones[:5]),
+        "organization": org,
+    }
+
+
+def read_zip_texts(zip_path: Path, suffixes: tuple[str, ...]) -> list[tuple[str, str]]:
+    rows: list[tuple[str, str]] = []
+    with zipfile.ZipFile(zip_path) as archive:
+        for name in archive.namelist():
+            if not name.lower().endswith(suffixes):
+                continue
+            try:
+                text = archive.read(name).decode("utf-8", errors="replace")
+            except KeyError:
+                continue
+            rows.append((name, text))
+    return rows
+
+
+def parse_contacts(apple_root: Path) -> list[dict[str, str]]:
+    zip_path = apple_root / "iCloud Contacts.zip"
+    if not zip_path.exists():
+        return []
+    contacts = []
+    for name, text in read_zip_texts(zip_path, (".vcf",)):
+        parsed = parse_vcard(text)
+        parsed["source_file"] = str(zip_path)
+        parsed["entry"] = name
+        contacts.append(parsed)
+    contacts.sort(key=lambda row: row.get("name", "").lower())
+    return contacts
+
+
+def todo_score(title: str, text: str) -> int:
+    haystack = f"{title}\n{text}".lower()
+    return sum(1 for term in TODO_TERMS if term in haystack)
+
+
+def parse_note_candidates(apple_root: Path) -> list[dict[str, str]]:
+    zip_path = apple_root / "iCloud Notes.zip"
+    if not zip_path.exists():
+        return []
+    candidates = []
+    for name, text in read_zip_texts(zip_path, (".txt",)):
+        title = Path(name).stem.replace(".txt", "")
+        score = todo_score(title, text)
+        if score == 0:
+            continue
+        excerpt = re.sub(r"\s+", " ", text).strip()[:500]
+        candidates.append(
+            {
+                "priority": "P0" if score >= 2 else "P1",
+                "status": "needs_review",
+                "title": title,
+                "entry": name,
+                "matched_terms": str(score),
+                "excerpt": excerpt,
+                "source_file": str(zip_path),
+                "recommended_action": "review_note_and_promote_source_backed_todo",
+            }
+        )
+    candidates.sort(key=lambda row: (row["priority"], row["title"].lower()))
+    return candidates
+
+
+def admin_note_candidates(notes: list[dict[str, str]]) -> list[dict[str, str]]:
+    rows = []
+    for note in notes:
+        text = f"{note['title']} {note['excerpt']}".lower()
+        matched = [term for term in ADMIN_TERMS if term in text]
+        if not matched:
+            continue
+        rows.append(
+            {
+                "priority": "P0"
+                if any(
+                    term in matched
+                    for term in (
+                        "stanford",
+                        "insurance",
+                        "claim",
+                        "doctor",
+                        "pharmacy",
+                        "lawsuit",
+                        "continuation of care",
+                        "alameda alliance",
+                    )
+                )
+                else "P1",
+                "status": "needs_reconciliation",
+                "lane": "admin_health_legal",
+                "title": note["title"],
+                "matched_terms": "; ".join(matched),
+                "excerpt": note["excerpt"],
+                "source_file": note["source_file"],
+                "entry": note["entry"],
+                "recommended_action": "compare_against_master_todo_and_promote_or_reject",
+            }
+        )
+    rows.sort(key=lambda row: (row["priority"], row["title"].lower()))
+    return rows
+
+
+def parse_calendar_reminder_inventory(apple_root: Path) -> list[dict[str, str]]:
+    zip_path = apple_root / "iCloud Calendars and Reminders.zip"
+    if not zip_path.exists():
+        return []
+    rows = []
+    with zipfile.ZipFile(zip_path) as archive:
+        for name in archive.namelist():
+            lower = name.lower()
+            if not (lower.endswith(".ics") or lower.endswith(".json") or lower.endswith(".csv")):
+                continue
+            data = archive.read(name)
+            rows.append(
+                {
+                    "source_file": str(zip_path),
+                    "entry": name,
+                    "size_bytes": str(len(data)),
+                    "kind": "reminders" if "reminder" in lower else "calendar",
+                    "recommended_action": "parse_calendar_or_reminder_items_if_needed",
+                }
+            )
+    return rows
+
+
+def write_csv(path: Path, rows: list[dict[str, str]], fieldnames: list[str]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def main() -> int:
+    args = parse_args()
+    apple_root = Path(args.apple_root).expanduser()
+    output_root = Path(args.output_root).expanduser()
+
+    contacts = parse_contacts(apple_root)
+    notes = parse_note_candidates(apple_root)
+    admin_notes = admin_note_candidates(notes)
+    calendar = parse_calendar_reminder_inventory(apple_root)
+
+    write_csv(
+        output_root / "contacts.csv",
+        contacts,
+        ["name", "emails", "phones", "organization", "source_file", "entry"],
+    )
+    write_csv(
+        output_root / "note_todo_candidates.csv",
+        notes,
+        [
+            "priority",
+            "status",
+            "title",
+            "entry",
+            "matched_terms",
+            "excerpt",
+            "source_file",
+            "recommended_action",
+        ],
+    )
+    write_csv(
+        output_root / "admin_reconciliation_queue.csv",
+        admin_notes,
+        [
+            "priority",
+            "status",
+            "lane",
+            "title",
+            "matched_terms",
+            "excerpt",
+            "source_file",
+            "entry",
+            "recommended_action",
+        ],
+    )
+    write_csv(
+        output_root / "calendar_reminder_inventory.csv",
+        calendar,
+        ["source_file", "entry", "size_bytes", "kind", "recommended_action"],
+    )
+
+    summary = {
+        "generated_at": datetime.now().isoformat(timespec="seconds"),
+        "apple_root": str(apple_root),
+        "contacts": len(contacts),
+        "note_todo_candidates": len(notes),
+        "admin_reconciliation_candidates": len(admin_notes),
+        "calendar_reminder_files": len(calendar),
+    }
+    (output_root / "summary.json").write_text(
+        json.dumps(summary, indent=2, sort_keys=True),
+        encoding="utf-8",
+    )
+    print(json.dumps(summary, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/request_personal_data_exports.py
+++ b/scripts/request_personal_data_exports.py
@@ -13,9 +13,58 @@ import webbrowser
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
+from typing import Any
 
 DEFAULT_STATE_PATH = Path.home() / ".local/state/inbox/data-export-email-watch.json"
 DEFAULT_CDP_URL = "http://127.0.0.1:9222"
+
+STATUS_RANK = {
+    "not_started": 0,
+    "opened_export_page": 10,
+    "browser_seen_export_page": 20,
+    "login_required_seen": 30,
+    "request_ui_seen": 40,
+    "request_submitted_seen": 50,
+    "request_submitted_manually": 60,
+    "confirmation_email_seen": 70,
+    "export_email_seen": 75,
+    "ready_ui_seen": 80,
+    "ready_email_seen": 90,
+    "download_link_expired": 95,
+    "download_link_opened": 100,
+}
+
+STATUS_STAGE = {
+    "not_started": "request",
+    "opened_export_page": "request",
+    "browser_seen_export_page": "request",
+    "login_required_seen": "request",
+    "request_ui_seen": "request",
+    "request_submitted_seen": "status",
+    "request_submitted_manually": "status",
+    "confirmation_email_seen": "status",
+    "export_email_seen": "status",
+    "ready_ui_seen": "ready",
+    "ready_email_seen": "ready",
+    "download_link_expired": "request",
+    "download_link_opened": "download",
+}
+
+MANUAL_BOUNDARY = {
+    "not_started": "open_request_page",
+    "opened_export_page": "complete_provider_request_in_browser",
+    "browser_seen_export_page": "complete_provider_request_in_browser",
+    "login_required_seen": "login_or_2fa_required",
+    "request_ui_seen": "submit_export_request_manually",
+    "request_submitted_seen": "wait_for_ready_email_or_status",
+    "request_submitted_manually": "wait_for_ready_email_or_status",
+    "confirmation_email_seen": "wait_for_ready_email_or_status",
+    "export_email_seen": "review_export_email",
+    "ready_ui_seen": "open_download_link_manually",
+    "ready_email_seen": "open_download_link_manually",
+    "download_link_expired": "re_request_export_in_browser",
+    "download_link_opened": "browser_download_may_require_manual_confirmation",
+}
 
 
 @dataclass(frozen=True)
@@ -157,6 +206,11 @@ def parse_args() -> argparse.Namespace:
         help="Show local request/open/email status without opening browser tabs.",
     )
     parser.add_argument(
+        "--json",
+        action="store_true",
+        help="With --status, print the normalized status model as JSON.",
+    )
+    parser.add_argument(
         "--state-path",
         default=str(DEFAULT_STATE_PATH),
         help="Path for local export request/watch state.",
@@ -167,6 +221,11 @@ def parse_args() -> argparse.Namespace:
         help="Print URLs that would open without opening browser tabs.",
     )
     parser.add_argument(
+        "--open",
+        action="store_true",
+        help="Actually open selected export pages. Default only reports what would be opened.",
+    )
+    parser.add_argument(
         "--record-only",
         action="store_true",
         help="Record selected pages as opened without opening browser tabs.",
@@ -175,6 +234,11 @@ def parse_args() -> argparse.Namespace:
         "--mark-requested",
         action="store_true",
         help="Mark selected providers as manually requested without opening browser tabs.",
+    )
+    parser.add_argument(
+        "--mark-expired",
+        action="store_true",
+        help="Mark selected providers' prior ready/download links as expired and needing re-request.",
     )
     parser.add_argument(
         "--delay",
@@ -226,7 +290,7 @@ def print_targets(targets: list[ExportTarget]) -> None:
         print(f"          {target.login_hint}")
 
 
-def load_state(path: Path) -> dict:
+def load_state(path: Path) -> dict[str, Any]:
     if not path.exists():
         return {}
     try:
@@ -236,10 +300,130 @@ def load_state(path: Path) -> dict:
     return data if isinstance(data, dict) else {}
 
 
-def save_state(path: Path, state: dict) -> None:
+def save_state(path: Path, state: dict[str, Any]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     state["updated_at"] = datetime.now().isoformat(timespec="seconds")
     path.write_text(json.dumps(state, indent=2, sort_keys=True))
+
+
+def better_status(old: str, new: str) -> str:
+    return new if STATUS_RANK.get(new, 0) >= STATUS_RANK.get(old, 0) else old
+
+
+def provider_status(raw: dict[str, Any]) -> str:
+    status = str(raw.get("status") or "not_started")
+    if status == "download_link_expired":
+        return status
+    requested_at = str(raw.get("requested_at") or "")
+    last_email_at = str(raw.get("last_email_at") or "")
+    if (
+        requested_at
+        and last_email_at
+        and requested_at > last_email_at
+        and status in {"ready_email_seen", "export_email_seen", "confirmation_email_seen"}
+    ):
+        return "request_submitted_manually"
+    if raw.get("last_download_opened_at"):
+        status = better_status(status, "download_link_opened")
+    elif last_email_at and not raw.get("status"):
+        status = better_status(status, "export_email_seen")
+    return status if status in STATUS_RANK else "export_email_seen"
+
+
+def provider_stage(status: str) -> str:
+    return STATUS_STAGE.get(status, "status")
+
+
+def provider_manual_boundary(status: str) -> str:
+    return MANUAL_BOUNDARY.get(status, "review_provider_status_manually")
+
+
+def normalize_provider_status(target: ExportTarget, raw: dict[str, Any]) -> dict[str, Any]:
+    status = provider_status(raw)
+    ready_at = raw.get("last_email_at") if status == "ready_email_seen" else ""
+    if status == "ready_ui_seen":
+        ready_at = raw.get("last_browser_seen_at") or ""
+    download_opened_at = str(raw.get("last_download_opened_at") or "")
+    return {
+        "key": target.key,
+        "name": str(raw.get("name") or target.name),
+        "status": status,
+        "stage": provider_stage(status),
+        "manual_boundary": provider_manual_boundary(status),
+        "priority": target.priority,
+        "url": str(raw.get("url") or target.url),
+        "request": {
+            "opened_at": str(raw.get("opened_at") or ""),
+            "opened_count": int(raw.get("opened_count") or 0),
+            "requested_at": str(raw.get("requested_at") or ""),
+        },
+        "browser": {
+            "seen_at": str(raw.get("last_browser_seen_at") or ""),
+            "url": str(raw.get("last_browser_url") or ""),
+            "title": str(raw.get("last_browser_title") or ""),
+            "signal": str(raw.get("last_browser_signal") or ""),
+        },
+        "email": {
+            "seen_at": str(raw.get("last_email_at") or ""),
+            "title": str(raw.get("last_email_title") or ""),
+            "snippet": str(raw.get("last_email_snippet") or ""),
+            "event_count": len(raw.get("email_events") or [])
+            if isinstance(raw.get("email_events"), list)
+            else 0,
+        },
+        "ready": {
+            "ready_at": str(ready_at or ""),
+            "source": "email"
+            if status == "ready_email_seen"
+            else "browser"
+            if status == "ready_ui_seen"
+            else "",
+        },
+        "download": {
+            "opened_at": download_opened_at,
+            "download_dir": str(raw.get("download_dir") or ""),
+            "expired_at": str(raw.get("last_download_expired_at") or ""),
+            "expired_reason": str(raw.get("download_expired_reason") or ""),
+            "event_count": len(raw.get("download_open_events") or [])
+            if isinstance(raw.get("download_open_events"), list)
+            else 0,
+        },
+    }
+
+
+def build_status_model(state: dict[str, Any]) -> dict[str, Any]:
+    providers_state = state.get("providers") if isinstance(state.get("providers"), dict) else {}
+    providers = [
+        normalize_provider_status(
+            target,
+            providers_state.get(target.key, {})
+            if isinstance(providers_state.get(target.key), dict)
+            else {},
+        )
+        for target in EXPORT_TARGETS
+    ]
+    counts: dict[str, int] = {}
+    for provider in providers:
+        stage = str(provider["stage"])
+        counts[stage] = counts.get(stage, 0) + 1
+    return {
+        "schema": "inbox.data_exports.status.v1",
+        "generated_at": datetime.now().isoformat(timespec="seconds"),
+        "state_updated_at": str(state.get("updated_at") or ""),
+        "summary": {
+            "total": len(providers),
+            "by_stage": counts,
+            "ready": sum(1 for provider in providers if provider["stage"] == "ready"),
+            "download": sum(1 for provider in providers if provider["stage"] == "download"),
+            "manual_attention": sum(
+                1
+                for provider in providers
+                if provider["manual_boundary"]
+                not in {"wait_for_ready_email_or_status", "review_export_email"}
+            ),
+        },
+        "providers": providers,
+    }
 
 
 def mark_opened(path: Path, targets: list[ExportTarget]) -> None:
@@ -255,7 +439,10 @@ def mark_opened(path: Path, targets: list[ExportTarget]) -> None:
                 "note": target.note,
                 "login_hint": target.login_hint,
                 "opened_at": opened_at,
-                "status": "opened_export_page",
+                "status": better_status(
+                    str(provider.get("status") or "not_started"),
+                    "opened_export_page",
+                ),
             }
         )
         provider["opened_count"] = int(provider.get("opened_count", 0)) + 1
@@ -268,6 +455,12 @@ def mark_requested(path: Path, targets: list[ExportTarget]) -> None:
     requested_at = datetime.now().isoformat(timespec="seconds")
     for target in targets:
         provider = providers.setdefault(target.key, {})
+        old_status = str(provider.get("status") or "not_started")
+        status = (
+            "request_submitted_manually"
+            if old_status == "download_link_expired"
+            else better_status(old_status, "request_submitted_manually")
+        )
         provider.update(
             {
                 "name": target.name,
@@ -275,32 +468,58 @@ def mark_requested(path: Path, targets: list[ExportTarget]) -> None:
                 "note": target.note,
                 "login_hint": target.login_hint,
                 "requested_at": requested_at,
-                "status": "request_submitted_manually",
+                "status": status,
+            }
+        )
+        if old_status == "download_link_expired":
+            provider.pop("last_download_expired_at", None)
+            provider.pop("download_expired_reason", None)
+    save_state(path, state)
+
+
+def mark_expired(path: Path, targets: list[ExportTarget], reason: str) -> None:
+    state = load_state(path)
+    providers = state.setdefault("providers", {})
+    expired_at = datetime.now().isoformat(timespec="seconds")
+    for target in targets:
+        provider = providers.setdefault(target.key, {})
+        provider.update(
+            {
+                "name": target.name,
+                "url": target.url,
+                "note": target.note,
+                "login_hint": target.login_hint,
+                "last_download_expired_at": expired_at,
+                "download_expired_reason": reason,
+                "status": "download_link_expired",
             }
         )
     save_state(path, state)
 
 
-def print_status(path: Path) -> None:
+def print_status(path: Path, *, as_json: bool = False) -> None:
     state = load_state(path)
-    providers = state.get("providers", {})
-    for target in EXPORT_TARGETS:
-        status = providers.get(target.key, {})
-        opened_at = status.get("opened_at", "not opened")
-        requested_at = status.get("requested_at", "")
-        current = status.get("status", "not_started")
-        email_at = status.get("last_email_at", "")
-        email_title = status.get("last_email_title", "")
-        print(f"{target.key:9} {current}")
+    model = build_status_model(state)
+    if as_json:
+        print(json.dumps(model, indent=2, sort_keys=True))
+        return
+    for provider in model["providers"]:
+        print(f"{provider['key']:9} {provider['stage']}:{provider['status']}")
+        print(f"          next:   {provider['manual_boundary']}")
+        opened_at = provider["request"]["opened_at"] or "not opened"
         print(f"          opened: {opened_at}")
-        if requested_at:
-            print(f"          requested: {requested_at}")
-        if email_at or email_title:
-            print(f"          email:  {email_at} {email_title}".rstrip())
-        events = status.get("email_events")
-        if isinstance(events, list) and len(events) > 1:
-            print(f"          email events: {len(events)}")
-        print(f"          url:    {target.url}")
+        if provider["request"]["requested_at"]:
+            print(f"          requested: {provider['request']['requested_at']}")
+        if provider["email"]["seen_at"] or provider["email"]["title"]:
+            print(
+                f"          email:  {provider['email']['seen_at']} "
+                f"{provider['email']['title']}".rstrip()
+            )
+        if provider["download"]["opened_at"]:
+            print(f"          download opened: {provider['download']['opened_at']}")
+        if provider["download"]["expired_at"]:
+            print(f"          expired: {provider['download']['expired_at']}")
+        print(f"          url:    {provider['url']}")
 
 
 def open_target_via_cdp(cdp_url: str, target: ExportTarget) -> None:
@@ -326,7 +545,7 @@ def main() -> int:
         print_targets(list(EXPORT_TARGETS))
         return 0
     if args.status:
-        print_status(state_path)
+        print_status(state_path, as_json=args.json)
         return 0
 
     selected = select_targets(args)
@@ -334,10 +553,20 @@ def main() -> int:
     if args.mark_requested:
         mark_requested(state_path, selected)
         return 0
+    if getattr(args, "mark_expired", False):
+        mark_expired(
+            state_path,
+            selected,
+            "ready/download link was stale and no file landed in the downloads directory",
+        )
+        return 0
     if args.record_only:
         mark_opened(state_path, selected)
         return 0
     if args.dry_run:
+        return 0
+    if not args.open:
+        print("Dry run only. Re-run with --open to open browser tabs.")
         return 0
 
     for target in selected:

--- a/scripts/run_imessage_index_incremental.sh
+++ b/scripts/run_imessage_index_incremental.sh
@@ -5,7 +5,6 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT_DIR"
 
 export PATH="/opt/homebrew/bin:/usr/local/bin:$HOME/.local/bin:$PATH"
-export UV_CACHE_DIR="${UV_CACHE_DIR:-/tmp/uv-cache}"
 
 ENV_FILE="${INBOX_ENV_FILE:-${INBOX_WORKFLOWS_ENV:-$ROOT_DIR/config/inbox.env}}"
 if [[ -f "$ENV_FILE" ]]; then
@@ -15,4 +14,7 @@ if [[ -f "$ENV_FILE" ]]; then
   set +a
 fi
 
-exec uv run python mcp_server.py
+export UV_CACHE_DIR="${UV_CACHE_DIR:-/tmp/uv-cache}"
+export INBOX_DISABLE_IMESSAGE_SYNC="${INBOX_DISABLE_IMESSAGE_SYNC:-0}"
+
+exec uv run python message_sync.py imessage-incremental

--- a/scripts/run_inbox_backend.sh
+++ b/scripts/run_inbox_backend.sh
@@ -4,6 +4,18 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT_DIR"
 
+ENV_FILE="${INBOX_WORKFLOWS_ENV:-$HOME/.config/raycast/inbox-workflows.env}"
+if [[ -f "$ENV_FILE" ]]; then
+  set -a
+  # shellcheck source=/dev/null
+  . "$ENV_FILE"
+  set +a
+fi
+
 export UV_CACHE_DIR="${UV_CACHE_DIR:-/tmp/uv-cache}"
+export INBOX_SERVER_ALLOW_UNAUTHENTICATED="${INBOX_SERVER_ALLOW_UNAUTHENTICATED:-0}"
+export INBOX_START_SCHEDULER="${INBOX_START_SCHEDULER:-0}"
+export INBOX_DISABLE_AMBIENT="${INBOX_DISABLE_AMBIENT:-1}"
+export INBOX_DISABLE_IMESSAGE_SYNC="${INBOX_DISABLE_IMESSAGE_SYNC:-1}"
 
 exec uv run python inbox_server.py

--- a/scripts/run_inbox_backend.sh
+++ b/scripts/run_inbox_backend.sh
@@ -4,7 +4,9 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT_DIR"
 
-ENV_FILE="${INBOX_WORKFLOWS_ENV:-$HOME/.config/raycast/inbox-workflows.env}"
+export PATH="/opt/homebrew/bin:/usr/local/bin:$HOME/.local/bin:$PATH"
+
+ENV_FILE="${INBOX_ENV_FILE:-${INBOX_WORKFLOWS_ENV:-$ROOT_DIR/config/inbox.env}}"
 if [[ -f "$ENV_FILE" ]]; then
   set -a
   # shellcheck source=/dev/null
@@ -16,6 +18,6 @@ export UV_CACHE_DIR="${UV_CACHE_DIR:-/tmp/uv-cache}"
 export INBOX_SERVER_ALLOW_UNAUTHENTICATED="${INBOX_SERVER_ALLOW_UNAUTHENTICATED:-0}"
 export INBOX_START_SCHEDULER="${INBOX_START_SCHEDULER:-0}"
 export INBOX_DISABLE_AMBIENT="${INBOX_DISABLE_AMBIENT:-1}"
-export INBOX_DISABLE_IMESSAGE_SYNC="${INBOX_DISABLE_IMESSAGE_SYNC:-1}"
+export INBOX_DISABLE_IMESSAGE_SYNC="${INBOX_DISABLE_IMESSAGE_SYNC:-0}"
 
 exec uv run python inbox_server.py

--- a/scripts/run_inbox_mcp_http_readonly.sh
+++ b/scripts/run_inbox_mcp_http_readonly.sh
@@ -4,6 +4,15 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT_DIR"
 
+export PATH="/opt/homebrew/bin:/usr/local/bin:$HOME/.local/bin:$PATH"
 export UV_CACHE_DIR="${UV_CACHE_DIR:-/tmp/uv-cache}"
+
+ENV_FILE="${INBOX_ENV_FILE:-${INBOX_WORKFLOWS_ENV:-$ROOT_DIR/config/inbox.env}}"
+if [[ -f "$ENV_FILE" ]]; then
+  set -a
+  # shellcheck source=/dev/null
+  . "$ENV_FILE"
+  set +a
+fi
 
 exec uv run python inbox_mcp_readonly.py

--- a/scripts/run_inbox_mcp_stdio.sh
+++ b/scripts/run_inbox_mcp_stdio.sh
@@ -4,6 +4,15 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT_DIR"
 
+export PATH="/opt/homebrew/bin:/usr/local/bin:$HOME/.local/bin:$PATH"
 export UV_CACHE_DIR="${UV_CACHE_DIR:-/tmp/uv-cache}"
+
+ENV_FILE="${INBOX_ENV_FILE:-${INBOX_WORKFLOWS_ENV:-$ROOT_DIR/config/inbox.env}}"
+if [[ -f "$ENV_FILE" ]]; then
+  set -a
+  # shellcheck source=/dev/null
+  . "$ENV_FILE"
+  set +a
+fi
 
 exec uv run python inbox_mcp_stdio.py

--- a/scripts/run_inbox_mcp_stdio_readonly.sh
+++ b/scripts/run_inbox_mcp_stdio_readonly.sh
@@ -4,6 +4,15 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT_DIR"
 
+export PATH="/opt/homebrew/bin:/usr/local/bin:$HOME/.local/bin:$PATH"
 export UV_CACHE_DIR="${UV_CACHE_DIR:-/tmp/uv-cache}"
+
+ENV_FILE="${INBOX_ENV_FILE:-${INBOX_WORKFLOWS_ENV:-$ROOT_DIR/config/inbox.env}}"
+if [[ -f "$ENV_FILE" ]]; then
+  set -a
+  # shellcheck source=/dev/null
+  . "$ENV_FILE"
+  set +a
+fi
 
 exec uv run python inbox_mcp_readonly_stdio.py

--- a/scripts/run_index_incremental.sh
+++ b/scripts/run_index_incremental.sh
@@ -15,7 +15,7 @@ INBOX_SERVER_URL="${INBOX_SERVER_URL:-http://127.0.0.1:9849}"
 INBOX_SERVER_TOKEN="${INBOX_SERVER_TOKEN:-}"
 export INBOX_START_SCHEDULER="${INBOX_START_SCHEDULER:-0}"
 export INBOX_DISABLE_AMBIENT="${INBOX_DISABLE_AMBIENT:-1}"
-export INBOX_DISABLE_IMESSAGE_SYNC="${INBOX_DISABLE_IMESSAGE_SYNC:-1}"
+export INBOX_DISABLE_IMESSAGE_SYNC="${INBOX_DISABLE_IMESSAGE_SYNC:-0}"
 
 if ! curl -fsS --max-time 2 "$INBOX_SERVER_URL/health" >/dev/null; then
   launchctl kickstart -k "gui/$(id -u)/com.jwalin.inbox.backend" 2>/dev/null || true

--- a/scripts/run_index_incremental.sh
+++ b/scripts/run_index_incremental.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ENV_FILE="${INBOX_WORKFLOWS_ENV:-$HOME/.config/raycast/inbox-workflows.env}"
+
+if [[ -f "$ENV_FILE" ]]; then
+  set -a
+  # shellcheck source=/dev/null
+  . "$ENV_FILE"
+  set +a
+fi
+
+INBOX_SERVER_URL="${INBOX_SERVER_URL:-http://127.0.0.1:9849}"
+INBOX_SERVER_TOKEN="${INBOX_SERVER_TOKEN:-}"
+export INBOX_START_SCHEDULER="${INBOX_START_SCHEDULER:-0}"
+export INBOX_DISABLE_AMBIENT="${INBOX_DISABLE_AMBIENT:-1}"
+export INBOX_DISABLE_IMESSAGE_SYNC="${INBOX_DISABLE_IMESSAGE_SYNC:-1}"
+
+if ! curl -fsS --max-time 2 "$INBOX_SERVER_URL/health" >/dev/null; then
+  launchctl kickstart -k "gui/$(id -u)/com.jwalin.inbox.backend" 2>/dev/null || true
+  deadline=$((SECONDS + 45))
+  until curl -fsS --max-time 2 "$INBOX_SERVER_URL/health" >/dev/null; do
+    if (( SECONDS >= deadline )); then
+      echo "Inbox backend did not become healthy at $INBOX_SERVER_URL" >&2
+      exit 1
+    fi
+    sleep 1
+  done
+fi
+
+auth_args=()
+if [[ -n "$INBOX_SERVER_TOKEN" ]]; then
+  auth_args=(-H "Authorization: Bearer $INBOX_SERVER_TOKEN")
+fi
+
+curl -fsS \
+  --max-time "${INBOX_INDEX_SYNC_TIMEOUT:-120}" \
+  -X POST \
+  "${auth_args[@]}" \
+  "$INBOX_SERVER_URL/index/sync/incremental"
+
+printf '\n'

--- a/scripts/run_wacli_sync_import_once.sh
+++ b/scripts/run_wacli_sync_import_once.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+export PATH="/opt/homebrew/bin:/usr/local/bin:$HOME/.local/bin:$PATH"
+
+ENV_FILE="${INBOX_ENV_FILE:-${INBOX_WORKFLOWS_ENV:-$ROOT_DIR/config/inbox.env}}"
+if [[ -f "$ENV_FILE" ]]; then
+  set -a
+  # shellcheck source=/dev/null
+  . "$ENV_FILE"
+  set +a
+fi
+
+export UV_CACHE_DIR="${UV_CACHE_DIR:-/tmp/uv-cache}"
+export WACLI_STORE_DIR="${WACLI_STORE_DIR:-$HOME/.wacli}"
+
+if ! command -v wacli >/dev/null 2>&1; then
+  echo "wacli is not installed. Run: brew install openclaw/tap/wacli" >&2
+  exit 127
+fi
+
+if ! wacli doctor 2>/dev/null | grep -q "AUTHENTICATED[[:space:]]*true"; then
+  echo "wacli is not authenticated. Run: wacli auth" >&2
+  exit 2
+fi
+
+wacli sync --once --idle-exit "${WACLI_IDLE_EXIT:-30s}" --refresh-contacts --refresh-groups
+uv run python scripts/import_wacli_to_openhuman.py --sync-index

--- a/scripts/run_whatsapp_scan_once.sh
+++ b/scripts/run_whatsapp_scan_once.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+ENV_FILE="${INBOX_WORKFLOWS_ENV:-$HOME/.config/raycast/inbox-workflows.env}"
+if [[ -f "$ENV_FILE" ]]; then
+  set -a
+  # shellcheck source=/dev/null
+  . "$ENV_FILE"
+  set +a
+fi
+
+PORT="${INBOX_WHATSAPP_CDP_PORT:-9223}"
+CDP_URL="${INBOX_WHATSAPP_CDP_URL:-http://127.0.0.1:$PORT}"
+PROFILE_MODE="${INBOX_WHATSAPP_PROFILE_MODE:-isolated}"
+CLICK_VISIBLE="${INBOX_WHATSAPP_CLICK_VISIBLE:-15}"
+SCROLL_PAGES="${INBOX_WHATSAPP_SCROLL_PAGES:-0}"
+IDB_LIMIT="${INBOX_WHATSAPP_IDB_LIMIT:-10000}"
+STRICT="${INBOX_WHATSAPP_SCAN_STRICT:-0}"
+UV_BIN="${INBOX_UV_BIN:-/opt/homebrew/bin/uv}"
+if [[ ! -x "$UV_BIN" ]]; then
+  UV_BIN="$(command -v uv || true)"
+fi
+
+if [[ -z "$UV_BIN" ]]; then
+  echo "uv not found; leaving existing WhatsApp data in place." >&2
+  if [[ "$STRICT" == "1" ]]; then
+    exit 1
+  fi
+  exit 0
+fi
+
+if ! curl -fsS --max-time 2 "$CDP_URL/json/version" >/dev/null; then
+  scripts/open_whatsapp_scanner_browser.sh "$PORT" "$PROFILE_MODE" >/dev/null
+  sleep "${INBOX_WHATSAPP_BROWSER_START_DELAY:-10}"
+fi
+
+if ! curl -fsS --max-time 2 "$CDP_URL/json/version" >/dev/null; then
+  echo "WhatsApp scanner browser is not reachable at $CDP_URL; leaving existing data in place." >&2
+  if [[ "$STRICT" == "1" ]]; then
+    exit 1
+  fi
+  exit 0
+fi
+
+set +e
+"$UV_BIN" run python scripts/whatsapp_web_scanner.py \
+  --cdp-url "$CDP_URL" \
+  --idb \
+  --idb-limit "$IDB_LIMIT" \
+  --click-visible "$CLICK_VISIBLE" \
+  --scroll-pages "$SCROLL_PAGES" \
+  --sync-index
+status=$?
+set -e
+
+if [[ "$status" -eq 0 ]]; then
+  exit 0
+fi
+
+echo "WhatsApp scanner exited with $status; leaving existing data in place." >&2
+if [[ "$STRICT" == "1" ]]; then
+  exit "$status"
+fi
+exit 0

--- a/scripts/track_data_export_browser.py
+++ b/scripts/track_data_export_browser.py
@@ -24,6 +24,7 @@ from request_personal_data_exports import (  # noqa: E402
     DEFAULT_STATE_PATH,
     EXPORT_TARGETS,
     ExportTarget,
+    better_status,
     load_state,
     save_state,
 )
@@ -94,19 +95,6 @@ READY_TERMS = (
     "your google data is ready",
     "copy of your information is ready",
 )
-
-STATUS_RANK = {
-    "not_started": 0,
-    "opened_export_page": 1,
-    "browser_seen_export_page": 2,
-    "login_required_seen": 3,
-    "request_ui_seen": 4,
-    "request_submitted_seen": 5,
-    "request_submitted_manually": 6,
-    "confirmation_email_seen": 7,
-    "ready_ui_seen": 8,
-    "ready_email_seen": 9,
-}
 
 PROVIDER_HOSTS = {
     "linkedin": ("linkedin.com",),
@@ -397,10 +385,6 @@ def classify_status(page_data: dict[str, Any]) -> tuple[str, str]:
     if any(term in text for term in LOGIN_TERMS):
         return "login_required_seen", "login/verification language visible"
     return "browser_seen_export_page", "provider page visible"
-
-
-def better_status(old: str, new: str) -> str:
-    return new if STATUS_RANK.get(new, 0) >= STATUS_RANK.get(old, 0) else old
 
 
 def update_state_for_page(

--- a/scripts/watch_data_export_emails.py
+++ b/scripts/watch_data_export_emails.py
@@ -13,6 +13,9 @@ from pathlib import Path
 from typing import Any
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from request_personal_data_exports import better_status
 
 from inbox_client import InboxClient
 
@@ -20,6 +23,7 @@ DEFAULT_STATE_PATH = Path.home() / ".local/state/inbox/data-export-email-watch.j
 DEFAULT_ENV_PATH = Path.home() / ".config/raycast/inbox-workflows.env"
 EXPORT_QUERY = (
     '("ready to download" OR "ready for download" OR "Your data is ready for download" OR '
+    '"download request is complete" OR "download from Data & Privacy" OR '
     '"download your data" OR "data export" OR "Google data" OR "Takeout" OR '
     '"Archive of Google data scheduled" OR "Scheduled Archive of Google Data started" OR '
     '"preparing your data for download" OR '
@@ -58,6 +62,8 @@ READY_TERMS = (
     "available to download",
     "download your files",
     "download your information",
+    "download request is complete",
+    "download from data & privacy",
     "your google data is ready",
     "copy of your information is ready",
 )
@@ -189,19 +195,22 @@ def update_provider_status(state: dict[str, Any], hits: list[dict[str, str | boo
             continue
         provider = providers.setdefault(provider_key, {})
         new_status = classify_email_status(hit)
-        old_status = str(provider.get("status") or "")
-        if old_status == "ready_email_seen" and new_status != "ready_email_seen":
-            status = old_status
-        else:
-            status = new_status
-        provider.update(
-            {
-                "status": status,
-                "last_email_at": hit.get("timestamp") or "",
-                "last_email_title": hit.get("title") or "",
-                "last_email_snippet": hit.get("snippet") or "",
-            }
-        )
+        old_status = str(provider.get("status") or "not_started")
+        requested_at = str(provider.get("requested_at") or "")
+        hit_timestamp = str(hit.get("timestamp") or "")
+        if requested_at and hit_timestamp and hit_timestamp < requested_at:
+            continue
+        status = better_status(old_status, new_status)
+        provider["status"] = status
+        current_timestamp = str(provider.get("last_email_at") or "")
+        if status == new_status and hit_timestamp >= current_timestamp:
+            provider.update(
+                {
+                    "last_email_at": hit_timestamp,
+                    "last_email_title": hit.get("title") or "",
+                    "last_email_snippet": hit.get("snippet") or "",
+                }
+            )
         events = provider.setdefault("email_events", [])
         if isinstance(events, list):
             event = {
@@ -220,7 +229,11 @@ def update_provider_status(state: dict[str, Any], hits: list[dict[str, str | boo
 def find_export_emails(client: InboxClient, newer_than: str, limit: int) -> list[dict[str, Any]]:
     query = f"{EXPORT_QUERY} newer_than:{newer_than}"
     data = client.search(query, sources=["gmail"], limit=limit)
-    return [normalize_result(item, set()) for item in data.get("results", [])]
+    return filter_export_hits([normalize_result(item, set()) for item in data.get("results", [])])
+
+
+def filter_export_hits(hits: list[dict[str, str | bool]]) -> list[dict[str, str | bool]]:
+    return [hit for hit in hits if str(hit.get("provider") or "unknown") != "unknown"]
 
 
 def notify(hit_count: int) -> None:
@@ -251,7 +264,7 @@ def poll_once(
     seen = seen_ids_from_state(state)
     query = f"{EXPORT_QUERY} newer_than:{args.newer_than}"
     data = client.search(query, sources=["gmail"], limit=args.limit)
-    hits = [normalize_result(item, seen) for item in data.get("results", [])]
+    hits = filter_export_hits([normalize_result(item, seen) for item in data.get("results", [])])
     printable = hits if args.include_seen else [hit for hit in hits if hit["is_new"]]
     print_hits(printable, as_json=args.json)
 

--- a/scripts/whatsapp_desktop_backfill.py
+++ b/scripts/whatsapp_desktop_backfill.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+REPO_ROOT = SCRIPT_DIR.parent
+sys.path.insert(0, str(REPO_ROOT))
+sys.path.insert(0, str(SCRIPT_DIR))
+
+from whatsapp_web_scanner import default_db_path, run_index_sync, write_scan  # noqa: E402
+
+from services import (  # noqa: E402
+    whatsapp_accessibility_contacts,
+    whatsapp_accessibility_thread,
+    whatsapp_contacts_all,
+    whatsapp_thread_full,
+)
+
+
+def _message_id(chat_id: str, sender: str, body: str, ts: int) -> str:
+    basis = f"{chat_id}:{sender}:{body}:{ts}"
+    return "desktop:" + "".join(ch if ch.isalnum() or ch in "_.:-" else "_" for ch in basis)[:180]
+
+
+def build_scan(max_pages: int, max_chats: int, max_loads: int, limit: int) -> dict:
+    contacts = whatsapp_contacts_all(max_pages=max_pages)
+    if not contacts:
+        contacts = whatsapp_accessibility_contacts(limit=max_chats)
+    selected = contacts[:max_chats]
+    messages = []
+    chats = []
+    for contact in selected:
+        chat_id = contact.guid or contact.id or contact.name
+        chats.append(
+            {
+                "chatId": chat_id,
+                "name": contact.name,
+                "lastMessageTs": int(contact.last_ts.timestamp()) if contact.last_ts else 0,
+                "messageCount": 0,
+            }
+        )
+        if max_loads > 0:
+            thread = whatsapp_thread_full(contact.name, max_loads=max_loads, limit=limit)
+        else:
+            thread = whatsapp_accessibility_thread(contact.name, limit=limit)
+        for msg in thread:
+            ts = int(msg.ts.timestamp()) if msg.ts else 0
+            body = msg.body.strip()
+            if not body:
+                continue
+            messages.append(
+                {
+                    "chatId": chat_id,
+                    "messageId": _message_id(chat_id, msg.sender, body, ts),
+                    "sender": msg.sender,
+                    "senderJid": "",
+                    "fromMe": msg.is_me,
+                    "body": body,
+                    "timestamp": ts,
+                    "messageType": "chat",
+                    "source": "whatsapp-desktop-ax",
+                    "activeChatName": contact.name,
+                }
+            )
+    return {
+        "source": "whatsapp-desktop-ax",
+        "chats": chats,
+        "messages": messages,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Backfill WhatsApp Desktop visible chats via AX.")
+    parser.add_argument("--db", default="", help="Target whatsapp_data.db path.")
+    parser.add_argument("--account-id", default="brave-cdp")
+    parser.add_argument("--max-pages", type=int, default=10)
+    parser.add_argument("--max-chats", type=int, default=25)
+    parser.add_argument("--max-loads", type=int, default=0)
+    parser.add_argument("--limit", type=int, default=100)
+    parser.add_argument("--sync-index", action="store_true")
+    args = parser.parse_args()
+
+    db_path = Path(args.db).expanduser() if args.db else default_db_path()
+    scan = build_scan(args.max_pages, args.max_chats, args.max_loads, args.limit)
+    written = write_scan(db_path, scan, args.account_id)
+    if args.sync_index:
+        run_index_sync()
+    print(json.dumps({"db_path": str(db_path), **written}, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/whatsapp_store_census.py
+++ b/scripts/whatsapp_store_census.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from whatsapp_web_scanner import CdpConnection, find_whatsapp_page
+
+DEFAULT_STORES = (
+    ("model-storage", "message"),
+    ("model-storage", "message-history"),
+    ("model-storage", "peer-message"),
+    ("model-storage", "message-info"),
+    ("model-storage", "message-association"),
+    ("model-storage", "chat"),
+    ("model-storage", "contact"),
+    ("model-storage", "group-metadata"),
+    ("fts-storage", "fts-v3-index"),
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Inspect WhatsApp Web IndexedDB stores for available message fields."
+    )
+    parser.add_argument("--cdp-url", default="http://127.0.0.1:9223")
+    parser.add_argument("--sample-rows", type=int, default=20)
+    parser.add_argument("--output", default="")
+    return parser.parse_args()
+
+
+def census_expression(sample_rows: int) -> str:
+    targets = json.dumps(DEFAULT_STORES)
+    return f"""
+(async()=>{{
+  const targets = {targets};
+  const sampleRows = {max(int(sample_rows), 1)};
+  const openDb = (name) => new Promise((resolve, reject) => {{
+    const req = indexedDB.open(name);
+    req.onerror = () => reject(req.error || new Error('open failed '+name));
+    req.onsuccess = () => resolve(req.result);
+  }});
+  const safeStringify = (value) => {{
+    const seen = new WeakSet();
+    return JSON.stringify(value, (key, val) => {{
+      if (typeof val === 'bigint') return String(val);
+      if (val instanceof ArrayBuffer) {{
+        const bytes = Array.from(new Uint8Array(val).slice(0, 24));
+        return {{kind:'ArrayBuffer', len: val.byteLength, hex: bytes.map(b => b.toString(16).padStart(2,'0')).join('')}};
+      }}
+      if (val && typeof val === 'object') {{
+        if (seen.has(val)) return '[Circular]';
+        seen.add(val);
+      }}
+      return val;
+    }});
+  }};
+  const readRows = (db, storeName) => new Promise((resolve) => {{
+    if (!Array.from(db.objectStoreNames).includes(storeName)) {{
+      return resolve({{exists:false, count:null, rows:[]}});
+    }}
+    const rows=[];
+    let count=null;
+    const tx=db.transaction(storeName,'readonly');
+    const store=tx.objectStore(storeName);
+    const countReq=store.count();
+    countReq.onsuccess=()=>{{ count=countReq.result || 0; }};
+    const req=store.openCursor(null,'prev');
+    req.onerror=()=>resolve({{exists:true,count,rows,error:String(req.error)}});
+    req.onsuccess=()=>{{
+      const cursor=req.result;
+      if (!cursor || rows.length>=sampleRows) return resolve({{exists:true,count,rows}});
+      const value=cursor.value;
+      let text='';
+      try {{ text=safeStringify(value) || ''; }} catch(e) {{ text=String(value); }}
+      const strings = Array.from(new Set((text.match(/[A-Za-z0-9][^"\\\\]{{8,}}/g)||[])
+        .filter(s => !/^https?:/.test(s))
+        .slice(0,30)));
+      const keys = value && typeof value === 'object' ? Object.keys(value).slice(0,80) : [];
+      rows.push({{key:String(cursor.key), keys, size:text.length, strings}});
+      cursor.continue();
+    }};
+  }});
+  const out=[];
+  for (const [dbName, storeName] of targets) {{
+    try {{
+      const db=await openDb(dbName);
+      const info=await readRows(db, storeName);
+      db.close();
+      out.push({{dbName, storeName, ...info}});
+    }} catch(e) {{
+      out.push({{dbName, storeName, error:String(e)}});
+    }}
+  }}
+  return out;
+}})()
+"""
+
+
+def main() -> int:
+    args = parse_args()
+    page = find_whatsapp_page(args.cdp_url)
+    with CdpConnection(page.websocket_url, timeout=30) as conn:
+        result = conn.command(
+            "Runtime.evaluate",
+            {
+                "expression": census_expression(args.sample_rows),
+                "returnByValue": True,
+                "awaitPromise": True,
+            },
+        )
+    if result.get("exceptionDetails"):
+        print(json.dumps(result["exceptionDetails"], indent=2), file=sys.stderr)
+        return 1
+    value = result.get("result", {}).get("value") or []
+    if args.output:
+        Path(args.output).expanduser().write_text(json.dumps(value, indent=2))
+    print(json.dumps(value, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/whatsapp_web_scanner.py
+++ b/scripts/whatsapp_web_scanner.py
@@ -164,9 +164,38 @@ def idb_scan_expression(limit: int) -> str:
       cursor.continue();
     }};
   }});
-  const textField = (value) => {{
-    for (const field of ["body", "text", "caption", "displayText", "display", "messageText", "formattedText", "formattedBody"]) {{
-      const text = String(value && value[field] ? value[field] : "").trim();
+  const textFieldNames = [
+    "body",
+    "text",
+    "caption",
+    "displayText",
+    "display",
+    "messageText",
+    "formattedText",
+    "formattedBody",
+    "conversation",
+    "selectedDisplayText",
+    "matchedText",
+    "title",
+    "description",
+  ];
+  const textField = (value, seen = new Set(), depth = 0) => {{
+    if (!value || depth > 5) return "";
+    if (typeof value === "string") return value.trim();
+    if (typeof value !== "object") return "";
+    if (seen.has(value)) return "";
+    seen.add(value);
+    for (const field of textFieldNames) {{
+      const text = String(value[field] || "").trim();
+      if (text) return text;
+    }}
+    for (const field of ["message", "content", "quotedMsg", "quotedStanza", "extendedTextMessage", "pollCreationMessage"]) {{
+      const text = textField(value[field], seen, depth + 1);
+      if (text) return text;
+    }}
+    for (const nested of Object.values(value)) {{
+      if (!nested || typeof nested !== "object") continue;
+      const text = textField(nested, seen, depth + 1);
       if (text) return text;
     }}
     return "";
@@ -332,7 +361,7 @@ def evaluate_idb_scan(conn: CdpConnection, limit: int) -> dict[str, Any]:
     return value
 
 
-def click_visible_chat(conn: CdpConnection, index: int) -> None:
+def click_visible_chat(conn: CdpConnection, index: int) -> bool:
     expression = f"""
     (() => {{
       const rows = Array.from(document.querySelectorAll(
@@ -345,7 +374,25 @@ def click_visible_chat(conn: CdpConnection, index: int) -> None:
       return true;
     }})()
     """
-    conn.command("Runtime.evaluate", {"expression": expression, "returnByValue": True})
+    result = conn.command("Runtime.evaluate", {"expression": expression, "returnByValue": True})
+    return bool(result.get("result", {}).get("value"))
+
+
+def scroll_chat_list(conn: CdpConnection) -> bool:
+    expression = """
+    (() => {
+      const list =
+        document.querySelector('[aria-label="Chat list"]') ||
+        document.querySelector('div[role="grid"]') ||
+        document.querySelector('[data-testid="chat-list"]');
+      if (!list) return false;
+      const before = list.scrollTop;
+      list.scrollTop = before + Math.max(list.clientHeight || 700, 700);
+      return list.scrollTop !== before;
+    })()
+    """
+    result = conn.command("Runtime.evaluate", {"expression": expression, "returnByValue": True})
+    return bool(result.get("result", {}).get("value"))
 
 
 def init_db(db_path: Path) -> None:
@@ -405,10 +452,58 @@ MESSAGE_BODY_FIELDS = (
     "messageText",
     "formattedText",
     "formattedBody",
+    "conversation",
+    "selectedDisplayText",
+    "matchedText",
+    "title",
+    "description",
 )
 
 
 def message_body(message: dict[str, Any]) -> str:
+    nested_fields = (
+        "message",
+        "content",
+        "quotedMsg",
+        "quotedStanza",
+        "extendedTextMessage",
+        "pollCreationMessage",
+    )
+
+    def extract(value: Any, seen: set[int], depth: int) -> str:
+        if value is None or depth > 5:
+            return ""
+        if isinstance(value, str):
+            return value.strip()
+        if not isinstance(value, dict):
+            if isinstance(value, list | tuple):
+                for item in value:
+                    if not isinstance(item, dict | list | tuple):
+                        continue
+                    text = extract(item, seen, depth + 1)
+                    if text:
+                        return text
+            return ""
+        obj_id = id(value)
+        if obj_id in seen:
+            return ""
+        seen.add(obj_id)
+        for field in MESSAGE_BODY_FIELDS:
+            text = extract(value.get(field), seen, depth + 1)
+            if text:
+                return text
+        for field in nested_fields:
+            text = extract(value.get(field), seen, depth + 1)
+            if text:
+                return text
+        for item in value.values():
+            if not isinstance(item, dict | list | tuple):
+                continue
+            text = extract(item, seen, depth + 1)
+            if text:
+                return text
+        return ""
+
     for field in MESSAGE_BODY_FIELDS:
         value = message.get(field)
         if value is None:
@@ -416,7 +511,7 @@ def message_body(message: dict[str, Any]) -> str:
         text = str(value).strip()
         if text:
             return text
-    return ""
+    return extract(message, set(), 0)
 
 
 def stable_message_id(message: dict[str, Any]) -> str:
@@ -555,6 +650,12 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--click-visible", type=int, default=0, help="Click and scan the first N visible chats."
     )
+    parser.add_argument(
+        "--scroll-pages",
+        type=int,
+        default=0,
+        help="After each visible-click pass, scroll the chat list this many pages and scan again.",
+    )
     parser.add_argument("--delay", type=float, default=1.0, help="Delay after clicking a chat.")
     parser.add_argument(
         "--idb", action="store_true", help="Read WhatsApp Web's IndexedDB model-storage DB."
@@ -590,10 +691,17 @@ def main() -> int:
             print("WhatsApp Web is not paired yet. Pair the QR code in Brave, then rerun.")
             return 2
         scans = [first_scan]
-        for index in range(max(args.click_visible, 0)):
-            click_visible_chat(conn, index)
-            time.sleep(max(args.delay, 0))
-            scans.append(evaluate_scan(conn))
+        for page in range(max(args.scroll_pages, 0) + 1):
+            for index in range(max(args.click_visible, 0)):
+                if not click_visible_chat(conn, index):
+                    continue
+                time.sleep(max(args.delay, 0))
+                scans.append(evaluate_scan(conn))
+            if page < max(args.scroll_pages, 0):
+                if not scroll_chat_list(conn):
+                    break
+                time.sleep(max(args.delay, 0))
+                scans.append(evaluate_scan(conn))
         for scan in scans:
             written = write_scan(db_path, scan, args.account_id)
             total["chats"] += written["chats"]

--- a/scripts/whatsapp_web_scanner.py
+++ b/scripts/whatsapp_web_scanner.py
@@ -346,6 +346,13 @@ def evaluate_scan(conn: CdpConnection) -> dict[str, Any]:
     return value
 
 
+def try_evaluate_scan(conn: CdpConnection) -> dict[str, Any] | None:
+    try:
+        return evaluate_scan(conn)
+    except RuntimeError:
+        return None
+
+
 def evaluate_idb_scan(conn: CdpConnection, limit: int) -> dict[str, Any]:
     result = conn.command(
         "Runtime.evaluate",
@@ -370,12 +377,45 @@ def click_visible_chat(conn: CdpConnection, index: int) -> bool:
       const row = rows[{index}];
       if (!row) return false;
       row.scrollIntoView({{block: 'center'}});
-      row.click();
-      return true;
+      const rect = row.getBoundingClientRect();
+      return {{
+        x: rect.left + Math.min(Math.max(rect.width / 2, 24), rect.width - 8),
+        y: rect.top + Math.min(Math.max(rect.height / 2, 8), rect.height - 8),
+      }};
     }})()
     """
     result = conn.command("Runtime.evaluate", {"expression": expression, "returnByValue": True})
-    return bool(result.get("result", {}).get("value"))
+    point = result.get("result", {}).get("value")
+    if not isinstance(point, dict):
+        return False
+    x = float(point.get("x") or 0)
+    y = float(point.get("y") or 0)
+    if x <= 0 or y <= 0:
+        return False
+    conn.command("Input.dispatchMouseEvent", {"type": "mouseMoved", "x": x, "y": y})
+    conn.command(
+        "Input.dispatchMouseEvent",
+        {
+            "type": "mousePressed",
+            "x": x,
+            "y": y,
+            "button": "left",
+            "buttons": 1,
+            "clickCount": 1,
+        },
+    )
+    conn.command(
+        "Input.dispatchMouseEvent",
+        {
+            "type": "mouseReleased",
+            "x": x,
+            "y": y,
+            "button": "left",
+            "buttons": 0,
+            "clickCount": 1,
+        },
+    )
+    return True
 
 
 def scroll_chat_list(conn: CdpConnection) -> bool:
@@ -696,12 +736,16 @@ def main() -> int:
                 if not click_visible_chat(conn, index):
                     continue
                 time.sleep(max(args.delay, 0))
-                scans.append(evaluate_scan(conn))
+                scan = try_evaluate_scan(conn)
+                if scan:
+                    scans.append(scan)
             if page < max(args.scroll_pages, 0):
                 if not scroll_chat_list(conn):
                     break
                 time.sleep(max(args.delay, 0))
-                scans.append(evaluate_scan(conn))
+                scan = try_evaluate_scan(conn)
+                if scan:
+                    scans.append(scan)
         for scan in scans:
             written = write_scan(db_path, scan, args.account_id)
             total["chats"] += written["chats"]

--- a/services.py
+++ b/services.py
@@ -1360,6 +1360,41 @@ def gmail_compose_send(service, to: str, subject: str, body: str) -> bool:
         return False
 
 
+def gmail_create_draft(
+    service,
+    to: str,
+    subject: str,
+    body: str,
+    thread_id: str = "",
+) -> dict[str, str]:
+    """Create a Gmail draft without sending it."""
+    _assert_live_write_allowed("create Gmail draft")
+    msg = MIMEText(body)
+    msg["to"] = to
+    msg["subject"] = subject
+    raw = base64.urlsafe_b64encode(msg.as_bytes()).decode()
+    message: dict[str, str] = {"raw": raw}
+    if thread_id:
+        message["threadId"] = thread_id
+    try:
+        result = service.users().drafts().create(userId="me", body={"message": message}).execute()
+        drafted_message = result.get("message", {})
+        return {
+            "id": result.get("id", ""),
+            "message_id": drafted_message.get("id", ""),
+            "thread_id": drafted_message.get("threadId", thread_id),
+        }
+    except Exception:
+        _log_service_failure(
+            "gmail_create_draft",
+            to=to,
+            subject=subject,
+            body_length=len(body),
+            thread_id=thread_id,
+        )
+        return {}
+
+
 def gmail_reply(
     service,
     msg_id: str,
@@ -2537,13 +2572,27 @@ def _whatsapp_pid() -> int | None:
     Returns None if WhatsApp is not running or Objective-C imports fail.
     """
     try:
-        from Foundation import NSWorkspace
+        from AppKit import NSWorkspace
 
         ws = NSWorkspace.sharedWorkspace()
         apps = ws.runningApplications()
         for app in apps:
             if app.bundleIdentifier() == "net.whatsapp.WhatsApp":
                 return app.processIdentifier()
+    except Exception:
+        pass
+    try:
+        result = subprocess.run(
+            ["pgrep", "-f", "/Applications/WhatsApp.app/Contents/MacOS/WhatsApp"],
+            capture_output=True,
+            text=True,
+            timeout=2,
+            check=False,
+        )
+        for line in result.stdout.splitlines():
+            line = line.strip()
+            if line:
+                return int(line)
     except Exception:
         pass
     return None
@@ -2771,6 +2820,11 @@ def whatsapp_contacts(limit: int = 20) -> list[Contact]:
     return contacts[:limit]
 
 
+def whatsapp_accessibility_contacts(limit: int = 20) -> list[Contact]:
+    """List WhatsApp conversations from the live desktop Accessibility tree only."""
+    return _whatsapp_accessibility_tree()[:limit]
+
+
 def _whatsapp_select_chat(chat_name: str) -> bool:
     """Click the sidebar AXButton whose parsed name matches chat_name."""
     try:
@@ -2949,7 +3003,7 @@ def whatsapp_contacts_all(max_pages: int = 10) -> list[Contact]:
         seen: dict[str, Contact] = {}
         stagnant = 0
         for _ in range(max_pages):
-            for c in whatsapp_contacts(limit=200):
+            for c in whatsapp_accessibility_contacts(limit=200):
                 if c.name and c.name not in seen:
                     seen[c.name] = c
             before = len(seen)
@@ -2957,7 +3011,7 @@ def whatsapp_contacts_all(max_pages: int = 10) -> list[Contact]:
             if err != 0:
                 break
             time.sleep(0.3)
-            for c in whatsapp_contacts(limit=200):
+            for c in whatsapp_accessibility_contacts(limit=200):
                 if c.name and c.name not in seen:
                     seen[c.name] = c
             if len(seen) == before:
@@ -3079,6 +3133,11 @@ def whatsapp_thread(chat_name: str, limit: int = 50) -> list[Msg]:
     openhuman_messages = _openhuman_whatsapp_thread(chat_name, limit)
     if openhuman_messages:
         return openhuman_messages
+    return whatsapp_accessibility_thread(chat_name, limit=limit)
+
+
+def whatsapp_accessibility_thread(chat_name: str, limit: int = 50) -> list[Msg]:
+    """Fetch visible WhatsApp messages for a conversation from Accessibility only."""
     try:
         if not whatsapp_check_accessibility(prompt=False):
             return []

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -188,9 +188,65 @@ class TestClientMessages:
         call_args = client._client.get.call_args
         assert call_args[1]["params"]["thread_id"] == "t1"
 
+    def test_messages_with_account(self, client):
+        client._client.get.return_value = _mock_response([])
+        client.messages("gmail", "msg1", account="me@gmail.com")
+        call_args = client._client.get.call_args
+        assert call_args[1]["params"]["account"] == "me@gmail.com"
+
     def test_send(self, client):
         client._client.post.return_value = _mock_response({"ok": True})
         assert client.send("42", "imessage", "hello") is True
+
+
+class TestClientGmail:
+    def test_gmail_search(self, client):
+        client._client.get.return_value = _mock_response([{"message_id": "msg1"}])
+        result = client.gmail_search(q="invoice", account="me@gmail.com", limit=5)
+        assert result == [{"message_id": "msg1"}]
+        client._client.get.assert_called_once_with(
+            "/gmail/search",
+            params={
+                "q": "invoice",
+                "limit": 5,
+                "label": "",
+                "account": "me@gmail.com",
+                "from_filter": "",
+                "subject_filter": "",
+                "after": "",
+                "before": "",
+            },
+        )
+
+    def test_gmail_thread(self, client):
+        client._client.get.return_value = _mock_response([{"message_id": "msg1"}])
+        result = client.gmail_thread("msg1", thread_id="thread1", account="me@gmail.com")
+        assert result == [{"message_id": "msg1"}]
+        client._client.get.assert_called_once_with(
+            "/messages/gmail/msg1",
+            params={"limit": 50, "thread_id": "thread1", "account": "me@gmail.com"},
+        )
+
+    def test_gmail_create_draft(self, client):
+        client._client.post.return_value = _mock_response({"ok": True, "draft_id": "draft1"})
+        result = client.gmail_create_draft(
+            "alice@example.com",
+            "Hello",
+            "Draft body",
+            account="me@gmail.com",
+            thread_id="thread1",
+        )
+        assert result["draft_id"] == "draft1"
+        client._client.post.assert_called_once_with(
+            "/messages/gmail/drafts",
+            json={
+                "to": "alice@example.com",
+                "subject": "Hello",
+                "body": "Draft body",
+                "account": "me@gmail.com",
+                "thread_id": "thread1",
+            },
+        )
 
 
 # ── Calendar ────────────────────────────────────────────────────────────────

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -163,6 +163,15 @@ class TestClientIndexedInbox:
             params={"limit": 8, "workflow": "job_hunt", "account": "me@gmail.com"},
         )
 
+    def test_command_center(self, client):
+        client._client.get.return_value = _mock_response({"queues": [], "source_coverage": []})
+        result = client.command_center(workflow="job_hunt", account="me@gmail.com", limit=6)
+        assert result == {"queues": [], "source_coverage": []}
+        client._client.get.assert_called_once_with(
+            "/inbox/command-center",
+            params={"limit": 6, "workflow": "job_hunt", "account": "me@gmail.com"},
+        )
+
 
 # ── Messages ────────────────────────────────────────────────────────────────
 

--- a/tests/test_data_exports.py
+++ b/tests/test_data_exports.py
@@ -1,0 +1,412 @@
+from __future__ import annotations
+
+from argparse import Namespace
+
+from scripts import open_ready_export_links, request_personal_data_exports
+from scripts import track_data_export_browser as browser_tracker
+from scripts import watch_data_export_emails as email_watch
+
+
+def provider_by_key(model: dict, key: str) -> dict:
+    return next(provider for provider in model["providers"] if provider["key"] == key)
+
+
+def test_status_model_normalizes_existing_state_without_migration():
+    state = {
+        "updated_at": "2026-05-27T10:00:00",
+        "providers": {
+            "github": {
+                "status": "ready_email_seen",
+                "opened_at": "2026-05-27T09:00:00",
+                "requested_at": "2026-05-27T09:05:00",
+                "last_email_at": "2026-05-27T09:30:00",
+                "last_email_title": "Your data export is ready to download",
+                "email_events": [{"id": "m1"}],
+            }
+        },
+    }
+
+    model = request_personal_data_exports.build_status_model(state)
+    github = provider_by_key(model, "github")
+    linkedin = provider_by_key(model, "linkedin")
+
+    assert model["schema"] == "inbox.data_exports.status.v1"
+    assert github["stage"] == "ready"
+    assert github["ready"] == {"ready_at": "2026-05-27T09:30:00", "source": "email"}
+    assert github["manual_boundary"] == "open_download_link_manually"
+    assert linkedin["status"] == "not_started"
+    assert linkedin["manual_boundary"] == "open_request_page"
+
+
+def test_email_watch_promotes_confirmation_then_ready_without_downgrade():
+    state = {"providers": {"github": {"status": "request_submitted_manually"}}}
+    email_watch.update_provider_status(
+        state,
+        [
+            {
+                "id": "m1",
+                "provider": "github",
+                "timestamp": "2026-05-27T10:00:00",
+                "title": "Your data export is ready to download",
+                "snippet": "Archive is ready.",
+                "is_new": True,
+            },
+            {
+                "id": "m2",
+                "provider": "github",
+                "timestamp": "2026-05-27T09:00:00",
+                "title": "Request received",
+                "snippet": "We are preparing your export.",
+                "is_new": True,
+            },
+        ],
+    )
+
+    provider = state["providers"]["github"]
+    assert provider["status"] == "ready_email_seen"
+    assert [event["id"] for event in provider["email_events"]] == ["m1", "m2"]
+
+
+def test_email_watch_preserves_ready_metadata_when_later_email_is_downgrade():
+    state = {
+        "providers": {
+            "github": {
+                "status": "ready_email_seen",
+                "last_email_at": "2026-05-27T10:00:00",
+                "last_email_title": "Your data export is ready to download",
+                "last_email_snippet": "Archive is ready.",
+            }
+        }
+    }
+
+    email_watch.update_provider_status(
+        state,
+        [
+            {
+                "id": "m2",
+                "provider": "github",
+                "timestamp": "2026-05-27T11:00:00",
+                "title": "Request received",
+                "snippet": "We are preparing your export.",
+                "is_new": True,
+            }
+        ],
+    )
+
+    provider = state["providers"]["github"]
+    assert provider["status"] == "ready_email_seen"
+    assert provider["last_email_at"] == "2026-05-27T10:00:00"
+    assert provider["last_email_title"] == "Your data export is ready to download"
+    assert provider["last_email_snippet"] == "Archive is ready."
+    assert provider["email_events"][0]["status"] == "confirmation_email_seen"
+
+
+def test_email_watch_keeps_newest_ready_metadata():
+    state = {"providers": {"apple": {"status": "confirmation_email_seen"}}}
+
+    email_watch.update_provider_status(
+        state,
+        [
+            {
+                "id": "newer",
+                "provider": "apple",
+                "timestamp": "2026-05-24T16:47:34",
+                "title": "Your download request is complete.",
+                "snippet": "The data download you requested is now complete.",
+                "is_new": True,
+            },
+            {
+                "id": "older",
+                "provider": "apple",
+                "timestamp": "2026-05-17T13:21:04",
+                "title": "Your download request is complete.",
+                "snippet": "The data download you requested is now complete.",
+                "is_new": True,
+            },
+        ],
+    )
+
+    provider = state["providers"]["apple"]
+    assert provider["status"] == "ready_email_seen"
+    assert provider["last_email_at"] == "2026-05-24T16:47:34"
+    assert provider["last_email_title"] == "Your download request is complete."
+
+
+def test_email_watch_filters_unknown_resume_export_noise():
+    hits = [
+        {
+            "id": "resume",
+            "provider": "unknown",
+            "timestamp": "2026-05-27T19:32:26",
+            "title": "Forward Deployed Engineer - Jwalin Shah",
+            "snippet": "Forward Deployed Engineer - Jwalin Shah",
+            "is_new": True,
+        },
+        {
+            "id": "linkedin",
+            "provider": "linkedin",
+            "timestamp": "2026-05-27T20:00:00",
+            "title": "Your LinkedIn data archive is ready",
+            "snippet": "Download your archive.",
+            "is_new": True,
+        },
+    ]
+
+    filtered = email_watch.filter_export_hits(hits)
+
+    assert [hit["id"] for hit in filtered] == ["linkedin"]
+
+
+def test_email_watch_ignores_ready_email_from_prior_request_cycle():
+    state = {
+        "providers": {
+            "linkedin": {
+                "status": "request_submitted_manually",
+                "requested_at": "2026-05-27T20:41:29",
+            }
+        }
+    }
+
+    email_watch.update_provider_status(
+        state,
+        [
+            {
+                "id": "old-ready",
+                "provider": "linkedin",
+                "timestamp": "2026-05-11T22:41:07",
+                "title": "The first installment of your LinkedIn data archive is ready!",
+                "snippet": "Download your archive.",
+                "is_new": False,
+            }
+        ],
+    )
+
+    provider = state["providers"]["linkedin"]
+    assert provider["status"] == "request_submitted_manually"
+    assert "last_email_at" not in provider
+
+
+def test_browser_tracker_records_request_ui_but_preserves_ready_state():
+    state = {"providers": {"linkedin": {"status": "ready_email_seen"}}}
+    page = browser_tracker.BrowserPage(
+        target_id="tab-1",
+        websocket_url="ws://127.0.0.1/devtools/page/1",
+        url="https://www.linkedin.com/mypreferences/d/download-my-data",
+        title="Download your data",
+    )
+
+    browser_tracker.update_state_for_page(
+        state,
+        "linkedin",
+        page,
+        {
+            "href": page.url,
+            "title": page.title,
+            "htmlLength": 100,
+        },
+        "request_ui_seen",
+        "export request controls visible",
+    )
+
+    provider = state["providers"]["linkedin"]
+    assert provider["status"] == "ready_email_seen"
+    assert provider["last_browser_signal"] == "export request controls visible"
+
+
+def test_mark_opened_and_requested_do_not_downgrade_ready_state(tmp_path):
+    state_path = tmp_path / "exports.json"
+    target = next(
+        target for target in request_personal_data_exports.EXPORT_TARGETS if target.key == "github"
+    )
+    state_path.write_text(
+        """
+{
+  "providers": {
+    "github": {
+      "status": "ready_email_seen",
+      "last_email_at": "2026-05-27T10:00:00",
+      "last_email_title": "Your data export is ready to download"
+    }
+  }
+}
+""".strip()
+    )
+
+    request_personal_data_exports.mark_opened(state_path, [target])
+    request_personal_data_exports.mark_requested(state_path, [target])
+
+    state = request_personal_data_exports.load_state(state_path)
+    provider = state["providers"]["github"]
+    assert provider["status"] == "ready_email_seen"
+    assert provider["opened_count"] == 1
+    assert provider["opened_at"]
+    assert provider["requested_at"]
+    assert provider["last_email_at"] == "2026-05-27T10:00:00"
+
+
+def test_open_ready_links_records_download_as_terminal_processor_state(tmp_path):
+    state_path = tmp_path / "exports.json"
+    open_ready_export_links.update_state(
+        state_path,
+        [
+            {
+                "provider": "claude",
+                "message_id": "msg-1",
+                "subject": "Your data is ready for download",
+                "domain": "claude.ai",
+                "url": "https://claude.ai/download/export",
+            }
+        ],
+        tmp_path / "downloads",
+    )
+
+    state = request_personal_data_exports.load_state(state_path)
+    provider = state["providers"]["claude"]
+    model = request_personal_data_exports.build_status_model(state)
+    claude = provider_by_key(model, "claude")
+
+    assert provider["status"] == "download_link_opened"
+    assert claude["stage"] == "download"
+    assert claude["download"]["event_count"] == 1
+
+
+def test_open_ready_links_can_render_private_download_checklist(tmp_path):
+    output_path = tmp_path / "ready-links.md"
+    download_dir = tmp_path / "downloads"
+
+    open_ready_export_links.write_links(
+        output_path,
+        [
+            {
+                "provider": "github",
+                "message_id": "msg-1",
+                "subject": "[GitHub] Your data export is ready to download",
+                "domain": "github.com",
+                "url": "https://github.com/settings/migration/download?token=secret",
+            }
+        ],
+        download_dir,
+    )
+
+    text = output_path.read_text()
+    assert "Personal Data Export Download Links" in text
+    assert str(download_dir) in text
+    assert "https://github.com/settings/migration/download?token=secret" in text
+    assert "- Done: [ ] downloaded into `_downloads`" in text
+
+
+def test_request_script_default_path_is_read_only(monkeypatch, tmp_path, capsys):
+    monkeypatch.setattr(
+        request_personal_data_exports,
+        "parse_args",
+        lambda: Namespace(
+            providers=["github"],
+            all=False,
+            priority=False,
+            list=False,
+            status=False,
+            json=False,
+            state_path=str(tmp_path / "exports.json"),
+            dry_run=False,
+            open=False,
+            record_only=False,
+            mark_requested=False,
+            delay=0,
+            via_cdp=False,
+            cdp_url="http://127.0.0.1:9222",
+        ),
+    )
+    opened: list[str] = []
+    monkeypatch.setattr(request_personal_data_exports.webbrowser, "open_new_tab", opened.append)
+
+    assert request_personal_data_exports.main() == 0
+
+    assert opened == []
+    assert "Dry run only" in capsys.readouterr().out
+
+
+def test_mark_expired_reopens_provider_request_lane(tmp_path):
+    state_path = tmp_path / "exports.json"
+    target = next(
+        target for target in request_personal_data_exports.EXPORT_TARGETS if target.key == "openai"
+    )
+    state_path.write_text(
+        """
+{
+  "providers": {
+    "openai": {
+      "status": "download_link_opened",
+      "last_download_opened_at": "2026-05-27T10:00:00",
+      "download_dir": "/tmp/downloads"
+    }
+  }
+}
+""".strip()
+    )
+
+    request_personal_data_exports.mark_expired(state_path, [target], "old signed link expired")
+
+    model = request_personal_data_exports.build_status_model(
+        request_personal_data_exports.load_state(state_path)
+    )
+    openai = provider_by_key(model, "openai")
+
+    assert openai["status"] == "download_link_expired"
+    assert openai["stage"] == "request"
+    assert openai["manual_boundary"] == "re_request_export_in_browser"
+    assert openai["download"]["expired_reason"] == "old signed link expired"
+
+
+def test_mark_requested_starts_new_cycle_after_expired_download_link(tmp_path):
+    state_path = tmp_path / "exports.json"
+    target = next(
+        target
+        for target in request_personal_data_exports.EXPORT_TARGETS
+        if target.key == "linkedin"
+    )
+    state_path.write_text(
+        """
+{
+  "providers": {
+    "linkedin": {
+      "status": "download_link_expired",
+      "last_download_expired_at": "2026-05-27T10:00:00",
+      "download_expired_reason": "old signed link expired"
+    }
+  }
+}
+""".strip()
+    )
+
+    request_personal_data_exports.mark_requested(state_path, [target])
+
+    model = request_personal_data_exports.build_status_model(
+        request_personal_data_exports.load_state(state_path)
+    )
+    linkedin = provider_by_key(model, "linkedin")
+
+    assert linkedin["status"] == "request_submitted_manually"
+    assert linkedin["stage"] == "status"
+    assert linkedin["manual_boundary"] == "wait_for_ready_email_or_status"
+    assert linkedin["download"]["expired_at"] == ""
+    assert linkedin["download"]["expired_reason"] == ""
+
+
+def test_status_model_treats_old_ready_email_as_prior_request_cycle():
+    state = {
+        "providers": {
+            "linkedin": {
+                "status": "ready_email_seen",
+                "requested_at": "2026-05-27T20:41:29",
+                "last_email_at": "2026-05-11T22:41:07",
+                "last_email_title": "The first installment of your LinkedIn data archive is ready!",
+            }
+        }
+    }
+
+    model = request_personal_data_exports.build_status_model(state)
+    linkedin = provider_by_key(model, "linkedin")
+
+    assert linkedin["status"] == "request_submitted_manually"
+    assert linkedin["stage"] == "status"
+    assert linkedin["manual_boundary"] == "wait_for_ready_email_or_status"

--- a/tests/test_import_wacli_to_openhuman.py
+++ b/tests/test_import_wacli_to_openhuman.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import importlib.util
+import sqlite3
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "import_wacli_to_openhuman.py"
+SPEC = importlib.util.spec_from_file_location("import_wacli_to_openhuman", SCRIPT)
+assert SPEC and SPEC.loader
+import_wacli = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(import_wacli)
+
+
+def create_wacli_db(path: Path) -> None:
+    with sqlite3.connect(path) as conn:
+        conn.executescript(
+            """
+            CREATE TABLE chats (
+                jid TEXT PRIMARY KEY,
+                kind TEXT NOT NULL,
+                name TEXT,
+                last_message_ts INTEGER
+            );
+            CREATE TABLE messages (
+                chat_jid TEXT NOT NULL,
+                chat_name TEXT,
+                msg_id TEXT NOT NULL,
+                sender_jid TEXT,
+                sender_name TEXT,
+                ts INTEGER,
+                from_me INTEGER,
+                text TEXT,
+                display_text TEXT,
+                media_type TEXT,
+                media_caption TEXT,
+                filename TEXT
+            );
+            INSERT INTO chats VALUES ('123@s.whatsapp.net', 'dm', 'Nitin', 100);
+            INSERT INTO messages VALUES (
+                '123@s.whatsapp.net', 'Nitin', 'm1', '123@s.whatsapp.net', 'Nitin',
+                100, 0, 'real body', '(message)', '', '', ''
+            );
+            INSERT INTO messages VALUES (
+                '123@s.whatsapp.net', 'Nitin', 'm2', 'me', 'me',
+                101, 1, '', '(message)', '', '', ''
+            );
+            INSERT INTO messages VALUES (
+                '123@s.whatsapp.net', 'Nitin', 'm3', 'me', 'me',
+                102, 1, '', 'Sent image', 'image', '', ''
+            );
+            """
+        )
+
+
+def test_import_wacli_upserts_chats_and_filters_placeholders(tmp_path: Path):
+    source_db = tmp_path / "wacli.db"
+    dest_db = tmp_path / "whatsapp_data.db"
+    create_wacli_db(source_db)
+
+    stats = import_wacli.import_wacli(source_db, dest_db, account_id="wacli-test", dry_run=False)
+
+    assert stats == {
+        "source_chats": 1,
+        "source_messages": 3,
+        "source_text_messages": 2,
+        "dry_run": 0,
+    }
+    with sqlite3.connect(dest_db) as conn:
+        chat = conn.execute("SELECT account_id, chat_id, display_name FROM wa_chats").fetchone()
+        bodies = conn.execute(
+            "SELECT message_id, body, message_type FROM wa_messages ORDER BY message_id"
+        ).fetchall()
+
+    assert chat == ("wacli-test", "123@s.whatsapp.net", "Nitin")
+    assert bodies == [
+        ("m1", "real body", "chat"),
+        ("m2", "", "chat"),
+        ("m3", "Sent image", "image"),
+    ]

--- a/tests/test_inbox_app.py
+++ b/tests/test_inbox_app.py
@@ -18,10 +18,12 @@ from inbox import (
     InboxApp,
     MessageView,
     NotificationItem,
+    OpsQueueItem,
     ReminderItem,
     SearchResultItem,
     SearchScreen,
 )
+from ops_brain import load_ops_queue_rows, ops_brain_status
 
 
 class HarnessInboxApp(InboxApp):
@@ -79,6 +81,37 @@ def _make_index_health(
         "reasons": reasons or [],
         "sync_states": [],
     }
+
+
+def _make_source_coverage() -> list[dict]:
+    return [
+        {
+            "source": "gmail",
+            "account": "j@example.com",
+            "item_count": 12,
+            "thread_count": 5,
+            "latest_item_at": "2026-05-10T12:00:00+00:00",
+            "last_success_at": "2026-05-10T12:05:00+00:00",
+            "last_success_age_seconds": 60,
+            "status": "ok",
+            "healthy": True,
+            "stale": False,
+            "reasons": [],
+        },
+        {
+            "source": "linkedin",
+            "account": "",
+            "item_count": 0,
+            "thread_count": 0,
+            "latest_item_at": "",
+            "last_success_at": "",
+            "last_success_age_seconds": None,
+            "status": "missing",
+            "healthy": False,
+            "stale": True,
+            "reasons": ["no_sync_state"],
+        },
+    ]
 
 
 def test_poll_interval_reads_env_override(monkeypatch) -> None:
@@ -2135,7 +2168,7 @@ def test_collect_auxiliary_data_prefers_command_center() -> None:
         "waiting_threads": [{"thread_id": "wait-1"}],
         "index_health": _make_index_health(),
         "queues": [],
-        "source_coverage": [],
+        "source_coverage": _make_source_coverage(),
     }
 
     app = _make_app(client)
@@ -2145,10 +2178,39 @@ def test_collect_auxiliary_data_prefers_command_center() -> None:
     assert snapshot.actionable_threads == [{"thread_id": "action-1"}]
     assert snapshot.waiting_threads == [{"thread_id": "wait-1"}]
     assert snapshot.index_health == _make_index_health()
+    assert snapshot.source_coverage == _make_source_coverage()
     client.command_center.assert_called_once_with(limit=20)
     client.inbox_now.assert_not_called()
     client.index_health.assert_not_called()
     client.index_view.assert_not_called()
+
+
+def test_collect_poll_data_marks_changed_when_source_coverage_changes() -> None:
+    client = MagicMock()
+    client.conversations.return_value = []
+    client.calendar_events.return_value = []
+    client.notes.return_value = []
+    client.reminders.return_value = []
+    client.reminder_lists.return_value = []
+    client.github_notifications.return_value = []
+    client.command_center.return_value = {
+        "now_items": [],
+        "actionable_threads": [],
+        "waiting_threads": [],
+        "index_health": _make_index_health(),
+        "source_coverage": _make_source_coverage(),
+    }
+
+    app = _make_app(client)
+    app.conversations = []
+    app.index_health = _make_index_health()
+    app.source_coverage = []
+
+    snapshot = app._collect_poll_data()
+
+    assert snapshot.changed is True
+    assert snapshot.source_coverage == _make_source_coverage()
+    client.command_center.assert_called_once_with(limit=20)
 
 
 def test_collect_poll_data_marks_changed_when_index_health_changes() -> None:
@@ -2237,6 +2299,67 @@ def test_indexed_tabs_show_index_health_state(
                 assert expected in _sidebar_text(app)
 
     asyncio.run(runner())
+
+
+def test_health_tab_renders_command_center_source_coverage() -> None:
+    async def runner() -> None:
+        app = _make_app(MagicMock())
+        app.source_coverage = _make_source_coverage()
+        app.capture_health = {"healthy": True, "summary": {"ok": 0, "total": 0}, "sources": []}
+
+        async with app.run_test() as pilot:
+            app._active_filter = "health"
+            app._render_sidebar()
+            await pilot.pause()
+
+            sidebar = _sidebar_text(app)
+            assert "Source coverage 1/2 current" in sidebar
+            assert "Gmail" in sidebar
+            assert "12 items" in sidebar
+            assert "5 threads" in sidebar
+            assert "LinkedIn" in sidebar
+            assert "no sync state" in sidebar
+            assert "1/2 coverage current" in _status_text(app)
+            assert "1 sync gap" in _status_text(app)
+
+    asyncio.run(runner())
+
+
+def test_source_coverage_selection_shows_sync_gap_detail() -> None:
+    async def runner() -> None:
+        app = _make_app(MagicMock())
+        app.source_coverage = _make_source_coverage()
+
+        async with app.run_test() as pilot:
+            app._active_filter = "health"
+            app._render_sidebar()
+            await pilot.pause()
+            lv = app.query_one("#contact-list", ListView)
+
+            class _Event:
+                item = lv.children[2]
+
+            app.on_item_selected(_Event())
+
+            detail = app.query_one("#detail-view", DetailView).detail
+            assert detail == _make_source_coverage()[1]
+            assert "source coverage" in _status_text(app)
+
+    asyncio.run(runner())
+
+
+def test_detail_view_renders_source_coverage_sync_gaps() -> None:
+    detail = DetailView()
+    detail.detail = _make_source_coverage()[1]
+
+    children = list(detail.compose())
+
+    assert len(children) == 1
+    text = str(children[0].content)
+    assert "LinkedIn coverage" in text
+    assert "Threads indexed: 0" in text
+    assert "Stale reasons / sync gaps" in text
+    assert "no sync state" in text
 
 
 def test_collect_auxiliary_data_github_failure_preserves_old() -> None:
@@ -2647,6 +2770,50 @@ def test_drive_tab_empty_state() -> None:
             await pilot.pause(0.5)
             status_text = _status_text(app)
             assert "0 files" in status_text
+
+    asyncio.run(runner())
+
+
+def test_ops_brain_loads_local_reconciliation_queues(tmp_path, monkeypatch) -> None:
+    reconciliation = tmp_path / "reconciliation"
+    reconciliation.mkdir()
+    (reconciliation / "connector_gmail_evidence_queue.csv").write_text(
+        "priority,lane,subject,evidence_role,candidate_action\n"
+        "P0,insurance,Claim thread,Active claim,Read and promote source-backed action\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("OPS_KERNEL_PATH", str(tmp_path))
+
+    rows = load_ops_queue_rows()
+    status = ops_brain_status()
+
+    assert rows[0]["_ops_queue_id"] == "connector_gmail"
+    assert rows[0]["_ops_title"] == "Claim thread"
+    assert status["queue_rows"] == 1
+    assert (
+        status["provider_policy"] == "providers are replaceable adapters; local ledgers are truth"
+    )
+
+
+def test_ops_tab_shows_local_queue_rows(tmp_path, monkeypatch) -> None:
+    async def runner() -> None:
+        reconciliation = tmp_path / "reconciliation"
+        reconciliation.mkdir()
+        (reconciliation / "connector_gmail_evidence_queue.csv").write_text(
+            "priority,lane,subject,evidence_role,candidate_action\n"
+            "P0,stanford,Itemized bill,Itemized bill evidence,Review attachment\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("OPS_KERNEL_PATH", str(tmp_path))
+        app = _make_app(MagicMock())
+
+        async with app.run_test() as pilot:
+            app.action_filter_ops()
+            await pilot.pause(0.5)
+            assert app._active_filter == "ops"
+            assert "ops rows" in _status_text(app)
+            lv = app.query_one("#contact-list", ListView)
+            assert any(isinstance(child, OpsQueueItem) for child in lv.children)
 
     asyncio.run(runner())
 

--- a/tests/test_inbox_app.py
+++ b/tests/test_inbox_app.py
@@ -2122,6 +2122,35 @@ def test_collect_auxiliary_data_uses_inbox_now_brief_and_surfaces_index_health()
     client.index_view.assert_not_called()
 
 
+def test_collect_auxiliary_data_prefers_command_center() -> None:
+    client = MagicMock()
+    client.calendar_events.return_value = []
+    client.notes.return_value = []
+    client.reminders.return_value = []
+    client.reminder_lists.return_value = []
+    client.github_notifications.return_value = []
+    client.command_center.return_value = {
+        "now_items": [{"now_kind": "thread", "thread_id": "now-1", "title": "Reply"}],
+        "actionable_threads": [{"thread_id": "action-1"}],
+        "waiting_threads": [{"thread_id": "wait-1"}],
+        "index_health": _make_index_health(),
+        "queues": [],
+        "source_coverage": [],
+    }
+
+    app = _make_app(client)
+    snapshot = app._collect_auxiliary_data()
+
+    assert snapshot.now_threads == [{"now_kind": "thread", "thread_id": "now-1", "title": "Reply"}]
+    assert snapshot.actionable_threads == [{"thread_id": "action-1"}]
+    assert snapshot.waiting_threads == [{"thread_id": "wait-1"}]
+    assert snapshot.index_health == _make_index_health()
+    client.command_center.assert_called_once_with(limit=20)
+    client.inbox_now.assert_not_called()
+    client.index_health.assert_not_called()
+    client.index_view.assert_not_called()
+
+
 def test_collect_poll_data_marks_changed_when_index_health_changes() -> None:
     client = MagicMock()
     client.conversations.return_value = []

--- a/tests/test_message_index_store.py
+++ b/tests/test_message_index_store.py
@@ -471,3 +471,57 @@ def test_set_sync_state_is_idempotent(tmp_path):
     assert len(states) == 1
     assert states[0]["checkpoint_value"] == "12345"
     assert states[0]["metadata"] == metadata
+
+
+def test_source_counts_groups_index_items_by_source_and_account(tmp_path):
+    store = MessageIndexStore(tmp_path / "index.sqlite3")
+    store.upsert_item(
+        _item(
+            source="gmail",
+            account="a@example.com",
+            external_id="m1",
+            thread_id="t1",
+            sender="Recruiter",
+            subject="Interview",
+            created_at="2026-04-18T00:00:00+00:00",
+        )
+    )
+    store.upsert_item(
+        _item(
+            source="gmail",
+            account="a@example.com",
+            external_id="m2",
+            thread_id="t1",
+            sender="Me",
+            subject="Re: Interview",
+            created_at="2026-04-19T00:00:00+00:00",
+        )
+    )
+    store.upsert_item(
+        _item(
+            source="linkedin",
+            account="brave-cdp",
+            external_id="li1",
+            thread_id="lt1",
+            sender="Founder",
+            subject="Robotics role",
+            created_at="2026-04-20T00:00:00+00:00",
+        )
+    )
+
+    assert store.source_counts() == [
+        {
+            "source": "gmail",
+            "account": "a@example.com",
+            "item_count": 2,
+            "thread_count": 1,
+            "latest_item_at": "2026-04-19T00:00:00+00:00",
+        },
+        {
+            "source": "linkedin",
+            "account": "brave-cdp",
+            "item_count": 1,
+            "thread_count": 1,
+            "latest_item_at": "2026-04-20T00:00:00+00:00",
+        },
+    ]

--- a/tests/test_message_index_store.py
+++ b/tests/test_message_index_store.py
@@ -63,6 +63,60 @@ def test_upsert_item_replaces_existing_row(tmp_path):
     assert rows[0]["latest_subject"] == "Updated subject"
 
 
+def test_list_threads_filters_by_source_and_account(tmp_path):
+    store = MessageIndexStore(tmp_path / "index.sqlite3")
+    store.upsert_item(
+        _item(
+            source="imessage",
+            account="local",
+            external_id="im1",
+            thread_id="chat-1",
+            sender="+15551234567",
+            body="Indexed iMessage",
+        )
+    )
+    store.upsert_item(
+        _item(
+            source="gmail",
+            account="me@example.com",
+            external_id="gm1",
+            thread_id="thread-1",
+            sender="sender@example.com",
+            subject="Email",
+        )
+    )
+    store.rebuild_threads()
+
+    rows = store.list_threads(limit=5, source="imessage", account="local")
+
+    assert [row["thread_id"] for row in rows] == ["chat-1"]
+
+
+def test_list_thread_items_returns_recent_items_chronologically(tmp_path):
+    store = MessageIndexStore(tmp_path / "index.sqlite3")
+    for idx in range(3):
+        store.upsert_item(
+            _item(
+                source="whatsapp",
+                account="brave-cdp",
+                external_id=f"wa-{idx}",
+                thread_id="chat-1",
+                sender="Me" if idx == 2 else "Alex",
+                body=f"Message {idx}",
+                created_at=f"2026-04-18T0{idx}:00:00+00:00",
+            )
+        )
+
+    rows = store.list_thread_items(
+        source="whatsapp",
+        account="brave-cdp",
+        thread_id="chat-1",
+        limit=2,
+    )
+
+    assert [row["external_id"] for row in rows] == ["wa-1", "wa-2"]
+
+
 def test_rebuild_threads_marks_human_reply_as_actionable(tmp_path):
     store = MessageIndexStore(tmp_path / "index.sqlite3")
     store.upsert_item(

--- a/tests/test_message_sync.py
+++ b/tests/test_message_sync.py
@@ -595,6 +595,36 @@ def test_sync_imessage_bootstrap_advances_checkpoint_for_skipped_rows(tmp_path, 
     assert state["checkpoint_value"] == "2"
 
 
+def test_sync_imessage_incremental_can_be_disabled_for_sandboxed_runners(tmp_path, monkeypatch):
+    store = MessageIndexStore(tmp_path / "index.sqlite3")
+    store.set_sync_state(
+        source="imessage",
+        account="local",
+        checkpoint_type="rowid",
+        checkpoint_value="42",
+        full_sync=False,
+        status="error",
+        last_error="unable to open database file",
+        metadata={},
+    )
+    monkeypatch.setenv("INBOX_DISABLE_IMESSAGE_SYNC", "1")
+    monkeypatch.setattr(
+        message_sync,
+        "_imessage_messages_after",
+        lambda _last_rowid: (_ for _ in ()).throw(AssertionError("should not read chat.db")),
+    )
+
+    stats = message_sync.sync_imessage_incremental(store)
+
+    assert stats == {"local": 0}
+    state = store.get_sync_state("imessage", "local")
+    assert state is not None
+    assert state["status"] == "idle"
+    assert state["last_error"] == ""
+    assert state["checkpoint_value"] == "42"
+    assert state["metadata"]["disabled"] is True
+
+
 def _create_openhuman_whatsapp_db(db_path):
     db_path.parent.mkdir(parents=True)
     conn = sqlite3.connect(db_path)
@@ -948,6 +978,44 @@ def test_incremental_rebuilds_only_changed_imessage_scope(tmp_path, monkeypatch)
     assert changed_imessage["latest_external_id"] == "imsg-2"
     assert changed_imessage["latest_subject"] == "New iMessage"
     assert changed_imessage["updated_at"] != "sentinel"
+
+
+def test_incremental_records_source_error_and_continues(tmp_path, monkeypatch):
+    store = MessageIndexStore(tmp_path / "index.sqlite3")
+
+    def fake_gmail_incremental(sync_store: MessageIndexStore) -> dict[str, int]:
+        sync_store.upsert_item(
+            _indexed_item(
+                source="gmail",
+                account="acct@example.com",
+                external_id="gmail-1",
+                thread_id="gmail-thread",
+                created_at="2026-04-18T01:00:00+00:00",
+                subject="New Gmail",
+            )
+        )
+        return {"acct@example.com": 1}
+
+    monkeypatch.setattr(message_sync, "sync_gmail_incremental", fake_gmail_incremental)
+    monkeypatch.setattr(
+        message_sync,
+        "sync_imessage_incremental",
+        lambda _store: (_ for _ in ()).throw(OSError("messages db unavailable")),
+    )
+    monkeypatch.setattr(message_sync, "sync_whatsapp_incremental", lambda _store: {})
+    monkeypatch.setattr(message_sync, "sync_linkedin_incremental", lambda _store: {})
+
+    result = message_sync.incremental(store)
+
+    assert result == {
+        "gmail": {"acct@example.com": 1},
+        "imessage": {},
+        "whatsapp": {},
+        "linkedin": {},
+    }
+    assert store.get_sync_state("imessage", "local")["status"] == "error"
+    rows = _thread_rows(store)
+    assert rows[("gmail", "acct@example.com", "gmail-thread")]["latest_subject"] == "New Gmail"
 
 
 def test_rebuild_all_threads_preserves_global_repair_path(tmp_path):

--- a/tests/test_message_sync.py
+++ b/tests/test_message_sync.py
@@ -189,7 +189,18 @@ def test_message_sync_cli_smoke_is_no_secret_success_path():
     assert result.stderr == ""
     assert json.loads(result.stdout) == {
         "entrypoint": "message_sync.py",
-        "modes": ["bootstrap", "incremental", "rebuild", "summary"],
+        "modes": [
+            "bootstrap",
+            "incremental",
+            "incremental-no-imessage",
+            "imessage-incremental",
+            "whatsapp-bootstrap",
+            "whatsapp-incremental",
+            "linkedin-bootstrap",
+            "linkedin-incremental",
+            "rebuild",
+            "summary",
+        ],
         "ok": True,
     }
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -2658,8 +2658,8 @@ class TestPhase4:
             ]
         )
         inbox_server.state.gmail_services = {"me@gmail.com": MagicMock()}
-        inbox_server.state.tasks_services = {}
-        inbox_server.state.cal_services = {}
+        inbox_server.state.tasks_services = {"me@gmail.com": MagicMock()}
+        inbox_server.state.cal_services = {"me@gmail.com": MagicMock()}
         mock_tasks.return_value = []
         mock_events.return_value = []
 
@@ -2687,6 +2687,8 @@ class TestPhase4:
         jobs = next(queue for queue in data["queues"] if queue["key"] == "jobs")
         assert jobs["items"][0]["thread_id"] == "t-action"
         mock_gmail.assert_not_called()
+        mock_tasks.assert_not_called()
+        mock_events.assert_not_called()
 
     @patch("inbox_server.gmail_search")
     @patch("inbox_server.tasks_list")

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1267,6 +1267,74 @@ class TestGmailExtensions:
         data = resp.json()
         assert len(data) == 1
         assert data[0]["name"] == "Alice"
+        assert data[0]["id"] == "msg1"
+        assert data[0]["message_id"] == "msg1"
+        assert data[0]["thread_id"] == "thread1"
+        assert data[0]["account"] == "me@gmail.com"
+        assert data[0]["gmail_account"] == "me@gmail.com"
+        assert data[0]["subject"] == data[0]["snippet"]
+        assert data[0]["from"] == "alice@example.com"
+        assert data[0]["timestamp"] == data[0]["last_ts"]
+
+    @patch("inbox_server.gmail_thread")
+    def test_get_gmail_thread_by_message_id_with_account(self, mock_thread, client):
+        import inbox_server
+
+        svc = MagicMock()
+        inbox_server.state.gmail_services = {"me@gmail.com": svc}
+        mock_thread.return_value = [
+            Msg(
+                sender="Alice",
+                body="Hello",
+                ts=datetime(2025, 1, 1, 12, 0),
+                is_me=False,
+                source="gmail",
+                message_id="msg1",
+            )
+        ]
+
+        resp = client.get(
+            "/messages/gmail/msg1",
+            params={"thread_id": "thread1", "account": "me@gmail.com"},
+        )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data[0]["message_id"] == "msg1"
+        assert data[0]["source"] == "gmail"
+        mock_thread.assert_called_once_with(svc, "msg1", "thread1")
+
+    @patch("inbox_server.gmail_create_draft")
+    def test_gmail_create_draft(self, mock_create_draft, client):
+        import inbox_server
+
+        inbox_server.state.gmail_services = {"me@gmail.com": MagicMock()}
+        mock_create_draft.return_value = {
+            "id": "draft1",
+            "message_id": "msg1",
+            "thread_id": "thread1",
+        }
+
+        resp = client.post(
+            "/messages/gmail/drafts",
+            json={
+                "to": "alice@example.com",
+                "subject": "Hello",
+                "body": "Draft body",
+                "thread_id": "thread1",
+                "account": "me@gmail.com",
+            },
+        )
+
+        assert resp.status_code == 200
+        assert resp.json() == {
+            "ok": True,
+            "account": "me@gmail.com",
+            "draft_id": "draft1",
+            "message_id": "msg1",
+            "thread_id": "thread1",
+        }
+        mock_create_draft.assert_called_once()
 
     @patch("inbox_server.gmail_reply")
     def test_gmail_reply(self, mock_reply, client):

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -2463,6 +2463,106 @@ class TestPhase4:
         assert any(ref["reason"] == "Track offer response" for ref in data["source_refs"])
         mock_gmail.assert_not_called()
 
+    @pytest.mark.safe
+    @patch("inbox_server.gmail_search")
+    @patch("inbox_server.tasks_list")
+    @patch("inbox_server.calendar_events")
+    def test_daily_brief_is_index_only_and_read_only(
+        self, mock_events, mock_tasks, mock_gmail, client
+    ):
+        import inbox_server
+
+        action_row = {
+            "thread_id": "t-action",
+            "account": "me@gmail.com",
+            "participants_json": ["Recruiter"],
+            "latest_subject": "Interview follow up",
+            "latest_snippet": "Can you reply today?",
+            "latest_item_at": "2026-04-18T01:00:00+00:00",
+            "summary": "Recruiter needs a reply",
+            "open_loop": "Reply to recruiter",
+            "topic": "opportunity",
+            "needs_reply": 1,
+            "message_count": 2,
+            "latest_sender": "Recruiter",
+        }
+        waiting_row = {
+            "thread_id": "t-wait",
+            "account": "me@gmail.com",
+            "participants_json": ["Hiring Manager"],
+            "latest_subject": "Offer timing",
+            "latest_snippet": "We will get back to you",
+            "latest_item_at": "2026-04-17T01:00:00+00:00",
+            "summary": "Waiting for offer update",
+            "open_loop": "Track offer response",
+            "topic": "opportunity",
+            "needs_reply": 0,
+            "message_count": 4,
+            "latest_sender": "Me",
+        }
+        recent_row = {
+            "thread_id": "t-recent",
+            "account": "me@gmail.com",
+            "participants_json": ["Ops"],
+            "latest_subject": "Digest",
+            "latest_snippet": "Recent update",
+            "latest_item_at": "2026-04-19T01:00:00+00:00",
+            "summary": "Recent operational update",
+            "open_loop": "",
+            "topic": "ops",
+            "needs_reply": 0,
+            "message_count": 1,
+            "latest_sender": "Ops",
+        }
+
+        def list_threads(**kwargs):
+            if kwargs.get("actions") == ("track",):
+                return [waiting_row]
+            if kwargs.get("sort_mode") == "recent":
+                return [recent_row]
+            return [action_row]
+
+        inbox_server.state.index_store.list_threads = MagicMock(side_effect=list_threads)
+        inbox_server.state.index_store.list_sync_states = MagicMock(
+            return_value=[
+                {
+                    "source": "gmail",
+                    "account": "me@gmail.com",
+                    "checkpoint_type": "internalDateMs",
+                    "checkpoint_value": "123",
+                    "last_success_at": datetime.now(UTC).isoformat(),
+                    "last_full_sync_at": "2026-04-18T00:00:00+00:00",
+                    "status": "idle",
+                    "last_run_started_at": "2026-04-18T00:55:00+00:00",
+                    "last_error": "",
+                    "metadata": {},
+                }
+            ]
+        )
+
+        resp = client.get("/inbox/daily-brief", params={"limit": 5, "account": "me@gmail.com"})
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["read_model"] == "daily_brief"
+        assert data["read_only"] is True
+        assert data["raw_provider_fetch"] is False
+        assert data["write_actions"] == []
+        assert data["reasons"] == []
+        assert [section["key"] for section in data["sections"]] == [
+            "actionable",
+            "waiting-on",
+            "recent",
+        ]
+        assert data["sections"][0]["threads"][0]["thread_id"] == "t-action"
+        assert data["sections"][1]["threads"][0]["thread_id"] == "t-wait"
+        assert data["sections"][2]["threads"][0]["thread_id"] == "t-recent"
+        assert data["workflow_counts"] == {"job_hunt": 1}
+        assert any(ref["thread_id"] == "t-action" for ref in data["source_refs"])
+        mock_gmail.assert_not_called()
+        mock_tasks.assert_not_called()
+        mock_events.assert_not_called()
+
     @patch("inbox_server.gmail_search")
     @patch("inbox_server.tasks_list")
     @patch("inbox_server.calendar_events")

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -56,6 +56,28 @@ def client():
         yield c
 
 
+def test_lifespan_honors_scheduler_autostart_env(monkeypatch):
+    import inbox_server
+
+    fake_state = inbox_server.ServerState()
+    runtime = inbox_server.InboxServerRuntime(
+        server_state=fake_state,
+        init_contacts_func=lambda: 0,
+        google_auth_func=inbox_server._empty_google_services,
+        start_scheduler=True,
+        ambient_autostart=False,
+    )
+    monkeypatch.setenv("INBOX_START_SCHEDULER", "0")
+
+    with (
+        patch("inbox_server._scheduler_loop") as mock_loop,
+        TestClient(inbox_server.create_app(runtime), raise_server_exceptions=False),
+    ):
+        pass
+
+    mock_loop.assert_not_called()
+
+
 @pytest.fixture
 def populated_client(client):
     """Client with some fake data in the conv_cache."""
@@ -2562,6 +2584,109 @@ class TestPhase4:
         mock_gmail.assert_not_called()
         mock_tasks.assert_not_called()
         mock_events.assert_not_called()
+
+    @patch("inbox_server.gmail_search")
+    @patch("inbox_server.tasks_list")
+    @patch("inbox_server.calendar_events")
+    def test_command_center_rolls_up_queues_coverage_and_approval_candidates(
+        self, mock_events, mock_tasks, mock_gmail, client
+    ):
+        import inbox_server
+
+        action_row = {
+            "thread_id": "t-action",
+            "account": "me@gmail.com",
+            "participants_json": ["Recruiter"],
+            "latest_subject": "Interview follow up",
+            "latest_snippet": "Can you reply today?",
+            "latest_item_at": "2026-04-18T01:00:00+00:00",
+            "summary": "Recruiter needs a reply",
+            "open_loop": "Reply to recruiter",
+            "topic": "opportunity",
+            "needs_reply": 1,
+            "message_count": 2,
+            "latest_sender": "Recruiter",
+        }
+        waiting_row = {
+            "thread_id": "t-wait",
+            "account": "me@gmail.com",
+            "participants_json": ["Hiring Manager"],
+            "latest_subject": "Offer timing",
+            "latest_snippet": "We will get back to you",
+            "latest_item_at": "2026-04-17T01:00:00+00:00",
+            "summary": "Waiting for offer update",
+            "open_loop": "Track offer response",
+            "topic": "opportunity",
+            "needs_reply": 0,
+            "message_count": 4,
+            "latest_sender": "Me",
+        }
+
+        def list_threads(**kwargs):
+            if kwargs.get("has_open_loop"):
+                return [waiting_row]
+            if kwargs.get("sort_mode") == "recent" and not kwargs.get("needs_reply"):
+                return [action_row, waiting_row]
+            return [action_row]
+
+        inbox_server.state.index_store.list_threads = MagicMock(side_effect=list_threads)
+        inbox_server.state.index_store.source_counts = MagicMock(
+            return_value=[
+                {
+                    "source": "gmail",
+                    "account": "me@gmail.com",
+                    "item_count": 12,
+                    "thread_count": 3,
+                    "latest_item_at": "2026-04-18T01:00:00+00:00",
+                }
+            ]
+        )
+        inbox_server.state.index_store.list_sync_states = MagicMock(
+            return_value=[
+                {
+                    "source": "gmail",
+                    "account": "me@gmail.com",
+                    "checkpoint_type": "internalDateMs",
+                    "checkpoint_value": "123",
+                    "last_success_at": datetime.now(UTC).isoformat(),
+                    "last_full_sync_at": "2026-04-18T00:00:00+00:00",
+                    "status": "idle",
+                    "last_run_started_at": "2026-04-18T00:55:00+00:00",
+                    "last_error": "",
+                    "metadata": {},
+                }
+            ]
+        )
+        inbox_server.state.gmail_services = {"me@gmail.com": MagicMock()}
+        inbox_server.state.tasks_services = {}
+        inbox_server.state.cal_services = {}
+        mock_tasks.return_value = []
+        mock_events.return_value = []
+
+        resp = client.get("/inbox/command-center", params={"limit": 5, "account": "me@gmail.com"})
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["read_model"] == "command_center"
+        assert data["read_only"] is True
+        assert data["raw_provider_fetch"] is False
+        assert data["write_actions"] == []
+        assert {queue["key"] for queue in data["queues"]} == {
+            "now",
+            "people",
+            "jobs",
+            "admin",
+            "waiting",
+            "approval",
+        }
+        assert data["source_coverage"][0]["source"] == "gmail"
+        assert data["source_coverage"][0]["item_count"] == 12
+        assert data["approval_queue"][0]["action"] == "send_reply"
+        assert data["approval_queue"][0]["status"] == "needs_human_approval"
+        assert data["agent_work"][0]["permission"] == "read_only"
+        jobs = next(queue for queue in data["queues"] if queue["key"] == "jobs")
+        assert jobs["items"][0]["thread_id"] == "t-action"
+        mock_gmail.assert_not_called()
 
     @patch("inbox_server.gmail_search")
     @patch("inbox_server.tasks_list")

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -943,6 +943,52 @@ def test_load_favorites_handles_corrupt_file(tmp_path, monkeypatch):
     assert result == set()
 
 
+def test_gmail_create_draft_uses_drafts_create(monkeypatch):
+    monkeypatch.delenv("INBOX_TEST_MODE", raising=False)
+
+    class FakeDraftCreate:
+        def __init__(self):
+            self.body = None
+
+        def create(self, userId, body):  # noqa: N803
+            self.user_id = userId
+            self.body = body
+            return self
+
+        def execute(self):
+            return {"id": "draft1", "message": {"id": "msg1", "threadId": "thread1"}}
+
+    class FakeUsers:
+        def __init__(self):
+            self.drafts_resource = FakeDraftCreate()
+
+        def drafts(self):
+            return self.drafts_resource
+
+    class FakeGmailService:
+        def __init__(self):
+            self.users_resource = FakeUsers()
+
+        def users(self):
+            return self.users_resource
+
+    svc = FakeGmailService()
+
+    result = services.gmail_create_draft(
+        svc,
+        "alice@example.com",
+        "Hello",
+        "Draft body",
+        thread_id="thread1",
+    )
+
+    assert result == {"id": "draft1", "message_id": "msg1", "thread_id": "thread1"}
+    create_call = svc.users_resource.drafts_resource
+    assert create_call.user_id == "me"
+    assert create_call.body["message"]["threadId"] == "thread1"
+    assert "raw" in create_call.body["message"]
+
+
 class _WriteShouldNotRun:
     def __getattr__(self, name: str) -> Any:
         raise AssertionError(f"live write service was touched: {name}")

--- a/tests/test_tools_registry.py
+++ b/tests/test_tools_registry.py
@@ -43,6 +43,8 @@ def test_create_sheet_and_append_rows_are_confirm_gated():
     by_name = {tool.name: tool for tool in TOOLS}
     assert by_name["create_sheet"].confirm is True
     assert by_name["append_sheet_rows"].confirm is True
+    assert by_name["create_email_draft"].confirm is True
+    assert by_name["delete_email_thread"].confirm is True
 
 
 def test_all_mutating_tools_require_confirm():
@@ -172,6 +174,59 @@ def test_index_view_dispatches_to_named_index_route():
         "method": "GET",
         "path": "/index/views/waiting-on-me",
         "params": {"limit": 7},
+        "json": None,
+    }
+
+
+def test_gmail_agent_tools_dispatch_to_expected_routes():
+    handlers = _handlers()
+
+    thread = asyncio.run(
+        handlers["get_email_thread"](
+            message_id="msg/1",
+            thread_id="thread 1",
+            account="me@example.com",
+        )
+    )
+    draft = asyncio.run(
+        handlers["create_email_draft"](
+            to="alice@example.com",
+            subject="Hello",
+            body="Draft body",
+            thread_id="thread 1",
+            account="me@example.com",
+            confirm=True,
+        )
+    )
+    deleted = asyncio.run(
+        handlers["delete_email_thread"](
+            message_id="msg/1",
+            confirm=True,
+        )
+    )
+
+    assert thread == {
+        "method": "GET",
+        "path": "/messages/gmail/msg%2F1",
+        "params": {"thread_id": "thread 1", "account": "me@example.com"},
+        "json": None,
+    }
+    assert draft == {
+        "method": "POST",
+        "path": "/messages/gmail/drafts",
+        "params": None,
+        "json": {
+            "to": "alice@example.com",
+            "subject": "Hello",
+            "body": "Draft body",
+            "thread_id": "thread 1",
+            "account": "me@example.com",
+        },
+    }
+    assert deleted == {
+        "method": "POST",
+        "path": "/messages/gmail/msg%2F1/delete",
+        "params": None,
         "json": None,
     }
 

--- a/tests/test_tools_registry.py
+++ b/tests/test_tools_registry.py
@@ -124,6 +124,13 @@ def test_index_health_status_and_needs_action_dispatch_to_compact_routes():
             account="me@example.com",
         )
     )
+    command_center = asyncio.run(
+        handlers["get_command_center"](
+            workflow="job_hunt",
+            account="me@example.com",
+            limit=6,
+        )
+    )
 
     assert health == {
         "method": "GET",
@@ -141,6 +148,12 @@ def test_index_health_status_and_needs_action_dispatch_to_compact_routes():
         "method": "GET",
         "path": "/inbox/needs-action",
         "params": {"workflow": "job_hunt", "account": "me@example.com"},
+        "json": None,
+    }
+    assert command_center == {
+        "method": "GET",
+        "path": "/inbox/command-center",
+        "params": {"workflow": "job_hunt", "account": "me@example.com", "limit": 6},
         "json": None,
     }
 

--- a/tests/test_tui_tabs.py
+++ b/tests/test_tui_tabs.py
@@ -13,4 +13,4 @@ def test_tui_tabs_have_unique_ids_and_textual_ids():
 
 def test_tui_tabs_include_expected_detail_modes():
     detail_tabs = {tab["id"] for tab in TUI_TABS if tab["mode"] == "detail"}
-    assert detail_tabs == {"calendar", "notes", "reminders", "github", "drive", "health"}
+    assert detail_tabs == {"calendar", "notes", "reminders", "github", "drive", "health", "ops"}

--- a/tests/test_whatsapp_web_scanner.py
+++ b/tests/test_whatsapp_web_scanner.py
@@ -167,6 +167,44 @@ def test_write_scan_uses_alternate_message_text_fields(tmp_path):
     ]
 
 
+def test_write_scan_extracts_nested_indexeddb_message_text(tmp_path):
+    db_path = tmp_path / "whatsapp_data.db"
+    scan = {
+        "source": "brave-cdp-idb",
+        "messages": [
+            {
+                "chatId": "chat-1@c.us",
+                "messageId": "nested-conversation",
+                "sender": "Alice",
+                "message": {"conversation": "from nested conversation"},
+            },
+            {
+                "chatId": "chat-1@c.us",
+                "messageId": "nested-extended",
+                "sender": "Alice",
+                "content": {
+                    "extendedTextMessage": {"text": "from nested extended text"},
+                },
+            },
+        ],
+    }
+
+    whatsapp_web_scanner.write_scan(db_path, scan, "acct")
+
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    try:
+        messages = conn.execute(
+            "SELECT message_id, body FROM wa_messages ORDER BY message_id"
+        ).fetchall()
+    finally:
+        conn.close()
+    assert [(row["message_id"], row["body"]) for row in messages] == [
+        ("nested-conversation", "from nested conversation"),
+        ("nested-extended", "from nested extended text"),
+    ]
+
+
 def test_write_scan_accepts_indexeddb_chat_metadata(tmp_path):
     db_path = tmp_path / "whatsapp_data.db"
     scan = {

--- a/tools_registry.py
+++ b/tools_registry.py
@@ -229,6 +229,24 @@ TOOLS: list[Tool] = [
             Param("account", str, "", "body"),
         ],
     ),
+    Tool(
+        name="create_email_draft",
+        method="POST",
+        path="/messages/gmail/drafts",
+        description=(
+            "Create a Gmail draft without sending it. Confirmation-gated because it "
+            "writes to Gmail."
+        ),
+        readonly=False,
+        confirm=True,
+        params=[
+            Param("to", str, _EMPTY, "body"),
+            Param("subject", str, _EMPTY, "body"),
+            Param("body", str, _EMPTY, "body"),
+            Param("thread_id", str, "", "body"),
+            Param("account", str, "", "body"),
+        ],
+    ),
     # ---------- Google Sheets (read) ----------
     Tool(
         name="list_sheets",
@@ -302,6 +320,7 @@ TOOLS: list[Tool] = [
         params=[
             Param("message_id", str, _EMPTY, "path"),
             Param("thread_id", str, "", "query"),
+            Param("account", str, "", "query"),
         ],
     ),
     Tool(
@@ -317,6 +336,14 @@ TOOLS: list[Tool] = [
         method="POST",
         path="/messages/gmail/{message_id}/read",
         description="Mark a Gmail message as read. Confirmation-gated.",
+        confirm=True,
+        params=[Param("message_id", str, _EMPTY, "path")],
+    ),
+    Tool(
+        name="delete_email_thread",
+        method="POST",
+        path="/messages/gmail/{message_id}/delete",
+        description="Move a Gmail message/thread to Trash. Confirmation-gated.",
         confirm=True,
         params=[Param("message_id", str, _EMPTY, "path")],
     ),

--- a/tools_registry.py
+++ b/tools_registry.py
@@ -193,6 +193,21 @@ TOOLS: list[Tool] = [
             Param("account", str, "", "query"),
         ],
     ),
+    Tool(
+        name="get_command_center",
+        method="GET",
+        path="/inbox/command-center",
+        description=(
+            "Get the read-only command center: source coverage, Now, people, jobs, "
+            "admin, waiting, approval candidates, and agent work lanes."
+        ),
+        readonly=True,
+        params=[
+            Param("workflow", str, "", "query"),
+            Param("account", str, "", "query"),
+            Param("limit", int, 10, "query"),
+        ],
+    ),
     # ---------- Gmail (write) ----------
     Tool(
         name="send_email_reply",

--- a/tui_tabs.py
+++ b/tui_tabs.py
@@ -147,6 +147,16 @@ TUI_TABS: tuple[TabMeta, ...] = (
         "command_name": "Switch to Capture Health",
         "command_description": "Show source capture and egress health",
     },
+    {
+        "id": "ops",
+        "label": "Ops",
+        "textual_tab_id": "tab-ops",
+        "mode": "detail",
+        "action": "action_filter_ops",
+        "command_id": "switch_ops",
+        "command_name": "Switch to Ops",
+        "command_description": "Show provider-agnostic ops queues",
+    },
 )
 
 TAB_BY_TEXTUAL_ID = {tab["textual_tab_id"]: tab for tab in TUI_TABS}


### PR DESCRIPTION
## What
Adds an agent-safe /inbox/daily-brief endpoint backed only by the local index.

## Why
This is the selected Inbox focus-next slice: one demoable daily/operator brief path that stays read-only, avoids raw provider fetches, and exposes source refs and index health.

## Validation
- INBOX_TEST_MODE=1 uv run pytest tests/test_server.py::TestPhase4::test_daily_brief_is_index_only_and_read_only -q --no-cov
- INBOX_TEST_MODE=1 uv run pytest tests/test_server.py::TestPhase4 -q --no-cov
- uv run ruff check inbox_server.py tests/test_server.py
- scripts/validate_agent_safe.sh

## Notes
Stacked on #60 (codex/reconcile-inbox-local-main-2026-05-20).