### PR TITLE
LA-03: PR-2B thin submit_work → bridge ingest (no Inbox execution)

### DIFF
--- a/MCP_SETUP.md
+++ b/MCP_SETUP.md
@@ -42,6 +42,8 @@ Run the private inbox backend and the MCP layers separately:
    - Fail-closed `INBOX_CONTROL_PLANE_TOKEN` (unlike `mcp_gateway.py`, an
      empty token is unauthorized)
    - `INBOX_CONTROL_PLANE_SPAWN` defaults to `0`; `confirm=true` is not authority
+   - `submit_work` forwards to Bridge `ingest` via `bridge_work_client.py`
+     (argv allowlist, `shell=False`); stores intake path/ids only — not spawn
    - Does not wrap the REST `tools_registry.py` surface and does not mint leases
 
 ## Which Path To Use

--- a/bridge_work_client.py
+++ b/bridge_work_client.py
@@ -1,0 +1,177 @@
+"""Thin Bridge intake client for the Inbox MCP control plane (PR-2B).
+
+Calls only the existing Bridge CLI handshake:
+
+    bridge ingest - --repo <dir>
+
+This is intake, not execution. It never invokes spawn, promote-approval,
+deliver, or any other Bridge verb. argv is allowlisted; shell=False.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Protocol
+
+BRIDGE_BIN_ENV = "INBOX_BRIDGE_BIN"
+BRIDGE_REPO_ENV = "INBOX_BRIDGE_REPO"
+CONTRACT_VERSION = "bridge.contracts.v1"
+INGEST_TIMEOUT_SEC = 30
+ALLOWED_VERBS = frozenset({"ingest"})
+
+
+class BridgeIngestError(RuntimeError):
+    """Bridge intake failed closed (reject, missing config, or bad output)."""
+
+
+@dataclass(frozen=True)
+class BridgeIngestReceipt:
+    """Ids/paths returned by Bridge ingest. Never an execution grant."""
+
+    result_id: str
+    work_packet_id: str
+    status: str
+    summary: str
+    intake_path: str
+
+    @property
+    def ok(self) -> bool:
+        return self.status == "accepted_for_intake" and bool(self.intake_path)
+
+
+class BridgeWorkClientProtocol(Protocol):
+    def ingest_event(self, envelope: dict[str, Any]) -> BridgeIngestReceipt: ...
+
+
+def _resolve_bridge_bin(configured: str | None = None) -> Path:
+    raw = (configured if configured is not None else os.getenv(BRIDGE_BIN_ENV, "")).strip()
+    if raw:
+        path = Path(raw).expanduser()
+    else:
+        found = shutil.which("bridge")
+        if not found:
+            raise BridgeIngestError("bridge_binary_missing")
+        path = Path(found)
+    if not path.is_file():
+        raise BridgeIngestError("bridge_binary_missing")
+    # Fail closed: refuse relative / PATH-injected names that are not "bridge".
+    if path.name != "bridge":
+        raise BridgeIngestError("bridge_binary_not_allowlisted")
+    return path.resolve()
+
+
+def _resolve_bridge_repo(configured: str | None = None) -> Path:
+    raw = (configured if configured is not None else os.getenv(BRIDGE_REPO_ENV, "")).strip()
+    if not raw:
+        raise BridgeIngestError("bridge_repo_missing")
+    path = Path(raw).expanduser()
+    if not path.is_dir():
+        raise BridgeIngestError("bridge_repo_missing")
+    return path.resolve()
+
+
+def build_ingest_argv(*, bridge_bin: Path, repo: Path) -> list[str]:
+    """Fixed argv for Bridge intake. No user-controlled verbs or flags."""
+    if bridge_bin.name != "bridge":
+        raise BridgeIngestError("bridge_binary_not_allowlisted")
+    if not bridge_bin.is_absolute():
+        raise BridgeIngestError("bridge_binary_not_allowlisted")
+    if not repo.is_absolute() or not repo.is_dir():
+        raise BridgeIngestError("bridge_repo_missing")
+    argv = [str(bridge_bin), "ingest", "-", "--repo", str(repo)]
+    if argv[1] not in ALLOWED_VERBS:
+        raise BridgeIngestError("bridge_verb_not_allowlisted")
+    return argv
+
+
+def build_submit_work_envelope(
+    *,
+    work_id: str,
+    summary: str,
+    evidence_refs: list[dict[str, Any]],
+    occurred_at: str,
+) -> dict[str, Any]:
+    """Map control-plane submit_work into Bridge EventEnvelope v1."""
+    text = (summary or "").strip()
+    if not text:
+        text = f"submit_work {work_id}"
+    # Evidence refs stay in metadata as opaque strings — not policy fields.
+    metadata = {
+        "work_id": work_id,
+        "evidence_ref_count": str(len(evidence_refs)),
+    }
+    return {
+        "version": CONTRACT_VERSION,
+        "id": f"inbox:control_plane:{work_id}",
+        "kind": "inbox.control_plane.submit_work",
+        "source": "inbox",
+        "external_id": work_id,
+        "occurred_at": occurred_at,
+        "payload": {
+            "text": text,
+            "external_ref": work_id,
+            "metadata": metadata,
+        },
+    }
+
+
+def _parse_result_bundle(stdout: str) -> BridgeIngestReceipt:
+    try:
+        payload = json.loads(stdout)
+    except json.JSONDecodeError as exc:
+        raise BridgeIngestError("bridge_result_unparseable") from exc
+    if not isinstance(payload, dict):
+        raise BridgeIngestError("bridge_result_unparseable")
+    status = str(payload.get("status") or "").strip()
+    receipt = BridgeIngestReceipt(
+        result_id=str(payload.get("id") or "").strip(),
+        work_packet_id=str(payload.get("work_packet_id") or "").strip(),
+        status=status,
+        summary=str(payload.get("summary") or "").strip(),
+        intake_path=str(payload.get("intake_path") or "").strip(),
+    )
+    if not receipt.ok:
+        raise BridgeIngestError("bridge_rejected")
+    if payload.get("verification_receipt"):
+        # Intake must never carry execution evidence.
+        raise BridgeIngestError("bridge_claimed_execution")
+    return receipt
+
+
+class BridgeWorkClient:
+    """Allowlisted subprocess caller for `bridge ingest` only."""
+
+    def __init__(self, *, bridge_bin: Path | None = None, repo: Path | None = None) -> None:
+        self._bridge_bin = bridge_bin
+        self._repo = repo
+
+    @classmethod
+    def from_env(cls) -> BridgeWorkClient:
+        return cls()
+
+    def ingest_event(self, envelope: dict[str, Any]) -> BridgeIngestReceipt:
+        bridge_bin = self._bridge_bin or _resolve_bridge_bin()
+        repo = self._repo or _resolve_bridge_repo()
+        argv = build_ingest_argv(bridge_bin=bridge_bin, repo=repo)
+        try:
+            completed = subprocess.run(
+                argv,
+                input=json.dumps(envelope, separators=(",", ":"), sort_keys=True),
+                capture_output=True,
+                text=True,
+                shell=False,
+                timeout=INGEST_TIMEOUT_SEC,
+                check=False,
+            )
+        except subprocess.TimeoutExpired as exc:
+            raise BridgeIngestError("bridge_ingest_timeout") from exc
+        except OSError as exc:
+            raise BridgeIngestError("bridge_ingest_failed") from exc
+        if completed.returncode != 0:
+            raise BridgeIngestError("bridge_rejected")
+        return _parse_result_bundle(completed.stdout)

--- a/docs/invariants.md
+++ b/docs/invariants.md
@@ -185,7 +185,10 @@ Auth fails closed:
 INBOX_CONTROL_PLANE_TOKEN = "" → ¬authorized(/mcp)
 ```
 
-**Enforcement:** `mcp_control_plane.py` on `127.0.0.1:8002`. Seven frozen tools. No Bridge spawn, no model-supplied tokens, no epistemic MCP tool.
+**Enforcement:** `mcp_control_plane.py` on `127.0.0.1:8002`. Seven frozen tools.
+`submit_work` may call Bridge `ingest` via allowlisted `bridge_work_client.py`
+(`shell=False`, verb=`ingest` only) and stores intake path/ids. No Bridge spawn,
+no model-supplied tokens, no epistemic MCP tool. Bridge reject → DENIED ∧ ¬executor.
 
 **Oracle reference:** `saltzer-schroeder-oracle.md` Principle 2 (Fail-Safe Defaults) and Principle 3 (Complete Mediation).
 

--- a/mcp_control_plane.py
+++ b/mcp_control_plane.py
@@ -1,11 +1,12 @@
-"""Ingest-only Inbox MCP control plane (PR-1).
+"""Ingest-only Inbox MCP control plane (PR-1 + PR-2B Bridge intake).
 
 Bind: 127.0.0.1:8002
 Frozen tools: resolve, capture, submit_work, get_work, cancel_work,
 verify_work, run_shortcut.
 
-This surface can accept and capture work. It cannot mint authority or execute
-workers, providers, or Shortcuts. confirm=true is intent, not a lease.
+This surface can accept and capture work and forward submit_work to Bridge
+`ingest`. It cannot mint authority or execute workers, providers, or
+Shortcuts. confirm=true is intent, not a lease. Bridge intake ≠ spawn.
 """
 
 from __future__ import annotations
