### PR TITLE
LifeOps MCP v0: bounded ChatGPT Business cockpit over Inbox

### DIFF
--- a/docs/lifeops-mcp-v0.md
+++ b/docs/lifeops-mcp-v0.md
@@ -1,0 +1,162 @@
+# LifeOps MCP v0
+
+## Goal
+
+Make ChatGPT Business the cockpit for the existing Inbox/Mac capability layer without exposing the whole Inbox REST API or weakening its write-approval invariants.
+
+```text
+ChatGPT Business
+      |
+      | MCP over HTTPS
+      v
+Secure MCP Tunnel (preferred for ChatGPT)
+      |
+      v
+lifeops_mcp.py :9850
+      |
+      | authenticated localhost HTTP
+      v
+inbox_server.py :9849
+      |
+      +-- iMessage / Contacts / Notes / Reminders
+      +-- Gmail / Calendar / Tasks / Drive / Docs / Sheets
+      +-- Maps travel time / current location
+      +-- GitHub / connector index / audit
+```
+
+The MCP adapter is intentionally smaller than Inbox. V0 proves one useful vertical slice before widening permissions.
+
+## V0 tool surface
+
+Read tools:
+
+- `search` and `fetch` — cross-source evidence retrieval
+- `source_health` — provider, capture, and egress health
+- `calendar_events` — calendar commitments
+- `travel_time` — route duration
+- `departure_times` — leave-time calculation for located events
+- `tasks` — current Google Tasks
+
+Bounded write workflow:
+
+- `propose_create_task`
+- `propose_update_calendar_event`
+- `approve_pending_action`
+- `execute_approved_action`
+
+No MCP tool can send messages, delete data, run arbitrary shell commands, or execute arbitrary Inbox endpoints in v0.
+
+## Why writes are not direct
+
+Inbox already has a stronger invariant than a generic confirmation dialog: each guarded action is approved through a single-use lease bound to the exact HTTP method, path, provider, operation, account/resource, item count, query hash, payload hash, and expiry.
+
+The MCP layer preserves that sequence:
+
+```text
+propose -> pending approval -> explicit confirmation -> lease -> exact execution -> read-back verification
+```
+
+Do not add a generic `request(method, path, body)` tool and do not bypass the Inbox approval middleware.
+
+## Local startup
+
+Checkout the branch and install the existing project dependencies:
+
+```bash
+git checkout lifeops-mcp-v0
+uv sync
+```
+
+Use a strong existing Inbox token or generate a new random one. Never commit it:
+
+```bash
+export INBOX_SERVER_TOKEN='<strong-random-token>'
+```
+
+Start both local services:
+
+```bash
+bash scripts/run_lifeops_mcp_v0.sh
+```
+
+Defaults:
+
+- Inbox REST: `http://127.0.0.1:9849`
+- LifeOps MCP: `http://127.0.0.1:9850/mcp`
+- automatic departure-task creation: OFF during validation
+
+The MCP process binds only to loopback. The tunnel is the only intended remote ingress.
+
+## ChatGPT Business connection — preferred
+
+ChatGPT cannot connect directly to localhost. For the actual Business connection, use OpenAI Secure MCP Tunnel so the MCP server stays private rather than placing it directly on the public internet.
+
+In ChatGPT Business on web:
+
+1. As a workspace admin/owner, open Workspace Settings -> Apps -> Create and enable Developer Mode for yourself if needed.
+2. Choose the private/local MCP connection flow and Secure MCP Tunnel.
+3. Point the tunnel's local target at `http://127.0.0.1:9850/mcp`.
+4. Let ChatGPT scan the tools.
+5. Keep the app in developer/draft mode while the tool surface is changing.
+6. Test the acceptance sequence below before publishing it to the workspace.
+
+Follow the current Secure MCP Tunnel instructions presented by ChatGPT/OpenAI for the tunnel client rather than copying a stale tunnel command into this repository.
+
+## ngrok — useful dev path, not the default trust boundary
+
+For a quick network/MCP smoke test, ngrok can forward an HTTPS endpoint to the local MCP port:
+
+```bash
+brew install ngrok
+ngrok config add-authtoken '<YOUR_NGROK_AUTHTOKEN>'
+ngrok http 9850
+```
+
+That produces a public HTTPS endpoint whose MCP URL is approximately:
+
+```text
+https://<assigned-host>/mcp
+```
+
+Important: **do not connect a bare public ngrok endpoint to personal-data/write tools.** `INBOX_SERVER_TOKEN` protects LifeOps -> Inbox; it does not authenticate Internet -> LifeOps MCP. If ngrok is used beyond a disposable smoke test, add a ChatGPT-compatible MCP authentication layer or verified edge policy first. For the normal ChatGPT Business setup, prefer Secure MCP Tunnel.
+
+## First acceptance test: Street play practice
+
+Do not broaden the connector until this works end to end.
+
+1. `source_health()` shows iMessage/Calendar/Tasks/Maps dependencies usable enough for the test.
+2. Search for `street play practice`, `45738 Bridgeport`, or the relevant contact and retrieve the source messages as evidence.
+3. Read the 2026-08-24 calendar and identify the existing `Street play practice` event.
+4. Calculate travel time for the known legs, including pickup and practice destination.
+5. Propose updating the existing calendar event location to the evidence-backed practice address.
+6. Show the exact proposed change to the user. Do not approve it implicitly.
+7. After explicit user approval, approve and execute the recorded action.
+8. Re-read the calendar event and verify the location changed.
+9. Run `departure_times` and verify a sensible leave time can now be produced.
+
+A later `prepare_travel` tool may compose these primitives once the behavior is proven. Do not build it first.
+
+## Expansion rule
+
+Add a new MCP write tool only when a real workflow is blocked without it. The next likely candidates are:
+
+- complete/update Google Task
+- draft/send or reply to a message
+- local notification / Apple Shortcut invocation
+- GitHub actions
+
+Each must map to a typed Inbox capability and preserve the same propose/approve/execute/verify discipline where consequences warrant it.
+
+## Non-goals for v0
+
+- no generic shell
+- no unrestricted filesystem access
+- no arbitrary REST proxy
+- no automatic deletion
+- no direct messaging writes
+- no World Monitor integration
+- no Perplexity UI automation
+- no Postgres migration
+- no new user interface
+
+Those are backlog items, not prerequisites for proving the cockpit.

