### PR TITLE
fix(tasks): land TASK-026 Phase C provider identity + create idempotency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ htmlcov/
 .inbox_capture_health.sqlite3*
 .inbox_egress_audit.sqlite3*
 .inbox_approvals.sqlite3*
+.inbox_task_create_bindings.sqlite3*
 .inbox_runtime/
 .factory/runtime/
 .factory/outputs/

--- a/inbox_server.py
+++ b/inbox_server.py
@@ -1055,6 +1055,9 @@ class TaskCreateRequest(BaseModel):
     list_id: str = "@default"
     due: str = ""
     notes: str = ""
+    # Optional canary/client identity. When set, a successful create binds
+    # provider list_id+task_id so retries of the same key cannot insert again.
+    idempotency_key: str = ""
 
 
 class TaskUpdateRequest(BaseModel):
@@ -1882,8 +1885,13 @@ async def _process_followup_reminders() -> None:
                         try:
                             _, tasks_svc = _get_tasks_service_for_account("")
                             due_iso = datetime.now().strftime("%Y-%m-%dT00:00:00.000Z")
-                            ok = await asyncio.to_thread(
+                            created = await asyncio.to_thread(
                                 task_create, tasks_svc, title, "@default", due_iso, notes
+                            )
+                            ok = (
+                                bool(created.get("ok"))
+                                if isinstance(created, dict)
+                                else bool(created)
                             )
                             if ok:
                                 task_created_via = "google_tasks"
@@ -1956,9 +1964,10 @@ async def _process_departure_alerts() -> None:
                     try:
                         _, tasks_svc = _get_tasks_service_for_account("")
                         due_iso = dep.departure_time.strftime("%Y-%m-%dT00:00:00.000Z")
-                        ok = await asyncio.to_thread(
+                        created = await asyncio.to_thread(
                             task_create, tasks_svc, title, "@default", due_iso, notes
                         )
+                        ok = bool(created.get("ok")) if isinstance(created, dict) else bool(created)
                     except Exception:
                         pass
                 if not ok:
@@ -3627,9 +3636,34 @@ async def list_tasks(
 
 @app.post("/tasks")
 async def create_task(req: TaskCreateRequest, account: str = ""):
+    from task_create_bindings import get_binding, put_binding
+
+    idem = str(req.idempotency_key or "").strip()
+    if idem:
+        existing = await asyncio.to_thread(get_binding, idem)
+        if existing:
+            return {
+                "ok": True,
+                "task_id": existing["task_id"],
+                "list_id": existing["list_id"],
+                "idempotent_replay": True,
+                "idempotency_key": idem,
+            }
+
     _, svc = _get_tasks_service_for_account(account)
-    ok = await asyncio.to_thread(task_create, svc, req.title, req.list_id, req.due, req.notes)
-    return {"ok": ok}
+    result = await asyncio.to_thread(task_create, svc, req.title, req.list_id, req.due, req.notes)
+    if not isinstance(result, dict):
+        result = {"ok": bool(result), "task_id": "", "list_id": req.list_id}
+    if result.get("ok") and idem and result.get("task_id"):
+        await asyncio.to_thread(
+            put_binding,
+            idem,
+            list_id=str(result["list_id"]),
+            task_id=str(result["task_id"]),
+            title=req.title,
+        )
+        result = {**result, "idempotent_replay": False, "idempotency_key": idem}
+    return result
 
 
 @app.post("/tasks/{task_id}/complete")
@@ -3913,13 +3947,10 @@ async def create_task_from_message(req: TaskFromMessageRequest):
         notes = req.notes
         if req.message_source == "gmail":
             notes = f"{notes}\n\nFrom email: {req.message_id}".strip()
-        ok = await asyncio.to_thread(task_create, svc, req.title, req.list_id, "", notes)
-        if not ok:
+        created = await asyncio.to_thread(task_create, svc, req.title, req.list_id, "", notes)
+        if not (isinstance(created, dict) and created.get("ok") and created.get("task_id")):
             raise HTTPException(500, "Failed to create Google Task")
-        # Query newly-created task id (Google Tasks API doesn't return it from task_create)
-        tasks = await asyncio.to_thread(tasks_list, svc, req.list_id, False, 10)
-        latest = next((t for t in tasks if t.title == req.title), None)
-        task_id = latest.id if latest else ""
+        task_id = str(created["task_id"])
     elif req.task_type == "reminders":
         notes = req.notes
         if req.message_source == "gmail":

--- a/services.py
+++ b/services.py
@@ -4019,8 +4019,12 @@ def task_create(
     list_id: str = "@default",
     due: str = "",
     notes: str = "",
-) -> bool:
-    """Create a Google Task."""
+) -> dict[str, Any]:
+    """Create a Google Task and return exact provider identity.
+
+    Returns ``{"ok": bool, "task_id": str, "list_id": str}``. ``list_id`` is the
+    concrete Google Tasks list id (``@default`` is resolved when possible).
+    """
     _assert_live_write_allowed("create Google Task")
     try:
         body = {"title": title}
@@ -4028,11 +4032,23 @@ def task_create(
             body["notes"] = notes
         if due:
             body["due"] = due
-        service.tasks().insert(tasklist=list_id, body=body).execute()
-        return True
+        created = service.tasks().insert(tasklist=list_id, body=body).execute() or {}
+        task_id = str(created.get("id") or "")
+        resolved_list_id = str(list_id or "@default")
+        if resolved_list_id == "@default":
+            try:
+                list_meta = service.tasklists().get(tasklist="@default").execute() or {}
+                resolved_list_id = str(list_meta.get("id") or resolved_list_id)
+            except Exception:
+                self_link = str(created.get("selfLink") or "")
+                # .../lists/{listId}/tasks/{taskId}
+                marker = "/lists/"
+                if marker in self_link:
+                    resolved_list_id = self_link.split(marker, 1)[1].split("/", 1)[0]
+        return {"ok": bool(task_id), "task_id": task_id, "list_id": resolved_list_id}
     except Exception:
         _log_service_failure("task_create", title=title, list_id=list_id)
-        return False
+        return {"ok": False, "task_id": "", "list_id": str(list_id or "@default")}
 
 
 def task_complete(service, task_id: str, list_id: str = "@default") -> bool:

--- a/task_create_bindings.py
+++ b/task_create_bindings.py
@@ -1,0 +1,109 @@
+"""Tiny durable bindings for idempotent Google Tasks creates.
+
+Maps a caller-supplied idempotency/canary key to the exact provider
+``list_id`` + ``task_id`` so a retry of the same key cannot insert a second
+Google Tasks object. Not a sync engine or task authority — only a projection
+binding store for governed creates.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import threading
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+BASE_DIR = Path(__file__).parent
+BINDINGS_DB = BASE_DIR / ".inbox_task_create_bindings.sqlite3"
+
+_lock = threading.Lock()
+
+
+def _now_iso() -> str:
+    return datetime.now().isoformat()
+
+
+def _connect(db_path: Path | None = None) -> sqlite3.Connection:
+    path = db_path or BINDINGS_DB
+    conn = sqlite3.connect(str(path), timeout=30)
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS task_create_bindings (
+            idempotency_key TEXT PRIMARY KEY,
+            list_id TEXT NOT NULL,
+            task_id TEXT NOT NULL,
+            title TEXT NOT NULL DEFAULT '',
+            created_at TEXT NOT NULL
+        )
+        """
+    )
+    return conn
+
+
+def get_binding(idempotency_key: str, db_path: Path | None = None) -> dict[str, Any] | None:
+    key = str(idempotency_key or "").strip()
+    if not key:
+        return None
+    with _lock:
+        conn = _connect(db_path)
+        try:
+            row = conn.execute(
+                "SELECT idempotency_key, list_id, task_id, title, created_at "
+                "FROM task_create_bindings WHERE idempotency_key = ?",
+                (key,),
+            ).fetchone()
+        finally:
+            conn.close()
+    if not row:
+        return None
+    return {
+        "idempotency_key": row[0],
+        "list_id": row[1],
+        "task_id": row[2],
+        "title": row[3],
+        "created_at": row[4],
+    }
+
+
+def put_binding(
+    idempotency_key: str,
+    *,
+    list_id: str,
+    task_id: str,
+    title: str = "",
+    db_path: Path | None = None,
+) -> dict[str, Any]:
+    key = str(idempotency_key or "").strip()
+    if not key:
+        raise ValueError("idempotency_key is required")
+    if not list_id or not task_id:
+        raise ValueError("list_id and task_id are required")
+    created_at = _now_iso()
+    with _lock:
+        conn = _connect(db_path)
+        try:
+            conn.execute(
+                """
+                INSERT OR IGNORE INTO task_create_bindings
+                    (idempotency_key, list_id, task_id, title, created_at)
+                VALUES (?, ?, ?, ?, ?)
+                """,
+                (key, list_id, task_id, title, created_at),
+            )
+            conn.commit()
+            row = conn.execute(
+                "SELECT idempotency_key, list_id, task_id, title, created_at "
+                "FROM task_create_bindings WHERE idempotency_key = ?",
+                (key,),
+            ).fetchone()
+        finally:
+            conn.close()
+    assert row is not None
+    return {
+        "idempotency_key": row[0],
+        "list_id": row[1],
+        "task_id": row[2],
+        "title": row[3],
+        "created_at": row[4],
+    }

--- a/tests/test_task_create_provider_identity.py
+++ b/tests/test_task_create_provider_identity.py
@@ -1,0 +1,124 @@
+"""Regression: same canary idempotency key cannot create a second Google Task."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def approval_client():
+    import inbox_server
+
+    inbox_server._approval_leases.clear()
+    fake_state = inbox_server.ServerState()
+    runtime = inbox_server.InboxServerRuntime(
+        server_state=fake_state,
+        init_contacts_func=lambda: 0,
+        google_auth_func=inbox_server._empty_google_services,
+        start_scheduler=False,
+        ambient_autostart=False,
+    )
+
+    with (
+        patch.dict(
+            os.environ,
+            {
+                "INBOX_SERVER_TOKEN": "",
+                "INBOX_TEST_MODE": "1",
+                "INBOX_SERVER_ALLOW_UNAUTHENTICATED": "1",
+            },
+            clear=False,
+        ),
+        TestClient(inbox_server.create_app(runtime), raise_server_exceptions=False) as client,
+    ):
+        yield client
+    inbox_server._approval_leases.clear()
+
+
+def test_put_binding_then_get_roundtrips(tmp_path: Path):
+    from task_create_bindings import get_binding, put_binding
+
+    db = tmp_path / "bindings.sqlite3"
+    put_binding(
+        "canary-1",
+        list_id="LIST123",
+        task_id="TASK456",
+        title="LIFEOPS CANARY — TASK-026 — canary-1",
+        db_path=db,
+    )
+    got = get_binding("canary-1", db_path=db)
+    assert got is not None
+    assert got["list_id"] == "LIST123"
+    assert got["task_id"] == "TASK456"
+
+
+def test_put_binding_is_idempotent_and_preserves_first_provider_ids(tmp_path: Path):
+    from task_create_bindings import get_binding, put_binding
+
+    db = tmp_path / "bindings.sqlite3"
+    put_binding("canary-1", list_id="LIST_A", task_id="TASK_A", title="t", db_path=db)
+    put_binding("canary-1", list_id="LIST_B", task_id="TASK_B", title="t2", db_path=db)
+    got = get_binding("canary-1", db_path=db)
+    assert got is not None
+    assert got["list_id"] == "LIST_A"
+    assert got["task_id"] == "TASK_A"
+
+
+def test_create_task_route_replays_binding_without_second_provider_insert(
+    approval_client, monkeypatch, tmp_path
+):
+    import inbox_server
+    import task_create_bindings
+
+    db = tmp_path / "bindings.sqlite3"
+    monkeypatch.setattr(task_create_bindings, "BINDINGS_DB", db)
+
+    inbox_server.state.tasks_services = {"me@example.com": MagicMock()}
+    body = {
+        "title": "LIFEOPS CANARY — TASK-026 — req-abc",
+        "list_id": "@default",
+        "notes": "phase-c",
+        "idempotency_key": "req-abc",
+    }
+    lease = inbox_server.mint_local_approval_lease("POST", "/tasks", body=body)
+
+    calls = {"n": 0}
+
+    def _fake_create(service, title, list_id="@default", due="", notes=""):
+        calls["n"] += 1
+        return {"ok": True, "task_id": f"TASK-{calls['n']}", "list_id": "LIST_REAL"}
+
+    monkeypatch.setattr(inbox_server, "task_create", _fake_create)
+
+    first = approval_client.post(
+        "/tasks",
+        headers={"X-Inbox-Approval-Lease": lease},
+        json=body,
+    )
+    assert first.status_code == 200
+    first_body = first.json()
+    assert first_body["ok"] is True
+    assert first_body["task_id"] == "TASK-1"
+    assert first_body["list_id"] == "LIST_REAL"
+    assert first_body.get("idempotent_replay") is False
+    assert calls["n"] == 1
+
+    # Fresh lease for the same canary identity — must not call provider again.
+    lease2 = inbox_server.mint_local_approval_lease("POST", "/tasks", body=body)
+    second = approval_client.post(
+        "/tasks",
+        headers={"X-Inbox-Approval-Lease": lease2},
+        json=body,
+    )
+    assert second.status_code == 200
+    second_body = second.json()
+    assert second_body["ok"] is True
+    assert second_body["task_id"] == "TASK-1"
+    assert second_body["list_id"] == "LIST_REAL"
+    assert second_body.get("idempotent_replay") is True
+    assert calls["n"] == 1


### PR DESCRIPTION
## Summary
- Canonicalizes code already proven by the bounded TASK-026 / Inbox #78 Phase C canary: Google Tasks `create` now returns exact provider `list_id`/`task_id`, and optional `idempotency_key` binds that identity so retries cannot insert a second provider object.
- Preserves existing `inbox.tasks.write` / per-action approval lease gate; Inbox `lease_*` is **transport only** and is **not** HomeBase authorization.
- HomeBase authorization for the proven canary remains: Ticket/Spec/Decision → Contract/Grant → signed `AdmissionCheckReceipt` (see Phase C receipt under the isolated worktree; not included in this PR).

## Exact source
- Base: `origin/main` @ `be61619275150bbb0a608dfb62021bc2859488d0`
- Branch commit: `c6e9cb75652d91a529bab861cff91f66fcb4846a`
- Changed files only:
  - `services.py`
  - `inbox_server.py`
  - `task_create_bindings.py` (new)
  - `tests/test_task_create_provider_identity.py` (new)
  - `.gitignore` (ignore local bindings sqlite)

## Test plan
- [x] `pytest tests/test_task_create_provider_identity.py tests/test_services.py::test_test_mode_blocks_extended_live_writes -q` → 4 passed
- [x] `pytest tests/test_approval_route_gate.py tests/test_task_create_provider_identity.py tests/test_services.py::test_test_mode_blocks_extended_live_writes -q --no-cov` → 87 passed
- [ ] CI green on this PR
- [ ] After merge: fresh-main reproducibility (tests + no-mutation source contract proof)

## Explicit non-goals
No sync engine, no extra provider, no Bridge/HomeBase redesign, no OCI, no receipts/secrets/local state in tree.