@@ -13,6 +14,7 @@ from __future__ import annotations
 import json
 import os
 import uuid
+from datetime import UTC, datetime
 from pathlib import Path
 from secrets import compare_digest
 from typing import Any
@@ -23,6 +25,12 @@ from starlette.requests import Request
 from starlette.responses import JSONResponse
 
 from approval_store import ApprovalStore
+from bridge_work_client import (
+    BridgeIngestError,
+    BridgeWorkClient,
+    BridgeWorkClientProtocol,
+    build_submit_work_envelope,
+)
 from event_store import CaptureEvent, EventStore, EventStoreConflict, EventStoreValidationError
 
 CONTROL_PLANE_HOST = "127.0.0.1"
@@ -227,10 +235,14 @@ class ControlPlane:
         event_store: EventStore,
         approval_store: ApprovalStore,
         shortcut_registry: dict[str, Any] | None = None,
+        bridge_client: BridgeWorkClientProtocol | None = None,
     ) -> None:
         self.event_store = event_store
         self.approval_store = approval_store
         self.shortcut_registry = shortcut_registry or load_shortcut_registry()
+        # Default: real Bridge ingest client (fail-closed when env unset).
+        # Tests inject a stub; never a spawn/orchestrator client.
+        self.bridge_client: BridgeWorkClientProtocol = bridge_client or BridgeWorkClient.from_env()
         self.work: dict[str, dict[str, Any]] = {}
         self.execution_log: list[dict[str, Any]] = []
 