--- a/lifeops_mcp.py
+++ b/lifeops_mcp.py
@@ -1,0 +1,354 @@
+from __future__ import annotations
+
+import base64
+import json
+import os
+import re
+from typing import Any, Literal
+from urllib.parse import urlencode
+
+import httpx
+from mcp.server.fastmcp import FastMCP
+from mcp.types import ToolAnnotations
+
+INBOX_BASE_URL = os.environ.get("INBOX_SERVER_URL", "http://127.0.0.1:9849").rstrip("/")
+INBOX_TOKEN = os.environ.get("INBOX_SERVER_TOKEN", "").strip()
+MCP_PORT = int(os.environ.get("LIFEOPS_MCP_PORT", "9850"))
+
+mcp = FastMCP(
+    "LifeOps",
+    instructions=(
+        "LifeOps exposes evidence-backed personal context and bounded actions through the local Inbox server. "
+        "Prefer reads before writes. Never infer a write succeeded: execute it, then verify the resulting state. "
+        "Approval tools may only be used after the user explicitly confirms the exact pending action."
+    ),
+    host="127.0.0.1",
+    port=MCP_PORT,
+    streamable_http_path="/mcp",
+    stateless_http=True,
+    json_response=True,
+)
+
+
+def _headers(extra: dict[str, str] | None = None) -> dict[str, str]:
+    if not INBOX_TOKEN:
+        raise RuntimeError("INBOX_SERVER_TOKEN is required")
+    headers = {"Authorization": f"Bearer {INBOX_TOKEN}"}
+    if extra:
+        headers.update(extra)
+    return headers
+
+
+async def _request(
+    method: str,
+    path: str,
+    *,
+    params: dict[str, Any] | None = None,
+    body: dict[str, Any] | None = None,
+    extra_headers: dict[str, str] | None = None,
+) -> Any:
+    async with httpx.AsyncClient(base_url=INBOX_BASE_URL, timeout=45.0) as client:
+        response = await client.request(
+            method,
+            path,
+            params=params,
+            json=body,
+            headers=_headers(extra_headers),
+        )
+        response.raise_for_status()
+        if not response.content:
+            return None
+        return response.json()
+
+
+def _encode_search_id(query: str) -> str:
+    token = base64.urlsafe_b64encode(query.encode("utf-8")).decode("ascii").rstrip("=")
+    return f"search:{token}"
+
+
+def _decode_search_id(item_id: str) -> str:
+    if not item_id.startswith("search:"):
+        raise ValueError("Unsupported item id")
+    token = item_id.removeprefix("search:")
+    token += "=" * (-len(token) % 4)
+    return base64.urlsafe_b64decode(token.encode("ascii")).decode("utf-8")
+
+
+def _approval_path(path: str, params: dict[str, str] | None = None) -> str:
+    clean = path
+    if params:
+        nonempty = {k: v for k, v in params.items() if v != ""}
+        if nonempty:
+            clean = f"{path}?{urlencode(nonempty)}"
+    return clean
+
+
+async def _request_approval(method: str, path: str, body: dict[str, Any]) -> dict[str, Any]:
+    return await _request(
+        "POST",
+        "/approvals/request",
+        body={"method": method, "path": path, "body": body},
+    )
+
+
+def _allowed_execution(row: dict[str, Any]) -> bool:
+    method = str(row.get("method", "")).upper()
+    path = str(row.get("path", ""))
+    path_only = path.split("?", 1)[0]
+    if method == "POST" and path_only == "/tasks":
+        return True
+    if method == "PUT" and re.fullmatch(r"/calendar/events/[^/]+", path_only):
+        return True
+    return False
+
+
+@mcp.tool(
+    title="Search LifeOps sources",
+    annotations=ToolAnnotations(read_only_hint=True, open_world_hint=False),
+)
+async def search(query: str) -> str:
+    """Search Inbox-backed personal sources. Use this for company-knowledge/deep-research style discovery."""
+    await _request("POST", "/search", body={"q": query, "sources": ["all"], "limit": 50})
+    item_id = _encode_search_id(query)
+    payload = {
+        "results": [
+            {
+                "id": item_id,
+                "title": f"LifeOps search: {query}",
+                "url": f"lifeops://{item_id}",
+            }
+        ]
+    }
+    return json.dumps(payload, ensure_ascii=False)
+
+
+@mcp.tool(
+    title="Fetch LifeOps search evidence",
+    annotations=ToolAnnotations(read_only_hint=True, open_world_hint=False),
+)
+async def fetch(item_id: str) -> str:
+    """Fetch the evidence bundle for a LifeOps search result id returned by search."""
+    query = _decode_search_id(item_id)
+    data = await _request("POST", "/search", body={"q": query, "sources": ["all"], "limit": 50})
+    payload = {
+        "id": item_id,
+        "title": f"LifeOps search: {query}",
+        "text": json.dumps(data, ensure_ascii=False),
+        "url": f"lifeops://{item_id}",
+        "metadata": {"query": query, "source": "Inbox /search"},
+    }
+    return json.dumps(payload, ensure_ascii=False)
+
+
+@mcp.tool(
+    title="Check LifeOps source health",
+    annotations=ToolAnnotations(read_only_hint=True, open_world_hint=False),
+)
+async def source_health() -> dict[str, Any]:
+    """Check which local and cloud sources are configured, readable, writable, stale, or blocked."""
+    providers, capture, egress = await _parallel_reads()
+    return {"providers": providers, "capture": capture, "egress": egress}
+
+
+async def _parallel_reads() -> tuple[Any, Any, Any]:
+    import asyncio
+
+    return tuple(
+        await asyncio.gather(
+            _request("GET", "/status/providers"),
+            _request("GET", "/capture/health"),
+            _request("GET", "/egress/status"),
+        )
+    )  # type: ignore[return-value]
+
+
+@mcp.tool(
+    title="Get calendar events",
+    annotations=ToolAnnotations(read_only_hint=True, open_world_hint=False),
+)
+async def calendar_events(date: str) -> list[dict[str, Any]]:
+    """Get calendar events for an ISO date such as 2026-08-24 before reasoning about commitments or travel."""
+    data = await _request("GET", "/calendar/events", params={"date": date})
+    return list(data or [])
+
+
+@mcp.tool(
+    title="Calculate departure times",
+    annotations=ToolAnnotations(read_only_hint=True, open_world_hint=True),
+)
+async def departure_times(
+    origin: str = "",
+    mode: Literal["driving", "walking", "bicycling", "transit"] = "driving",
+    buffer_minutes: int = 10,
+    lookahead_hours: int = 24,
+) -> list[dict[str, Any]]:
+    """Calculate traffic-aware leave times for upcoming calendar events that have locations."""
+    params: dict[str, Any] = {
+        "mode": mode,
+        "buffer_minutes": max(0, min(buffer_minutes, 120)),
+        "lookahead_hours": max(1, min(lookahead_hours, 72)),
+    }
+    if origin:
+        params["origin"] = origin
+    data = await _request("GET", "/calendar/departure-times", params=params)
+    return list(data or [])
+
+
+@mcp.tool(
+    title="Calculate travel time",
+    annotations=ToolAnnotations(read_only_hint=True, open_world_hint=True),
+)
+async def travel_time(
+    origin: str,
+    destination: str,
+    mode: Literal["driving", "walking", "bicycling", "transit"] = "driving",
+) -> dict[str, Any]:
+    """Calculate current travel time between two places using Inbox's maps service."""
+    data = await _request(
+        "GET",
+        "/maps/travel-time",
+        params={"origin": origin, "destination": destination, "mode": mode},
+    )
+    return dict(data or {})
+
+
+@mcp.tool(
+    title="List Google Tasks",
+    annotations=ToolAnnotations(read_only_hint=True, open_world_hint=False),
+)
+async def tasks(
+    list_id: str = "@default",
+    show_completed: bool = False,
+    limit: int = 50,
+    account: str = "",
+) -> list[dict[str, Any]]:
+    """Read current Google Tasks before proposing task changes or checking whether work already exists."""
+    params: dict[str, Any] = {
+        "list_id": list_id,
+        "show_completed": show_completed,
+        "limit": max(1, min(limit, 200)),
+    }
+    if account:
+        params["account"] = account
+    data = await _request("GET", "/tasks", params=params)
+    return list(data or [])
+
+
+@mcp.tool(
+    title="Propose Google Task creation",
+    annotations=ToolAnnotations(
+        read_only_hint=False,
+        destructive_hint=False,
+        idempotent_hint=False,
+        open_world_hint=False,
+    ),
+)
+async def propose_create_task(
+    title: str,
+    due: str = "",
+    notes: str = "",
+    list_id: str = "@default",
+    account: str = "",
+) -> dict[str, Any]:
+    """Create a pending, payload-bound approval request for a new Google Task. This does not create the task yet."""
+    params = {"account": account} if account else None
+    path = _approval_path("/tasks", params)
+    body = {"title": title, "list_id": list_id, "due": due, "notes": notes}
+    return await _request_approval("POST", path, body)
+
+
+@mcp.tool(
+    title="Propose calendar event update",
+    annotations=ToolAnnotations(
+        read_only_hint=False,
+        destructive_hint=False,
+        idempotent_hint=False,
+        open_world_hint=False,
+    ),
+)
+async def propose_update_calendar_event(
+    event_id: str,
+    calendar_id: str = "primary",
+    account: str = "",
+    summary: str | None = None,
+    start: str | None = None,
+    end: str | None = None,
+    location: str | None = None,
+    description: str | None = None,
+) -> dict[str, Any]:
+    """Create a pending, payload-bound approval request to update an existing calendar event. No update happens yet."""
+    body = {
+        key: value
+        for key, value in {
+            "summary": summary,
+            "start": start,
+            "end": end,
+            "location": location,
+            "description": description,
+        }.items()
+        if value is not None
+    }
+    if not body:
+        raise ValueError("At least one field must be supplied")
+    path = _approval_path(
+        f"/calendar/events/{event_id}",
+        {"calendar_id": calendar_id, "account": account},
+    )
+    return await _request_approval("PUT", path, body)
+
+
+@mcp.tool(
+    title="Approve pending LifeOps action",
+    annotations=ToolAnnotations(
+        read_only_hint=False,
+        destructive_hint=True,
+        idempotent_hint=False,
+        open_world_hint=False,
+    ),
+)
+async def approve_pending_action(request_id: str) -> dict[str, Any]:
+    """Approve a pending LifeOps action. Only use after the user explicitly confirms the exact pending action in this conversation."""
+    row = await _request("GET", f"/approvals/{request_id}")
+    if not isinstance(row, dict) or not _allowed_execution(row):
+        raise ValueError("This MCP adapter only approves task creation and calendar updates")
+    if row.get("state") != "pending":
+        return row
+    return await _request(
+        "POST",
+        f"/approvals/{request_id}/decide",
+        body={"approve": True, "decided_by": "chatgpt-business-lifeops"},
+    )
+
+
+@mcp.tool(
+    title="Execute approved LifeOps action",
+    annotations=ToolAnnotations(
+        read_only_hint=False,
+        destructive_hint=False,
+        idempotent_hint=False,
+        open_world_hint=False,
+    ),
+)
+async def execute_approved_action(request_id: str) -> dict[str, Any]:
+    """Execute exactly the already-approved task/calendar action bound to request_id, then return the provider result."""
+    row = await _request("GET", f"/approvals/{request_id}")
+    if not isinstance(row, dict) or not _allowed_execution(row):
+        raise ValueError("This MCP adapter only executes task creation and calendar updates")
+    if row.get("state") != "approved" or not row.get("lease_id"):
+        raise ValueError("Action is not approved or has no approval lease")
+
+    body = json.loads(row.get("body_json") or "{}")
+    method = str(row["method"]).upper()
+    path = str(row["path"])
+    # Keep the exact path/query that was approved. httpx accepts the query in the path string.
+    result = await _request(
+        method,
+        path,
+        body=body,
+        extra_headers={"X-Inbox-Approval-Lease": str(row["lease_id"])},
+    )
+    return {"request_id": request_id, "executed": True, "result": result}
+
+
+if __name__ == "__main__":
+    mcp.run(transport="streamable-http")