@@ -256,8 +268,10 @@ class ControlPlane:
         operation: str,
         body: dict[str, Any],
         resource_ref: str,
+        work_id: str | None = None,
+        bridge: dict[str, Any] | None = None,
     ) -> str:
-        work_id = _now_work_id()
+        work_id = work_id or _now_work_id()
         created = self.approval_store.create_request(
             method="MCP",
             path=f"/control-plane/{operation}",
@@ -281,13 +295,20 @@ class ControlPlane:
             "server_authority": self._lookup_unused_approval(operation),
             "body": body,
         }
+        if bridge:
+            record["bridge"] = bridge
         self.work[work_id] = record
         self.approval_store.log_event(
             "control_plane_intake",
             request_id=created["request_id"],
             operation=operation,
             result="accepted_for_intake",
-            detail={"work_id": work_id, "executed": False, "spawn_flag": spawn_flag()},
+            detail={
+                "work_id": work_id,
+                "executed": False,
+                "spawn_flag": spawn_flag(),
+                "bridge": bridge,
+            },
         )
         return work_id
 
@@ -403,7 +424,39 @@ class ControlPlane:
         invalid = self._validate_evidence_refs(evidence_refs)
         if invalid:
             return _denied(invalid)
-        work_id = self._record_intake(
+
+        # Allocate id before Bridge so the EventEnvelope external_id is stable.
+        # Bridge reject → no local work record and no executor invocation.
+        work_id = _now_work_id()
+        envelope = build_submit_work_envelope(
+            work_id=work_id,
+            summary=summary,
+            evidence_refs=list(evidence_refs or []),
+            occurred_at=datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z"),
+        )
+        try:
+            receipt = self.bridge_client.ingest_event(envelope)
+        except BridgeIngestError as exc:
+            self.approval_store.log_event(
+                "control_plane_denied",
+                operation="submit_work",
+                result="DENIED",
+                detail={
+                    "reason": str(exc) or "bridge_rejected",
+                    "confirm": confirm,
+                    "executed": False,
+                },
+            )
+            return _denied(str(exc) or "bridge_rejected", confirm_is_authority=False)
+
+        bridge_meta = {
+            "result_id": receipt.result_id,
+            "work_packet_id": receipt.work_packet_id,
+            "intake_path": receipt.intake_path,
+            "status": receipt.status,
+            "summary": receipt.summary,
+        }
+        self._record_intake(
             operation="submit_work",
             body={
                 "evidence_refs": evidence_refs,
@@ -411,11 +464,16 @@ class ControlPlane:
                 "summary": summary,
             },
             resource_ref="submit_work",
+            work_id=work_id,
+            bridge=bridge_meta,
         )
         return _intake(
             work_id,
             confirm_is_authority=False,
             server_authority_present=bool(self.work[work_id]["server_authority"]),
+            bridge_intake_path=receipt.intake_path,
+            bridge_result_id=receipt.result_id,
+            bridge_work_packet_id=receipt.work_packet_id,
         )
 
     def get_work(self, work_id: str = "") -> dict[str, Any]:
@@ -585,11 +643,13 @@ def make_control_plane(
     event_db: Path | None = None,
     approval_db: Path | None = None,
     shortcut_registry: dict[str, Any] | None = None,
+    bridge_client: BridgeWorkClientProtocol | None = None,
 ) -> ControlPlane:
     return ControlPlane(
         event_store=EventStore(event_db),
         approval_store=ApprovalStore(approval_db),
         shortcut_registry=shortcut_registry,
+        bridge_client=bridge_client,
     )
 
 

--- a/tests/test_mcp_control_plane.py
+++ b/tests/test_mcp_control_plane.py
@@ -1,10 +1,11 @@
-"""PR-1 ingest-only MCP control plane. No Bridge, no spawn, no epistemic tool."""
+"""PR-2B MCP control plane: Bridge ingest only. No spawn, no epistemic tool."""
 
 from __future__ import annotations
 
 import ast
 import asyncio
 import json
+import shutil
 from pathlib import Path
 
 import httpx
@@ -15,6 +16,15 @@ from mcp.client.streamable_http import streamable_http_client
 from starlette.testclient import TestClient
 
 from approval_store import ApprovalStore
+from bridge_work_client import (
+    BRIDGE_BIN_ENV,
+    BRIDGE_REPO_ENV,
+    BridgeIngestError,
+    BridgeIngestReceipt,
+    BridgeWorkClient,
+    build_ingest_argv,
+    build_submit_work_envelope,
+)
 from event_store import CaptureEvent, EventStore, identity_digest_for
 from mcp_control_plane import (
     CONTROL_PLANE_PORT,
@@ -33,6 +43,29 @@ from tools_registry import TOOLS, include_names
 pytestmark = pytest.mark.safe
 
 ROOT = Path(__file__).resolve().parents[1]
+BRIDGE_BIN = shutil.which("bridge")
+
+
+class StubBridgeClient:
+    """Test double: records envelopes; never executes workers."""
+
+    def __init__(self, *, fail_with: str | None = None) -> None:
+        self.calls: list[dict] = []
+        self.fail_with = fail_with
+        self.executor_invocations = 0
+
+    def ingest_event(self, envelope: dict) -> BridgeIngestReceipt:
+        self.calls.append(envelope)
+        if self.fail_with:
+            raise BridgeIngestError(self.fail_with)
+        work_id = envelope.get("external_id") or "wrk_stub"
+        return BridgeIngestReceipt(
+            result_id=f"result:workpacket:inbox:control_plane:{work_id}",
+            work_packet_id=f"workpacket:inbox:control_plane:{work_id}",
+            status="accepted_for_intake",
+            summary="event accepted for intake; execution authority was not granted",
+            intake_path=f"/tmp/.bridge/intake/{work_id}.json",
+        )
 
 
 def _evidence_refs(**overrides) -> list[dict]:
@@ -61,10 +94,16 @@ def _capture_body(**overrides) -> dict:
 
 
 @pytest.fixture
-def plane(tmp_path) -> ControlPlane:
+def bridge_stub() -> StubBridgeClient:
+    return StubBridgeClient()
+
+
+@pytest.fixture
+def plane(tmp_path, bridge_stub) -> ControlPlane:
     return ControlPlane(
         event_store=EventStore(tmp_path / "events.sqlite3"),
         approval_store=ApprovalStore(tmp_path / "approvals.sqlite3"),
+        bridge_client=bridge_stub,
     )
 
 
@@ -211,21 +250,27 @@ def test_capture_matches_direct_eventstore_append(tmp_path):
     assert mcp["event"]["event_id"] == stored.event_id
 
 
-def test_submit_work_confirm_true_is_intake_not_execution(plane, monkeypatch):
+def test_submit_work_confirm_true_is_intake_not_execution(plane, bridge_stub, monkeypatch):
     monkeypatch.setenv(SPAWN_ENV, "0")
     result = plane.submit_work(_evidence_refs(), confirm=True, summary="do the thing")
     assert result["result"] == "accepted_for_intake"
     assert result["executed"] is False
     assert result["confirm_is_authority"] is False
     assert result["spawn_flag"] == 0
+    assert result["bridge_intake_path"]
+    assert result["bridge_result_id"]
+    assert result["bridge_work_packet_id"]
     assert plane.execution_log == []
+    assert bridge_stub.executor_invocations == 0
+    assert len(bridge_stub.calls) == 1
     listed = plane.get_work()
     assert listed["result"] == "ok"
     assert listed["work"][0]["work_id"] == result["work_id"]
     assert listed["work"][0]["executed"] is False
+    assert listed["work"][0]["bridge"]["intake_path"] == result["bridge_intake_path"]
 
 
-def test_submit_work_cannot_supply_lease_or_capability(plane):
+def test_submit_work_cannot_supply_lease_or_capability(plane, bridge_stub):
     for kwargs in (
         {"lease": "lease_fake"},
         {"lease_token": "tok"},
@@ -241,6 +286,7 @@ def test_submit_work_cannot_supply_lease_or_capability(plane):
         assert result["executed"] is False
     assert plane.execution_log == []
     assert plane.work == {}
+    assert bridge_stub.calls == []
 
 
 def test_submit_work_spawn_flag_one_still_does_not_execute(plane, monkeypatch):
@@ -253,9 +299,115 @@ def test_submit_work_spawn_flag_one_still_does_not_execute(plane, monkeypatch):
     assert plane.execution_log == []
 
 
-def test_submit_work_requires_evidence_refs(plane):
+def test_submit_work_requires_evidence_refs(plane, bridge_stub):
     assert plane.submit_work([])["result"] == "DENIED"
     assert plane.submit_work(None)["result"] == "DENIED"
+    assert bridge_stub.calls == []
+
+
+def test_submit_work_bridge_reject_does_not_invoke_executor(tmp_path):
+    stub = StubBridgeClient(fail_with="bridge_rejected")
+    plane = ControlPlane(
+        event_store=EventStore(tmp_path / "events.sqlite3"),
+        approval_store=ApprovalStore(tmp_path / "approvals.sqlite3"),
+        bridge_client=stub,
+    )
+    result = plane.submit_work(_evidence_refs(), confirm=True, summary="should fail closed")
+    assert result["result"] == "DENIED"
+    assert result["reason"] == "bridge_rejected"
+    assert result["executed"] is False
+    assert plane.work == {}
+    assert plane.execution_log == []
+    assert stub.executor_invocations == 0
+    assert len(stub.calls) == 1
+
+
+def test_submit_work_missing_bridge_authority_fails_closed(tmp_path, monkeypatch):
+    monkeypatch.delenv(BRIDGE_BIN_ENV, raising=False)
+    monkeypatch.delenv(BRIDGE_REPO_ENV, raising=False)
+    monkeypatch.setenv("PATH", "/usr/bin:/bin")
+    plane = ControlPlane(
+        event_store=EventStore(tmp_path / "events.sqlite3"),
+        approval_store=ApprovalStore(tmp_path / "approvals.sqlite3"),
+        bridge_client=BridgeWorkClient.from_env(),
+    )
+    result = plane.submit_work(_evidence_refs(), confirm=True)
+    assert result["result"] == "DENIED"
+    assert result["executed"] is False
+    assert result["reason"] in {
+        "bridge_binary_missing",
+        "bridge_repo_missing",
+        "bridge_binary_not_allowlisted",
+    }
+    assert plane.work == {}
+    assert plane.execution_log == []
+
+
+def test_bridge_work_client_argv_is_allowlisted_ingest_only(tmp_path):
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    bridge = bin_dir / "bridge"
+    bridge.write_text("#!/bin/sh\nexit 1\n", encoding="utf-8")
+    bridge.chmod(0o755)
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    argv = build_ingest_argv(bridge_bin=bridge.resolve(), repo=repo.resolve())
+    assert argv == [str(bridge.resolve()), "ingest", "-", "--repo", str(repo.resolve())]
+    assert "spawn" not in argv
+    assert "shell" not in "".join(argv).lower()
+
+
+def test_bridge_work_client_rejects_non_bridge_binary_name(tmp_path):
+    impostor = tmp_path / "not-bridge"
+    impostor.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    impostor.chmod(0o755)
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    with pytest.raises(BridgeIngestError, match="bridge_binary_not_allowlisted"):
+        build_ingest_argv(bridge_bin=impostor.resolve(), repo=repo.resolve())
+
+
+@pytest.mark.skipif(not BRIDGE_BIN, reason="local bridge binary not installed")
+def test_submit_work_integration_against_local_bridge(tmp_path, monkeypatch):
+    """Real `bridge ingest` handshake; stores intake path/id only."""
+    bridge_bin = Path(BRIDGE_BIN).resolve()
+    assert bridge_bin.name == "bridge"
+    repo = tmp_path / "bridge-repo"
+    repo.mkdir()
+    client = BridgeWorkClient(bridge_bin=bridge_bin, repo=repo)
+    plane = ControlPlane(
+        event_store=EventStore(tmp_path / "events.sqlite3"),
+        approval_store=ApprovalStore(tmp_path / "approvals.sqlite3"),
+        bridge_client=client,
+    )
+    monkeypatch.setenv(SPAWN_ENV, "0")
+    result = plane.submit_work(
+        _evidence_refs(),
+        confirm=True,
+        summary="LA-03 integration against local Bridge ingest",
+    )
+    assert result["result"] == "accepted_for_intake"
+    assert result["executed"] is False
+    assert result["spawn_flag"] == 0
+    assert result["confirm_is_authority"] is False
+    intake_path = Path(result["bridge_intake_path"])
+    assert intake_path.is_file()
+    assert str(repo.resolve()) in str(intake_path.resolve())
+    assert result["bridge_work_packet_id"].startswith("workpacket:")
+    assert result["bridge_result_id"].startswith("result:")
+    stored = json.loads(intake_path.read_text(encoding="utf-8"))
+    assert "event" in stored and "work_packet" in stored
+    assert plane.execution_log == []
+    # Adversarial: reject path does not write executor state
+    bad = StubBridgeClient(fail_with="bridge_rejected")
+    denied_plane = ControlPlane(
+        event_store=EventStore(tmp_path / "events2.sqlite3"),
+        approval_store=ApprovalStore(tmp_path / "approvals2.sqlite3"),
+        bridge_client=bad,
+    )
+    denied = denied_plane.submit_work(_evidence_refs(), confirm=True)
+    assert denied["result"] == "DENIED"
+    assert denied_plane.execution_log == []
 
 
 def test_server_side_approval_lookup_is_not_execution(plane):
@@ -329,7 +481,7 @@ def test_cancel_and_verify_do_not_execute(plane):
     assert plane.verify_work("wrk_missing")["result"] == "DENIED"
 
 
-def test_control_plane_source_cannot_import_spawn_or_bridge():
+def test_control_plane_source_cannot_import_spawn_or_subprocess():
     source = (ROOT / "mcp_control_plane.py").read_text(encoding="utf-8")
     tree = ast.parse(source)
     imported = set()
@@ -338,16 +490,42 @@ def test_control_plane_source_cannot_import_spawn_or_bridge():
             imported.update(alias.name.split(".")[0] for alias in node.names)
         elif isinstance(node, ast.ImportFrom) and node.module:
             imported.add(node.module.split(".")[0])
+    # PR-2B: thin bridge_work_client is allowed; subprocess/spawn stay out.
+    assert "bridge_work_client" in imported
     assert "subprocess" not in imported
-    assert "bridge" not in imported
+    assert "bridge" not in imported  # no Go package / spawn module
     assert "inbox_bridge_adapter" not in imported
-    assert "bridge_work_client" not in source
     assert "run_shell" not in source
     assert "epistemic" not in source.lower()
     assert "PublicAuthMiddleware" not in source
     assert "_is_publicly_authorized" not in source
     assert 'Mount("/mcp"' not in source
     assert "streamable_http_app()" in source
+    assert "bridge spawn" not in source.lower()
+    assert "promote-approval" not in source.lower()
+    # Client itself must not allowlist spawn.
+    client_src = (ROOT / "bridge_work_client.py").read_text(encoding="utf-8")
+    assert 'ALLOWED_VERBS = frozenset({"ingest"})' in client_src
+    assert "shell=False" in client_src
+    assert '"spawn"' not in client_src
+    assert '"promote-approval"' not in client_src
+
+
+def test_build_submit_work_envelope_is_bridge_contracts_v1():
+    envelope = build_submit_work_envelope(
+        work_id="wrk_abc",
+        summary="hello",
+        evidence_refs=_evidence_refs(),
+        occurred_at="2026-09-06T06:00:00Z",
+    )
+    assert envelope["version"] == "bridge.contracts.v1"
+    assert envelope["id"] == "inbox:control_plane:wrk_abc"
+    assert envelope["kind"] == "inbox.control_plane.submit_work"
+    assert envelope["source"] == "inbox"
+    assert envelope["payload"]["text"] == "hello"
+    assert "role" not in envelope
+    assert "lease" not in envelope
+    assert "capability" not in envelope
 
 
 def _tool_payload(result) -> dict:


### PR DESCRIPTION
## Summary
- `submit_work` builds a Bridge `EventEnvelope` and calls native `bridge ingest` via allowlisted `bridge_work_client.py` (`shell=False`, verb=`ingest` only).
- Stores Bridge `intake_path` / result / work-packet ids on `accepted_for_intake`; never spawns, never mints leases.
- Fail-closed: model-supplied authority → DENIED (no Bridge call); Bridge reject / missing bin/repo → DENIED ∧ empty `execution_log`; `confirm=true` is still not authority; seven-tool surface unchanged; `INBOX_CONTROL_PLANE_SPAWN` stays default 0.

Closes / addresses https://github.com/jwalin-shah/inbox/issues/74

## Test plan
- [x] `INBOX_TEST_MODE=1 uv run pytest tests/test_mcp_control_plane.py -q --no-cov` → **27 passed**
- [x] Integration against local `/Users/jwalinshah/.local/bin/bridge` (temp `--repo`)
- [x] Adversarial: confirm-only, model lease/capability, Bridge reject, missing Bridge config
- [ ] Do not merge to `main` in this pass
- [ ] Do not enable `INBOX_CONTROL_PLANE_SPAWN`

## Receipt
- Inbox SHA: `914acfb4ecc36997162a88a3df4180f351cd4ab4` (base `fd33b93` / `local-actuator/pr2a-mcp-transport`)
- Bridge target SHA (clean worktree with ingest contract exercised): `a5149f4962f889a13bf9217abea28f6c4e8eb2b2`
- Bridge binary used in prove/integration: `~/.local/bin/bridge` (2026-09-04)

## Stacking
Base is `local-actuator/pr2a-mcp-transport` (PR-2A). Not targeting `main`.


Made with [Cursor](https://cursor.com)