--- a/scripts/run_lifeops_mcp_v0.sh
+++ b/scripts/run_lifeops_mcp_v0.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${INBOX_SERVER_TOKEN:?Set INBOX_SERVER_TOKEN before starting LifeOps}"
+
+export INBOX_SERVER_URL="${INBOX_SERVER_URL:-http://127.0.0.1:9849}"
+export LIFEOPS_MCP_PORT="${LIFEOPS_MCP_PORT:-9850}"
+# Keep autonomous departure-task creation off during the first MCP validation.
+export INBOX_ENABLE_DEPARTURE_ALERTS="${INBOX_ENABLE_DEPARTURE_ALERTS:-0}"
+
+cleanup() {
+  if [[ -n "${INBOX_PID:-}" ]] && kill -0 "$INBOX_PID" 2>/dev/null; then
+    kill "$INBOX_PID" 2>/dev/null || true
+    wait "$INBOX_PID" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT INT TERM
+
+uv run python inbox_server.py &
+INBOX_PID=$!
+
+for _ in $(seq 1 60); do
+  if curl -fsS http://127.0.0.1:9849/health >/dev/null 2>&1; then
+    break
+  fi
+  if ! kill -0 "$INBOX_PID" 2>/dev/null; then
+    echo "Inbox server exited during startup" >&2
+    exit 1
+  fi
+  sleep 0.5
+done
+
+if ! curl -fsS http://127.0.0.1:9849/health >/dev/null 2>&1; then
+  echo "Inbox server did not become healthy" >&2
+  exit 1
+fi
+
+exec uv run python lifeops_mcp.py


### PR DESCRIPTION
## Purpose

Prove the smallest useful ChatGPT Business -> LifeOps MCP -> Inbox/Mac vertical slice without exposing the full Inbox REST API or weakening existing approval invariants.

## Adds

- `lifeops_mcp.py`: tool-only FastMCP adapter
- `scripts/run_lifeops_mcp_v0.sh`: local Inbox + MCP launcher
- `docs/lifeops-mcp-v0.md`: Secure MCP Tunnel / ngrok dev guidance and acceptance test

## V0 tools

Read:
- `search` / `fetch`
- source health
- calendar events
- travel/departure times
- Google Tasks

Bounded writes:
- propose Google Task creation
- propose Calendar event update
- explicit approval
- exact lease-bound execution

The adapter allowlists only task creation and calendar updates for approval/execution. It does not expose arbitrary REST, shell/filesystem, messaging writes, or deletes.

## First acceptance test

Use the existing Street play practice case to prove:
message evidence -> calendar correlation -> travel calculation -> proposed event enrichment -> explicit approval -> execution -> read-back verification -> departure time.

## Validation so far

- Python syntax compile passed for `lifeops_mcp.py` in an isolated container.
- Current MCP SDK docs/source were checked for `ToolAnnotations` snake_case names.
- Branch is 3 commits ahead of `main`, 0 behind.
- Host/runtime integration has **not** yet been exercised on the Mac because this environment does not have the repo's `mcp` dependency or access to the local Inbox data stores.

Keep draft until the Mac runtime + ChatGPT Developer Mode acceptance test passes.