### PR TITLE
TASK-026: source-converge EventStore/MCP/Bridge intake onto Phase-C main

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ htmlcov/
 .inbox_capture_health.sqlite3*
 .inbox_egress_audit.sqlite3*
 .inbox_approvals.sqlite3*
+.inbox_event_log.sqlite3*
 .inbox_runtime/
 .factory/runtime/
 .factory/outputs/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,7 @@ Inbox invariants are formalized as tensor equations in `docs/invariants.md`, eac
 | Server API (`inbox_server.py`) | `api-design-oracle.md` | X-Request-ID, structured errors, timeouts, connection pool hygiene |
 | Connectors (`connectors/`) | `saltzer-schroeder-oracle.md` | Auth check before use, 429 backoff, non-blocking sync, circuit breaker |
 | MCP gateway (`mcp_gateway.py`) | `api-design-oracle.md` | JSON-RPC 2.0 conformance, tool call validation, session lifecycle |
+| MCP control plane (`mcp_control_plane.py`) | `saltzer-schroeder-oracle.md` | Fail-closed auth, ApprovalStore lookup, ingest-only spawn=0, confirm≠authority |
 | Message sync (`message_sync.py`) | `data-quality-oracle.md` | Unique message IDs, no sync duplicates, idempotent sync |
 | Approval store (`approval_store.py`) | `saltzer-schroeder-oracle.md` | State machine consistency, complete mediation, audit logging |
 | Egress audit (`egress_audit.py`) | `saltzer-schroeder-oracle.md` | Host allowlist, all outbound traffic logged |

--- a/MCP_SETUP.md
+++ b/MCP_SETUP.md
@@ -35,6 +35,17 @@ Run the private inbox backend and the MCP layers separately:
    - Local subprocess entrypoint for the read-only tool surface
    - Useful if you want a second local MCP server with fewer capabilities
 
+6. `mcp_control_plane.py`
+   - Ingest-only LifeOps control plane on `127.0.0.1:8002`
+   - Frozen tools: `resolve`, `capture`, `submit_work`, `get_work`,
+     `cancel_work`, `verify_work`, `run_shortcut`
+   - Fail-closed `INBOX_CONTROL_PLANE_TOKEN` (unlike `mcp_gateway.py`, an
+     empty token is unauthorized)
+   - `INBOX_CONTROL_PLANE_SPAWN` defaults to `0`; `confirm=true` is not authority
+   - `submit_work` forwards to Bridge `ingest` via `bridge_work_client.py`
+     (argv allowlist, `shell=False`); stores intake path/ids only — not spawn
+   - Does not wrap the REST `tools_registry.py` surface and does not mint leases
+
 ## Which Path To Use
 
 Use local `stdio` when the assistant runs on the same machine as Inbox.

--- a/bridge_work_client.py
+++ b/bridge_work_client.py
@@ -1,0 +1,177 @@
+"""Thin Bridge intake client for the Inbox MCP control plane (PR-2B).
+
+Calls only the existing Bridge CLI handshake:
+
+    bridge ingest - --repo <dir>
+
+This is intake, not execution. It never invokes spawn, promote-approval,
+deliver, or any other Bridge verb. argv is allowlisted; shell=False.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Protocol
+
+BRIDGE_BIN_ENV = "INBOX_BRIDGE_BIN"
+BRIDGE_REPO_ENV = "INBOX_BRIDGE_REPO"
+CONTRACT_VERSION = "bridge.contracts.v1"
+INGEST_TIMEOUT_SEC = 30
+ALLOWED_VERBS = frozenset({"ingest"})
+
+
+class BridgeIngestError(RuntimeError):
+    """Bridge intake failed closed (reject, missing config, or bad output)."""
+
+
+@dataclass(frozen=True)
+class BridgeIngestReceipt:
+    """Ids/paths returned by Bridge ingest. Never an execution grant."""
+
+    result_id: str
+    work_packet_id: str
+    status: str
+    summary: str
+    intake_path: str
+
+    @property
+    def ok(self) -> bool:
+        return self.status == "accepted_for_intake" and bool(self.intake_path)
+
+
+class BridgeWorkClientProtocol(Protocol):
+    def ingest_event(self, envelope: dict[str, Any]) -> BridgeIngestReceipt: ...
+
+
+def _resolve_bridge_bin(configured: str | None = None) -> Path:
+    raw = (configured if configured is not None else os.getenv(BRIDGE_BIN_ENV, "")).strip()
+    if raw:
+        path = Path(raw).expanduser()
+    else:
+        found = shutil.which("bridge")
+        if not found:
+            raise BridgeIngestError("bridge_binary_missing")
+        path = Path(found)
+    if not path.is_file():
+        raise BridgeIngestError("bridge_binary_missing")
+    # Fail closed: refuse relative / PATH-injected names that are not "bridge".
+    if path.name != "bridge":
+        raise BridgeIngestError("bridge_binary_not_allowlisted")
+    return path.resolve()
+
+
+def _resolve_bridge_repo(configured: str | None = None) -> Path:
+    raw = (configured if configured is not None else os.getenv(BRIDGE_REPO_ENV, "")).strip()
+    if not raw:
+        raise BridgeIngestError("bridge_repo_missing")
+    path = Path(raw).expanduser()
+    if not path.is_dir():
+        raise BridgeIngestError("bridge_repo_missing")
+    return path.resolve()
+
+
+def build_ingest_argv(*, bridge_bin: Path, repo: Path) -> list[str]:
+    """Fixed argv for Bridge intake. No user-controlled verbs or flags."""
+    if bridge_bin.name != "bridge":
+        raise BridgeIngestError("bridge_binary_not_allowlisted")
+    if not bridge_bin.is_absolute():
+        raise BridgeIngestError("bridge_binary_not_allowlisted")
+    if not repo.is_absolute() or not repo.is_dir():
+        raise BridgeIngestError("bridge_repo_missing")
+    argv = [str(bridge_bin), "ingest", "-", "--repo", str(repo)]
+    if argv[1] not in ALLOWED_VERBS:
+        raise BridgeIngestError("bridge_verb_not_allowlisted")
+    return argv
+
+
+def build_submit_work_envelope(
+    *,
+    work_id: str,
+    summary: str,
+    evidence_refs: list[dict[str, Any]],
+    occurred_at: str,
+) -> dict[str, Any]:
+    """Map control-plane submit_work into Bridge EventEnvelope v1."""
+    text = (summary or "").strip()
+    if not text:
+        text = f"submit_work {work_id}"
+    # Evidence refs stay in metadata as opaque strings — not policy fields.
+    metadata = {
+        "work_id": work_id,
+        "evidence_ref_count": str(len(evidence_refs)),
+    }
+    return {
+        "version": CONTRACT_VERSION,
+        "id": f"inbox:control_plane:{work_id}",
+        "kind": "inbox.control_plane.submit_work",
+        "source": "inbox",
+        "external_id": work_id,
+        "occurred_at": occurred_at,
+        "payload": {
+            "text": text,
+            "external_ref": work_id,
+            "metadata": metadata,
+        },
+    }
+
+
+def _parse_result_bundle(stdout: str) -> BridgeIngestReceipt:
+    try:
+        payload = json.loads(stdout)
+    except json.JSONDecodeError as exc:
+        raise BridgeIngestError("bridge_result_unparseable") from exc
+    if not isinstance(payload, dict):
+        raise BridgeIngestError("bridge_result_unparseable")
+    status = str(payload.get("status") or "").strip()
+    receipt = BridgeIngestReceipt(
+        result_id=str(payload.get("id") or "").strip(),
+        work_packet_id=str(payload.get("work_packet_id") or "").strip(),
+        status=status,
+        summary=str(payload.get("summary") or "").strip(),
+        intake_path=str(payload.get("intake_path") or "").strip(),
+    )
+    if not receipt.ok:
+        raise BridgeIngestError("bridge_rejected")
+    if payload.get("verification_receipt"):
+        # Intake must never carry execution evidence.
+        raise BridgeIngestError("bridge_claimed_execution")
+    return receipt
+
+
+class BridgeWorkClient:
+    """Allowlisted subprocess caller for `bridge ingest` only."""
+
+    def __init__(self, *, bridge_bin: Path | None = None, repo: Path | None = None) -> None:
+        self._bridge_bin = bridge_bin
+        self._repo = repo
+
+    @classmethod
+    def from_env(cls) -> BridgeWorkClient:
+        return cls()
+
+    def ingest_event(self, envelope: dict[str, Any]) -> BridgeIngestReceipt:
+        bridge_bin = self._bridge_bin or _resolve_bridge_bin()
+        repo = self._repo or _resolve_bridge_repo()
+        argv = build_ingest_argv(bridge_bin=bridge_bin, repo=repo)
+        try:
+            completed = subprocess.run(
+                argv,
+                input=json.dumps(envelope, separators=(",", ":"), sort_keys=True),
+                capture_output=True,
+                text=True,
+                shell=False,
+                timeout=INGEST_TIMEOUT_SEC,
+                check=False,
+            )
+        except subprocess.TimeoutExpired as exc:
+            raise BridgeIngestError("bridge_ingest_timeout") from exc
+        except OSError as exc:
+            raise BridgeIngestError("bridge_ingest_failed") from exc
+        if completed.returncode != 0:
+            raise BridgeIngestError("bridge_rejected")
+        return _parse_result_bundle(completed.stdout)

--- a/config/shortcut_registry.example.json
+++ b/config/shortcut_registry.example.json
@@ -1,0 +1,17 @@
+{
+  "schema": "agent_os.shortcut_registry.v1",
+  "description": "Local-only map. Public MCP accepts shortcut_id (SC-NNN), never the stored name. argv is not executed while INBOX_CONTROL_PLANE_SPAWN=0.",
+  "entries": {
+    "SC-014": {
+      "shortcut_id": "SC-014",
+      "stored_name": "EXAMPLE_ONLY_replace_with_live_Shortcuts_name",
+      "risk_class": "consequential",
+      "requires_approval_store": true,
+      "input_schema": {
+        "type": "object",
+        "additionalProperties": false
+      }
+    }
+  },
+  "unknown_id": "DENIED"
+}

--- a/docs/TASK-026-SOURCE-CONVERGENCE-MANIFEST.md
+++ b/docs/TASK-026-SOURCE-CONVERGENCE-MANIFEST.md
@@ -1,0 +1,64 @@
+# TASK-026 Source Convergence Manifest
+
+Base: `61c824f0847d87e2444f14dd5b6413425efb2f24` (origin/main)
+Provenance: PR0 `c2844f5…` → PR1 `fe2ceb7…` → PR2 `b5acc062…`
+
+## REQUIRED_CONVERGENCE
+
+| Path | Action | Why |
+|---|---|---|
+| `event_store.py` | add from PR2 | append-only capture ledger |
+| `mcp_control_plane.py` | add from PR2 | ingest-only MCP + Bridge handoff |
+| `bridge_work_client.py` | add from PR2 | thin `bridge ingest` client |
+| `config/shortcut_registry.example.json` | add from PR2 | control-plane `run_shortcut` deny path (no exec) |
+| `tests/test_event_store.py` | add from PR2 | EventStore contract |
+| `tests/test_event_capture.py` | add from PR2 | HTTP capture contract |
+| `tests/test_mcp_control_plane.py` | add from PR2 | MCP + Bridge handoff contract |
+| `.gitignore` | add `.inbox_event_log.sqlite3*` | runtime DB ignore |
+| `inbox_server.py` | surgical patch | EventStore wiring + `POST /events/capture` only |
+| `tests/test_approval_route_gate.py` | surgical | exception for `/events/capture` |
+| `tools_registry.py` | surgical additive | `include_names` + optional `names=` (test dep) |
+| `AGENTS.md` | replay PR2 note if needed | docs freshness |
+| `MCP_SETUP.md` | replay control-plane section | docs |
+| `docs/invariants.md` | replay intake invariants | docs |
+| `docs/oracle-map.md` | replay one-line if needed | docs |
+
+## ALREADY_ON_MAIN_EQUIVALENT / MAIN WINS
+
+| Path | Decision |
+|---|---|
+| `services.py` | **keep main** (Phase-C provider identity/idempotency) |
+| `tests/test_task_create_provider_identity.py` | **keep main** (PR2 tip deletes it — do not) |
+
+## STALE_BRANCH_DRIFT (exclude)
+
+- Wholesale `inbox_server.py` / `services.py` from actuator tip
+- Any dirty runtime SQLite/logs/credentials
+- Prototype LifeOps stores / commitment DBs
+- Unrelated Inbox feature drift on actuator branches
+- ASSET-087 reconstruction / OCI/GAS templates
+
+## RUNTIME_STATE / SECRET_SENSITIVE / GENERATED
+
+None imported. EventStore default path `.inbox_event_log.sqlite3` is gitignored runtime only.
+
+## EventStore persistence review
+
+**Stores (allowed):** append-only observation rows in `.inbox_event_log.sqlite3` (gitignored): event_id, source, source_object_id, timestamps, event_type, payload, provenance, digest/schema metadata.
+
+**Does NOT own:** SYS-002 projects, Google Tasks lifecycle, provider facts, HomeBase authz, Bridge execution receipts, commitments, provider idempotency sidecars, ApprovalStore, egress audit.
+
+## Authority boundaries
+
+- EventStore = capture/evidence intake history only
+- MCP control plane = ingest-only; `confirm=true` ≠ authority; model lease/capability denied; `spawn=0`
+- `submit_work` = thin Bridge `ingest` handoff only; Inbox does not execute
+- Phase-C provider semantics on main (`services.py`, bindings removed) remain authoritative
+
+## Explicitly excluded branch drift
+
+- wholesale actuator `inbox_server.py` / `services.py`
+- PR2 tip deletion of `tests/test_task_create_provider_identity.py`
+- runtime DBs/logs/credentials/`.env`
+- `state/connector_state.db`, LifeOps prototype stores, ASSET-087 bytes
+- OCI/GAS/LaunchAgent/runtime path changes

--- a/docs/invariants.md
+++ b/docs/invariants.md
@@ -155,6 +155,67 @@ Maps to: `api-design-oracle.md`.
 
 **Oracle reference:** `api-design-oracle.md` — Session Lifecycle (init → use → cleanup is explicit).
 
+### 3.4 Control-plane authority boundary (P0)
+
+```
+∀call ∈ {submit_work, cancel_work, run_shortcut, verify_work}:
+  executed(call) = 0
+  ∧ spawn_default = 0
+  ∧ ¬∃credential ∈ call.args: model_supplied_authority(credential)
+  ∧ result(call) ∈ {accepted_for_intake, DENIED}
+  ∧ authority(call) = lookup(ApprovalStore)  // server-side only
+```
+
+`confirm = true` is intent, not a lease, capability, or approval.
+
+```
+∀call: confirm(call) = true ↛ authority(call)
+```
+
+Capture reuses EventStore identity; it is not a grant.
+
+```
+capture_mcp(obs) = EventStore.append(obs)
+∧ capture_mcp(obs) ↛ approval_lease
+```
+
+Auth fails closed:
+
+```
+INBOX_CONTROL_PLANE_TOKEN = "" → ¬authorized(/mcp)
+```
+
+**Enforcement:** `mcp_control_plane.py` on `127.0.0.1:8002`. Seven frozen tools.
+`submit_work` may call Bridge `ingest` via allowlisted `bridge_work_client.py`
+(`shell=False`, verb=`ingest` only) and stores intake path/ids. No Bridge spawn,
+no model-supplied tokens, no epistemic MCP tool. Bridge reject → DENIED ∧ ¬executor.
+
+**Oracle reference:** `saltzer-schroeder-oracle.md` Principle 2 (Fail-Safe Defaults) and Principle 3 (Complete Mediation).
+
+### 3.5 Control-plane Streamable HTTP session lifecycle (P0)
+
+```
+make_control_plane_app = FastMCP.streamable_http_app
+∧ lifespan(app) = session_manager.run()
+∧ ¬Mount("/mcp", streamable_http_app())
+∧ POST /mcp ↛ 307
+∧ initialize(streamable_http_client, /mcp) → session
+```
+
+Transport repair must not change authority semantics:
+
+```
+transport_fix ↛ executed
+∧ spawn_default = 0
+∧ tools = {resolve, capture, submit_work, get_work, cancel_work, verify_work, run_shortcut}
+```
+
+**Rationale:** Nested `Mount("/mcp", mcp.streamable_http_app())` placed the handler at `/mcp/mcp` and never started `StreamableHTTPSessionManager.run()`, so a standards-compliant client could not `initialize`. FastMCP's own Streamable HTTP app is the native lifespan owner.
+
+**Enforcement:** Integration test uses the official MCP Python client against uvicorn serving `make_control_plane_app()`.
+
+**Oracle reference:** `api-design-oracle.md` — Session Lifecycle (init → use → cleanup is explicit).
+
 ---
 
 ## 4. Data Integrity
@@ -307,7 +368,8 @@ Maps to: `saltzer-schroeder-oracle.md`.
 | 2.4     | External API safety | P1 | No | High |
 | 3.1     | JSON-RPC structure | P1 | No | Medium |
 | 3.2     | Tool call validation | P1 | No | High |
-| 3.3     | Session lifecycle | P1 | No | Medium |
+| 3.4     | Control-plane authority | P0 | Yes | High |
+| 3.5     | Control-plane Streamable HTTP lifecycle | P0 | Yes | High |
 | 4.1     | Unique message ID | P0 | No | High |
 | 4.2     | No sync duplicates | P1 | No | High |
 | 4.3     | Approval store consistency | P0 | No | High |

--- a/docs/oracle-map.md
+++ b/docs/oracle-map.md
@@ -13,6 +13,7 @@ Each inbox subsystem maps to orbit oracles from `~/projects/orbit/docs/research/
 | Connectors (`connectors/`) | `saltzer-schroeder-oracle.md` | `envoy.md` | Fail-safe defaults, economy of mechanism, least privilege; circuit breaker, retry budget |
 | Connector registry (`connector_registry.py`) | `saltzer-schroeder-oracle.md` | `sicp-oracle.md` | Complete mediation, fail-safe defaults; data abstraction, narrow interfaces |
 | MCP gateway (`mcp_gateway.py`) | `api-design-oracle.md` | `ousterhout-oracle.md` | Protocol conformance, session lifecycle, input validation; deep modules |
+| MCP control plane (`mcp_control_plane.py`) | `saltzer-schroeder-oracle.md` | `api-design-oracle.md` | Fail-closed auth, complete mediation via ApprovalStore lookup, ingest-only spawn=0; frozen seven-tool surface; FastMCP Streamable HTTP lifespan/session init |
 | MCP backend (`mcp_backend.py`) | `api-design-oracle.md` | `fowler-oracle.md` | HTTP client patterns, error mapping; adapter pattern |
 | Message sync (`message_sync.py`) | `data-quality-oracle.md` | `lamport-tla-oracle.md` | Record identity, idempotent sync, deduplication; state machine, safety |
 | Message index store (`message_index_store.py`) | `data-quality-oracle.md` | `ostep-oracle.md` | Index consistency, checkpoint integrity; persistence |

--- a/event_store.py
+++ b/event_store.py
@@ -1,0 +1,320 @@
+"""Append-only local capture log.
+
+PR-0 atom only. Retries are idempotent. Conflicting same-id payloads fail closed.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import sqlite3
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Literal
+
+BASE_DIR = Path(__file__).parent
+DEFAULT_EVENT_DB = BASE_DIR / ".inbox_event_log.sqlite3"
+EVENT_SCHEMA_VERSION = "inbox.capture.v1"
+MAX_PAYLOAD_BYTES = 65536
+SOURCE_REF_RE = re.compile(
+    r"^(manual|inbox|test|gmail|imessage|local):[A-Za-z0-9][A-Za-z0-9._:/-]{0,240}$"
+)
+
+# GitHits: unique event_id + payload hash conflict; WAL; triggers abort
+# UPDATE/DELETE on the events table.
+
+
+class EventStoreValidationError(ValueError):
+    """Malformed capture observation."""
+
+
+class EventStoreConflict(EventStoreValidationError):
+    """event_id already stores a different observation."""
+
+
+def _json_dumps(value: object) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+
+def _json_loads(value: str | None) -> Any:
+    return json.loads(value or "null")
+
+
+def _utcnow() -> str:
+    return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _normalise_timestamp(value: str, field_name: str) -> str:
+    text = str(value or "").strip()
+    if not text:
+        raise EventStoreValidationError(f"{field_name} is required")
+    try:
+        parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise EventStoreValidationError(f"{field_name} must be ISO-8601") from exc
+    if parsed.tzinfo is None:
+        raise EventStoreValidationError(f"{field_name} must include a timezone")
+    return text
+
+
+def _validate_source_ref(source_ref: str) -> str:
+    text = str(source_ref or "").strip()
+    if not text:
+        raise EventStoreValidationError("provenance.source_ref is required")
+    if ".." in text or "://" in text:
+        raise EventStoreValidationError("provenance.source_ref is untrusted")
+    if not SOURCE_REF_RE.fullmatch(text):
+        raise EventStoreValidationError("provenance.source_ref is malformed")
+    return text
+
+
+def identity_digest_for(
+    *,
+    source: str,
+    source_object_id: str,
+    occurred_at: str,
+    event_type: str,
+    payload: Any,
+    source_ref: str,
+) -> str:
+    canonical = {
+        "source": source,
+        "source_object_id": source_object_id,
+        "occurred_at": occurred_at,
+        "event_type": event_type,
+        "payload": payload,
+        "source_ref": source_ref,
+    }
+    return hashlib.sha256(_json_dumps(canonical).encode("utf-8")).hexdigest()
+
+
+@dataclass(frozen=True)
+class CaptureEvent:
+    event_id: str
+    source: str
+    source_object_id: str
+    observed_at: str
+    occurred_at: str
+    event_type: str
+    payload: Any
+    provenance: dict[str, str]
+    ingested_at: str
+    identity_digest: str
+    schema_version: str = EVENT_SCHEMA_VERSION
+
+    @classmethod
+    def create(
+        cls,
+        *,
+        source: str,
+        source_object_id: str,
+        observed_at: str,
+        occurred_at: str,
+        event_type: str,
+        payload: Any,
+        provenance: dict[str, Any] | None,
+        event_id: str | None = None,
+        ingested_at: str | None = None,
+    ) -> CaptureEvent:
+        source_text = str(source or "").strip()
+        event_type_text = str(event_type or "").strip()
+        object_id = str(source_object_id or "").strip()
+        if not source_text:
+            raise EventStoreValidationError("source is required")
+        if not event_type_text:
+            raise EventStoreValidationError("event_type is required")
+        if not object_id:
+            raise EventStoreValidationError("source_object_id is required")
+        if not isinstance(provenance, dict) or not provenance:
+            raise EventStoreValidationError("provenance is required")
+        source_ref = _validate_source_ref(str(provenance.get("source_ref", "")))
+        if payload is None:
+            raise EventStoreValidationError("payload is required")
+        encoded_payload = _json_dumps(payload)
+        if len(encoded_payload.encode("utf-8")) > MAX_PAYLOAD_BYTES:
+            raise EventStoreValidationError("payload is oversized")
+        occurred = _normalise_timestamp(occurred_at, "occurred_at")
+        observed = _normalise_timestamp(observed_at, "observed_at")
+        digest = identity_digest_for(
+            source=source_text,
+            source_object_id=object_id,
+            occurred_at=occurred,
+            event_type=event_type_text,
+            payload=payload,
+            source_ref=source_ref,
+        )
+        computed_id = f"evt_{digest[:32]}"
+        supplied = str(event_id or "").strip()
+        return cls(
+            event_id=supplied or computed_id,
+            source=source_text,
+            source_object_id=object_id,
+            observed_at=observed,
+            occurred_at=occurred,
+            event_type=event_type_text,
+            payload=payload,
+            provenance={"source_ref": source_ref},
+            ingested_at=ingested_at or _utcnow(),
+            identity_digest=digest,
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "event_id": self.event_id,
+            "source": self.source,
+            "source_object_id": self.source_object_id,
+            "observed_at": self.observed_at,
+            "occurred_at": self.occurred_at,
+            "event_type": self.event_type,
+            "payload": self.payload,
+            "provenance": self.provenance,
+            "ingested_at": self.ingested_at,
+            "schema_version": self.schema_version,
+        }
+
+
+class EventStore:
+    """SQLite-backed append-only capture log."""
+
+    def __init__(self, db_path: Path | None = None) -> None:
+        self.db_path = db_path or DEFAULT_EVENT_DB
+        self._ready = False
+
+    def _connect(self) -> sqlite3.Connection:
+        if not self._ready:
+            self.db_path.parent.mkdir(parents=True, exist_ok=True)
+            self._init_db()
+            self._ready = True
+        conn = sqlite3.connect(self.db_path)
+        conn.row_factory = sqlite3.Row
+        return conn
+
+    def _init_db(self) -> None:
+        conn = sqlite3.connect(self.db_path)
+        try:
+            conn.executescript(
+                """
+                PRAGMA journal_mode=WAL;
+
+                CREATE TABLE IF NOT EXISTS events (
+                    event_id TEXT PRIMARY KEY,
+                    identity_digest TEXT NOT NULL UNIQUE,
+                    schema_version TEXT NOT NULL,
+                    source TEXT NOT NULL,
+                    source_object_id TEXT NOT NULL,
+                    observed_at TEXT NOT NULL,
+                    occurred_at TEXT NOT NULL,
+                    event_type TEXT NOT NULL,
+                    payload_json TEXT NOT NULL,
+                    provenance_json TEXT NOT NULL,
+                    ingested_at TEXT NOT NULL
+                );
+
+                CREATE TRIGGER IF NOT EXISTS events_append_only_update
+                BEFORE UPDATE ON events
+                BEGIN
+                    SELECT RAISE(ABORT, 'events are append-only');
+                END;
+
+                CREATE TRIGGER IF NOT EXISTS events_append_only_delete
+                BEFORE DELETE ON events
+                BEGIN
+                    SELECT RAISE(ABORT, 'events are append-only');
+                END;
+                """
+            )
+        finally:
+            conn.close()
+
+    def append(
+        self, event: CaptureEvent
+    ) -> tuple[CaptureEvent, Literal["created", "already_exists"]]:
+        computed_id = f"evt_{event.identity_digest[:32]}"
+        if event.event_id != computed_id:
+            existing = self.get(event.event_id)
+            if existing is not None and existing.identity_digest != event.identity_digest:
+                raise EventStoreConflict("event_id already belongs to a different event")
+            raise EventStoreValidationError("event_id does not match identity digest")
+        values = {
+            "event_id": event.event_id,
+            "identity_digest": event.identity_digest,
+            "schema_version": event.schema_version,
+            "source": event.source,
+            "source_object_id": event.source_object_id,
+            "observed_at": event.observed_at,
+            "occurred_at": event.occurred_at,
+            "event_type": event.event_type,
+            "payload_json": _json_dumps(event.payload),
+            "provenance_json": _json_dumps(event.provenance),
+            "ingested_at": event.ingested_at,
+        }
+        with self._connect() as conn:
+            try:
+                cursor = conn.execute(
+                    """
+                    INSERT INTO events (
+                        event_id, identity_digest, schema_version, source,
+                        source_object_id, observed_at, occurred_at, event_type,
+                        payload_json, provenance_json, ingested_at
+                    ) VALUES (
+                        :event_id, :identity_digest, :schema_version, :source,
+                        :source_object_id, :observed_at, :occurred_at, :event_type,
+                        :payload_json, :provenance_json, :ingested_at
+                    )
+                    """,
+                    values,
+                )
+            except sqlite3.IntegrityError as exc:
+                by_id = conn.execute(
+                    "SELECT * FROM events WHERE event_id = ?", (event.event_id,)
+                ).fetchone()
+                by_digest = conn.execute(
+                    "SELECT * FROM events WHERE identity_digest = ?",
+                    (event.identity_digest,),
+                ).fetchone()
+                if by_id is not None:
+                    stored = self._row_to_event(by_id)
+                    if stored.identity_digest != event.identity_digest:
+                        raise EventStoreConflict(
+                            "event_id already belongs to a different event"
+                        ) from exc
+                    return stored, "already_exists"
+                if by_digest is not None:
+                    stored = self._row_to_event(by_digest)
+                    if stored.event_id != event.event_id:
+                        raise EventStoreConflict(
+                            "event_id already belongs to a different event"
+                        ) from exc
+                    return stored, "already_exists"
+                raise EventStoreValidationError("capture insert conflict") from exc
+            if int(cursor.rowcount or 0) != 1:
+                raise EventStoreValidationError("capture insert did not persist")
+            return event, "created"
+
+    def get(self, event_id: str) -> CaptureEvent | None:
+        with self._connect() as conn:
+            row = conn.execute("SELECT * FROM events WHERE event_id = ?", (event_id,)).fetchone()
+        return self._row_to_event(row) if row is not None else None
+
+    def count(self) -> int:
+        with self._connect() as conn:
+            row = conn.execute("SELECT count(*) FROM events").fetchone()
+        return int(row[0] if row else 0)
+
+    @staticmethod
+    def _row_to_event(row: sqlite3.Row) -> CaptureEvent:
+        return CaptureEvent(
+            event_id=row["event_id"],
+            source=row["source"],
+            source_object_id=row["source_object_id"],
+            observed_at=row["observed_at"],
+            occurred_at=row["occurred_at"],
+            event_type=row["event_type"],
+            payload=_json_loads(row["payload_json"]),
+            provenance=_json_loads(row["provenance_json"]),
+            ingested_at=row["ingested_at"],
+            identity_digest=row["identity_digest"],
+            schema_version=row["schema_version"],
+        )

--- a/inbox_server.py
+++ b/inbox_server.py
@@ -19,7 +19,7 @@ from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from secrets import compare_digest, token_urlsafe
-from typing import Any
+from typing import Any, Literal
 from urllib.parse import parse_qs, parse_qsl, urlsplit
 
 from fastapi import FastAPI, File, HTTPException, Query, Request, UploadFile, status
@@ -30,6 +30,7 @@ from pydantic import BaseModel, StrictBool
 import ambient_notes
 import egress_audit
 import google_account_resolution as _gacct
+from approval_store import ApprovalStore
 from capability_inventory import build_capability_inventory
 from capture_health import CaptureHealthRecord, CaptureHealthStore, capture_summary, utc_now_iso
 from connector_registry import (
@@ -39,6 +40,7 @@ from connector_registry import (
     partition_search_sources,
     search_connectors,
 )
+from event_store import CaptureEvent, EventStore, EventStoreConflict, EventStoreValidationError
 from gmail_triage import (
     KIND_PREFIX as _KIND_PREFIX,
 )
@@ -74,7 +76,6 @@ from memory_store import MemoryStore
 from message_index_store import MessageIndexStore
 from message_sync import bootstrap as index_bootstrap_sync
 from message_sync import incremental as index_incremental_sync
-from approval_store import ApprovalStore
 from scheduler import SchedulerStore
 from service_models import ApprovalGateDecision, ApprovalLease
 from services import (
@@ -1570,6 +1571,36 @@ class SourceAdapters:
     )
 
 
+class CaptureEventRequest(BaseModel):
+    source: str
+    event_type: str = "manual.capture"
+    source_object_id: str
+    observed_at: str
+    occurred_at: str
+    payload: Any
+    provenance: dict[str, Any]
+    event_id: str = ""
+
+
+class CapturedEventOut(BaseModel):
+    event_id: str
+    source: str
+    source_object_id: str
+    observed_at: str
+    occurred_at: str
+    event_type: str
+    payload: Any
+    provenance: dict[str, Any]
+    ingested_at: str
+    schema_version: str
+
+
+class CaptureEventOut(BaseModel):
+    result: Literal["created", "already_exists", "error"]
+    event: CapturedEventOut | None = None
+    error: str | None = None
+
+
 class ServerState:
     def __init__(self) -> None:
         self.gmail_services: dict[str, object] = {}
@@ -1588,6 +1619,7 @@ class ServerState:
         self.approvals: ApprovalStore = ApprovalStore()
         self.index_store: MessageIndexStore = MessageIndexStore()
         self.capture_health_store: CaptureHealthStore = CaptureHealthStore()
+        self.event_store: EventStore = EventStore()
         self.source_adapters: SourceAdapters = SourceAdapters()
 
 
@@ -2928,6 +2960,50 @@ async def get_capture_health():
 
 
 # ── Egress Audit ─────────────────────────────────────────────────────────────
+
+
+@app.post("/events/capture")
+async def capture_event(req: CaptureEventRequest):
+    """Append one raw observation. Local evidence only. Not a grant.
+
+    201 created. 200 already_exists (same id and digest; original receipt).
+    409 when the same id is reused with a different digest.
+    422 malformed, untrusted locator, or unused id that is not the digest identity.
+    413 oversized payload.
+    """
+    try:
+        event = CaptureEvent.create(
+            source=req.source,
+            source_object_id=req.source_object_id,
+            observed_at=req.observed_at,
+            occurred_at=req.occurred_at,
+            event_type=req.event_type,
+            payload=req.payload,
+            provenance=req.provenance,
+            event_id=req.event_id or None,
+        )
+        stored, result = await asyncio.to_thread(state.event_store.append, event)
+    except EventStoreConflict as exc:
+        return JSONResponse(
+            status_code=status.HTTP_409_CONFLICT,
+            content={"result": "error", "error": str(exc), "event": None},
+        )
+    except EventStoreValidationError as exc:
+        code = (
+            status.HTTP_413_CONTENT_TOO_LARGE
+            if "oversized" in str(exc)
+            else status.HTTP_422_UNPROCESSABLE_ENTITY
+        )
+        return JSONResponse(
+            status_code=code,
+            content={"result": "error", "error": str(exc), "event": None},
+        )
+    payload = CaptureEventOut(
+        result=result,
+        event=CapturedEventOut(**stored.to_dict()),
+    )
+    status_code = status.HTTP_201_CREATED if result == "created" else status.HTTP_200_OK
+    return JSONResponse(status_code=status_code, content=payload.model_dump())
 
 
 @app.get("/egress/status")

--- a/mcp_control_plane.py
+++ b/mcp_control_plane.py
@@ -1,0 +1,698 @@
+"""Ingest-only Inbox MCP control plane (PR-1 + PR-2B Bridge intake).
+
+Bind: 127.0.0.1:8002
+Frozen tools: resolve, capture, submit_work, get_work, cancel_work,
+verify_work, run_shortcut.
+
+This surface can accept and capture work and forward submit_work to Bridge
+`ingest`. It cannot mint authority or execute workers, providers, or
+Shortcuts. confirm=true is intent, not a lease. Bridge intake ≠ spawn.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import uuid
+from datetime import UTC, datetime
+from pathlib import Path
+from secrets import compare_digest
+from typing import Any
+
+from starlette.applications import Starlette
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+
+from approval_store import ApprovalStore
+from bridge_work_client import (
+    BridgeIngestError,
+    BridgeWorkClient,
+    BridgeWorkClientProtocol,
+    build_submit_work_envelope,
+)
+from event_store import CaptureEvent, EventStore, EventStoreConflict, EventStoreValidationError
+
+CONTROL_PLANE_HOST = "127.0.0.1"
+CONTROL_PLANE_PORT = 8002
+CONTROL_PLANE_TOKEN_ENV = "INBOX_CONTROL_PLANE_TOKEN"  # nosec: B105 - env var name, not a hardcoded credential
+SPAWN_ENV = "INBOX_CONTROL_PLANE_SPAWN"
+TRUST_LOOPBACK_ENV = "INBOX_CONTROL_PLANE_TRUST_LOOPBACK"
+CONTROL_PLANE_TOOL_NAMES = (
+    "resolve",
+    "capture",
+    "submit_work",
+    "get_work",
+    "cancel_work",
+    "verify_work",
+    "run_shortcut",
+)
+AUTHORITY_TYPES = frozenset(
+    {
+        "inbox_event",
+        "lifeops_packet",
+        "github",
+        "google_drive",
+        "research_claim",
+    }
+)
+MODEL_SUPPLIED_AUTHORITY_KEYS = frozenset(
+    {
+        "lease",
+        "lease_token",
+        "lease_id",
+        "capability",
+        "capability_token",
+        "capability_id",
+        "approval_digest",
+        "approval_credential",
+        "approval_token",
+        "fencing_token",
+        "worker_token",
+        "worker",
+        "spawn",
+        "shortcut_name",
+        "stored_name",
+    }
+)
+EVIDENCE_REF_KEYS = frozenset(
+    {
+        "ref",
+        "authority_type",
+        "authority_id",
+        "source_revision",
+        "as_of",
+        "digest",
+        "span",
+    }
+)
+SPAN_KEYS = frozenset({"path", "start", "end", "locator"})
+
+BASE_DIR = Path(__file__).parent
+DEFAULT_SHORTCUT_REGISTRY = BASE_DIR / "config" / "shortcut_registry.example.json"
+
+
+def spawn_flag() -> int:
+    raw = os.getenv(SPAWN_ENV, "0").strip() or "0"
+    return 1 if raw in {"1", "true", "TRUE", "yes"} else 0
+
+
+def trust_loopback() -> bool:
+    """ChatGPT Secure MCP Tunnel cannot paste our Bearer into Apps.
+
+    OpenAI authenticates the tunnel. Requests then arrive on 127.0.0.1.
+    Direct TestClient/curl still need the Bearer unless this flag is on.
+    """
+    raw = os.getenv(TRUST_LOOPBACK_ENV, "0").strip() or "0"
+    return raw in {"1", "true", "TRUE", "yes"}
+
+
+def _now_work_id() -> str:
+    return f"wrk_{uuid.uuid4().hex}"
+
+
+def _collect_mapping_keys(value: Any) -> set[str]:
+    keys: set[str] = set()
+    if isinstance(value, dict):
+        for key, inner in value.items():
+            keys.add(str(key))
+            keys.update(_collect_mapping_keys(inner))
+    elif isinstance(value, list):
+        for item in value:
+            keys.update(_collect_mapping_keys(item))
+    return keys
+
+
+def _denied(reason: str, **extra: Any) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "result": "DENIED",
+        "reason": reason,
+        "executed": False,
+        "spawn_flag": spawn_flag(),
+    }
+    payload.update(extra)
+    return payload
+
+
+def _intake(work_id: str, **extra: Any) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "result": "accepted_for_intake",
+        "work_id": work_id,
+        "executed": False,
+        "spawn_flag": spawn_flag(),
+    }
+    payload.update(extra)
+    return payload
+
+
+def load_shortcut_registry(path: Path | None = None) -> dict[str, Any]:
+    registry_path = path or Path(os.getenv("INBOX_SHORTCUT_REGISTRY", DEFAULT_SHORTCUT_REGISTRY))
+    if not registry_path.is_file():
+        return {"entries": {}, "unknown_id": "DENIED"}
+    raw = json.loads(registry_path.read_text(encoding="utf-8"))
+    entries = raw.get("entries") if isinstance(raw, dict) else {}
+    if not isinstance(entries, dict):
+        entries = {}
+    return {"entries": entries, "unknown_id": "DENIED"}
+
+
+def server_discovery_response(request_id: Any) -> dict[str, Any]:
+    """Sessionless card for ChatGPT Secure MCP Tunnel `server/discover`.
+
+    FastMCP still serves initialize/tools/list. The tunnel validator probes
+    discover first and does not send our bearer (connector headers override
+    tunnel extra_headers). Discover advertises identity only; it cannot execute.
+    """
+    return {
+        "jsonrpc": "2.0",
+        "id": request_id,
+        "result": {
+            "resultType": "complete",
+            "supportedVersions": ["2025-06-18"],
+            "capabilities": {"tools": {}},
+            "_meta": {
+                "io.modelcontextprotocol/serverInfo": {
+                    "name": "Inbox Control Plane",
+                    "version": "1.27.0",
+                }
+            },
+            "instructions": (
+                "Ingest-only control plane. Propose work with submit_work. "
+                "confirm=true is not authority. This surface does not spawn "
+                "workers, send mail, or run Shortcuts."
+            ),
+            "ttlMs": 300000,
+            "cacheScope": "private",
+        },
+    }
+
+
+class FailClosedAuthMiddleware(BaseHTTPMiddleware):
+    """Bearer auth that denies when the control-plane token is unset."""
+
+    async def dispatch(self, request: Request, call_next):
+        path = request.url.path
+        if path == "/health" or path.startswith("/.well-known/"):
+            return await call_next(request)
+        if request.method == "POST" and path.rstrip("/") == "/mcp":
+            try:
+                payload = json.loads((await request.body()).decode("utf-8") or "null")
+            except (UnicodeDecodeError, json.JSONDecodeError):
+                payload = None
+            if isinstance(payload, dict) and payload.get("method") == "server/discover":
+                return JSONResponse(server_discovery_response(payload.get("id")))
+        token = os.getenv(CONTROL_PLANE_TOKEN_ENV, "").strip()
+        if not token:
+            return JSONResponse(
+                {"detail": "Unauthorized"},
+                status_code=401,
+                headers={"WWW-Authenticate": "Bearer"},
+            )
+        client_host = request.client.host if request.client else ""
+        if trust_loopback() and client_host in {"127.0.0.1", "::1"}:
+            return await call_next(request)
+        auth_header = request.headers.get("authorization", "")
+        provided = ""
+        if auth_header.lower().startswith("bearer "):
+            provided = auth_header[7:].strip()
+        elif request.headers.get("x-api-key"):
+            provided = request.headers.get("x-api-key", "").strip()
+        if not provided or not compare_digest(provided, token):
+            return JSONResponse(
+                {"detail": "Unauthorized"},
+                status_code=401,
+                headers={"WWW-Authenticate": "Bearer"},
+            )
+        return await call_next(request)
+
+
+class ControlPlane:
+    """Ingest-only tool handlers. Execution is unconditionally disabled."""
+
+    def __init__(
+        self,
+        *,
+        event_store: EventStore,
+        approval_store: ApprovalStore,
+        shortcut_registry: dict[str, Any] | None = None,
+        bridge_client: BridgeWorkClientProtocol | None = None,
+    ) -> None:
+        self.event_store = event_store
+        self.approval_store = approval_store
+        self.shortcut_registry = shortcut_registry or load_shortcut_registry()
+        # Default: real Bridge ingest client (fail-closed when env unset).
+        # Tests inject a stub; never a spawn/orchestrator client.
+        self.bridge_client: BridgeWorkClientProtocol = bridge_client or BridgeWorkClient.from_env()
+        self.work: dict[str, dict[str, Any]] = {}
+        self.execution_log: list[dict[str, Any]] = []
+
+    def _reject_model_authority(self, payload: Any) -> dict[str, Any] | None:
+        keys = _collect_mapping_keys(payload)
+        hit = sorted(keys & MODEL_SUPPLIED_AUTHORITY_KEYS)
+        if hit:
+            return _denied("model_supplied_authority", keys=hit)
+        return None
+
+    def _lookup_unused_approval(self, operation: str) -> dict[str, Any] | None:
+        for row in self.approval_store.list_requests(state="approved", limit=200):
+            if row.get("operation") != operation:
+                continue
+            if not str(row.get("lease_id") or "").strip():
+                continue
+            return row
+        return None
+
+    def _record_intake(
+        self,
+        *,
+        operation: str,
+        body: dict[str, Any],
+        resource_ref: str,
+        work_id: str | None = None,
+        bridge: dict[str, Any] | None = None,
+    ) -> str:
+        work_id = work_id or _now_work_id()
+        created = self.approval_store.create_request(
+            method="MCP",
+            path=f"/control-plane/{operation}",
+            body=body,
+            provider="inbox.control_plane",
+            operation=operation,
+            approval_class="intake",
+            executor="none",
+            account_ref="",
+            resource_ref=resource_ref,
+            item_count=1,
+            payload_hash="",
+            query_hash="",
+        )
+        record = {
+            "work_id": work_id,
+            "operation": operation,
+            "state": "accepted_for_intake",
+            "executed": False,
+            "approval_request_id": created["request_id"],
+            "server_authority": self._lookup_unused_approval(operation),
+            "body": body,
+        }
+        if bridge:
+            record["bridge"] = bridge
+        self.work[work_id] = record
+        self.approval_store.log_event(
+            "control_plane_intake",
+            request_id=created["request_id"],
+            operation=operation,
+            result="accepted_for_intake",
+            detail={
+                "work_id": work_id,
+                "executed": False,
+                "spawn_flag": spawn_flag(),
+                "bridge": bridge,
+            },
+        )
+        return work_id
+
+    def _validate_evidence_refs(self, evidence_refs: Any) -> str | None:
+        if not isinstance(evidence_refs, list) or not evidence_refs:
+            return "missing_evidence_refs"
+        for item in evidence_refs:
+            if not isinstance(item, dict):
+                return "invalid_evidence_ref"
+            extra = set(item) - EVIDENCE_REF_KEYS
+            if extra:
+                return "invalid_evidence_ref"
+            ref = str(item.get("ref") or "").strip()
+            authority_type = str(item.get("authority_type") or "").strip()
+            authority_id = str(item.get("authority_id") or "").strip()
+            if not ref or not authority_id:
+                return "invalid_evidence_ref"
+            if authority_type not in AUTHORITY_TYPES:
+                return "invalid_evidence_ref"
+            if authority_type == "research_claim" and not str(item.get("digest") or "").strip():
+                return "research_claim_requires_manifest_digest"
+            span = item.get("span")
+            if span is not None and (not isinstance(span, dict) or (set(span) - SPAN_KEYS)):
+                return "invalid_evidence_ref"
+        return None
+
+    def resolve(self, worlds: list[str] | None = None) -> dict[str, Any]:
+        requested = list(worlds or ["control_plane", "capture", "approvals"])
+        probes = {
+            "control_plane": {
+                "status": "ok",
+                "source": "local",
+                "bind": f"{CONTROL_PLANE_HOST}:{CONTROL_PLANE_PORT}",
+            },
+            "capture": {
+                "status": "ok" if self.event_store is not None else "unavailable",
+                "source": "event_store",
+            },
+            "approvals": {
+                "status": "ok" if self.approval_store is not None else "unavailable",
+                "source": "approval_store",
+            },
+            "shortcut_registry": {
+                "status": "ok" if self.shortcut_registry.get("entries") else "unavailable",
+                "source": "local_registry",
+            },
+            "bridge": {"status": "unavailable", "source": "not_probed"},
+        }
+        results = []
+        required_failed = False
+        for world in requested:
+            name = str(world or "").strip()
+            if name in probes:
+                row = {"world": name, **probes[name]}
+            else:
+                row = {"world": name, "status": "unavailable", "source": "unknown_world"}
+            if row["status"] != "ok":
+                required_failed = True
+            results.append(row)
+        return {
+            "result": "DENIED" if required_failed else "ok",
+            "worlds": results,
+            "missing_filled_from_memory": False,
+            "executed": False,
+            "spawn_flag": spawn_flag(),
+        }
+
+    def capture(self, **observation: Any) -> dict[str, Any]:
+        denied = self._reject_model_authority(observation)
+        if denied:
+            return denied
+        try:
+            event = CaptureEvent.create(
+                source=observation.get("source", ""),
+                source_object_id=observation.get("source_object_id", ""),
+                observed_at=observation.get("observed_at", ""),
+                occurred_at=observation.get("occurred_at", ""),
+                event_type=observation.get("event_type", "manual.capture"),
+                payload=observation.get("payload"),
+                provenance=observation.get("provenance"),
+                event_id=observation.get("event_id") or None,
+            )
+            stored, result = self.event_store.append(event)
+        except EventStoreConflict as exc:
+            return {"result": "error", "error": str(exc), "event": None, "executed": False}
+        except EventStoreValidationError as exc:
+            return {"result": "error", "error": str(exc), "event": None, "executed": False}
+        return {"result": result, "event": stored.to_dict(), "executed": False}
+
+    def submit_work(
+        self,
+        evidence_refs: list[dict[str, Any]] | None = None,
+        *,
+        confirm: bool = False,
+        summary: str = "",
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        payload = {
+            "evidence_refs": evidence_refs,
+            "confirm": confirm,
+            "summary": summary,
+            **kwargs,
+        }
+        denied = self._reject_model_authority(payload)
+        if denied:
+            self.approval_store.log_event(
+                "control_plane_denied",
+                operation="submit_work",
+                result="DENIED",
+                detail={"reason": denied["reason"], "confirm": confirm},
+            )
+            return denied
+        invalid = self._validate_evidence_refs(evidence_refs)
+        if invalid:
+            return _denied(invalid)
+
+        # Allocate id before Bridge so the EventEnvelope external_id is stable.
+        # Bridge reject → no local work record and no executor invocation.
+        work_id = _now_work_id()
+        envelope = build_submit_work_envelope(
+            work_id=work_id,
+            summary=summary,
+            evidence_refs=list(evidence_refs or []),
+            occurred_at=datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z"),
+        )
+        try:
+            receipt = self.bridge_client.ingest_event(envelope)
+        except BridgeIngestError as exc:
+            self.approval_store.log_event(
+                "control_plane_denied",
+                operation="submit_work",
+                result="DENIED",
+                detail={
+                    "reason": str(exc) or "bridge_rejected",
+                    "confirm": confirm,
+                    "executed": False,
+                },
+            )
+            return _denied(str(exc) or "bridge_rejected", confirm_is_authority=False)
+
+        bridge_meta = {
+            "result_id": receipt.result_id,
+            "work_packet_id": receipt.work_packet_id,
+            "intake_path": receipt.intake_path,
+            "status": receipt.status,
+            "summary": receipt.summary,
+        }
+        self._record_intake(
+            operation="submit_work",
+            body={
+                "evidence_refs": evidence_refs,
+                "confirm": confirm,
+                "summary": summary,
+            },
+            resource_ref="submit_work",
+            work_id=work_id,
+            bridge=bridge_meta,
+        )
+        return _intake(
+            work_id,
+            confirm_is_authority=False,
+            server_authority_present=bool(self.work[work_id]["server_authority"]),
+            bridge_intake_path=receipt.intake_path,
+            bridge_result_id=receipt.result_id,
+            bridge_work_packet_id=receipt.work_packet_id,
+        )
+
+    def get_work(self, work_id: str = "") -> dict[str, Any]:
+        if work_id:
+            record = self.work.get(work_id)
+            if record is None:
+                return _denied("unknown_work")
+            return {
+                "result": "ok",
+                "work": {k: v for k, v in record.items() if k != "body"},
+                "executed": False,
+                "spawn_flag": spawn_flag(),
+            }
+        return {
+            "result": "ok",
+            "work": [{k: v for k, v in row.items() if k != "body"} for row in self.work.values()],
+            "executed": False,
+            "spawn_flag": spawn_flag(),
+        }
+
+    def cancel_work(self, work_id: str, *, confirm: bool = False, **kwargs: Any) -> dict[str, Any]:
+        payload = {"work_id": work_id, "confirm": confirm, **kwargs}
+        denied = self._reject_model_authority(payload)
+        if denied:
+            return denied
+        if work_id not in self.work:
+            return _denied("unknown_work")
+        intake_id = self._record_intake(
+            operation="cancel_work",
+            body={"work_id": work_id, "confirm": confirm},
+            resource_ref=work_id,
+        )
+        self.work[work_id]["state"] = "cancel_accepted_for_intake"
+        return _intake(intake_id, target_work_id=work_id)
+
+    def verify_work(
+        self, work_id: str = "", *, confirm: bool = False, **kwargs: Any
+    ) -> dict[str, Any]:
+        payload = {"work_id": work_id, "confirm": confirm, **kwargs}
+        denied = self._reject_model_authority(payload)
+        if denied:
+            return denied
+        if work_id and work_id not in self.work:
+            return _denied("unknown_work")
+        intake_id = self._record_intake(
+            operation="verify_work",
+            body={"work_id": work_id, "confirm": confirm},
+            resource_ref=work_id or "verify_work",
+        )
+        return _intake(intake_id, target_work_id=work_id or None, verifier_executed=False)
+
+    def run_shortcut(
+        self,
+        shortcut_id: str,
+        *,
+        confirm: bool = False,
+        shortcut_input: dict[str, Any] | None = None,
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        payload = {
+            "shortcut_id": shortcut_id,
+            "confirm": confirm,
+            "shortcut_input": shortcut_input or {},
+            **kwargs,
+        }
+        denied = self._reject_model_authority(payload)
+        if denied:
+            return denied
+        entries = self.shortcut_registry.get("entries") or {}
+        entry = entries.get(str(shortcut_id or "").strip())
+        if not isinstance(entry, dict):
+            return _denied("unknown_shortcut_id")
+        intake_id = self._record_intake(
+            operation="run_shortcut",
+            body={"shortcut_id": shortcut_id, "confirm": confirm},
+            resource_ref=shortcut_id,
+        )
+        return _intake(
+            intake_id,
+            shortcut_id=shortcut_id,
+            stored_name_returned=False,
+            argv_executed=False,
+        )
+
+
+def build_control_plane_mcp(plane: ControlPlane):
+    try:
+        from mcp.server.fastmcp import FastMCP
+    except ImportError as exc:  # pragma: no cover
+        raise RuntimeError("The 'mcp' package is required. Install with: uv sync") from exc
+
+    mcp = FastMCP(
+        "Inbox Control Plane",
+        stateless_http=True,
+        json_response=True,
+        host=CONTROL_PLANE_HOST,
+        port=CONTROL_PLANE_PORT,
+        streamable_http_path="/mcp",
+    )
+
+    @mcp.tool()
+    async def resolve(worlds: list[str] | None = None) -> dict:
+        """Per-world health. Missing required worlds fail closed. Never fills from memory."""
+        return plane.resolve(worlds)
+
+    @mcp.tool()
+    async def capture(
+        source: str,
+        source_object_id: str,
+        observed_at: str,
+        occurred_at: str,
+        payload: dict,
+        provenance: dict,
+        event_type: str = "manual.capture",
+        event_id: str = "",
+    ) -> dict:
+        """Append one observation via EventStore. Local evidence only. Not a grant."""
+        return plane.capture(
+            source=source,
+            source_object_id=source_object_id,
+            observed_at=observed_at,
+            occurred_at=occurred_at,
+            payload=payload,
+            provenance=provenance,
+            event_type=event_type,
+            event_id=event_id,
+        )
+
+    @mcp.tool()
+    async def submit_work(
+        evidence_refs: list[dict],
+        confirm: bool = False,
+        summary: str = "",
+    ) -> dict:
+        """Accept work for intake. confirm is not authority. Never executes."""
+        return plane.submit_work(evidence_refs, confirm=confirm, summary=summary)
+
+    @mcp.tool()
+    async def get_work(work_id: str = "") -> dict:
+        """Read accepted intake records. Does not execute workers."""
+        return plane.get_work(work_id)
+
+    @mcp.tool()
+    async def cancel_work(work_id: str, confirm: bool = False) -> dict:
+        """Record a cancel request for intake. Does not kill sessions or workers."""
+        return plane.cancel_work(work_id, confirm=confirm)
+
+    @mcp.tool()
+    async def verify_work(work_id: str = "", confirm: bool = False) -> dict:
+        """Queue bounded verification. Does not run verifier argv or mint receipts."""
+        return plane.verify_work(work_id, confirm=confirm)
+
+    @mcp.tool()
+    async def run_shortcut(
+        shortcut_id: str,
+        confirm: bool = False,
+        shortcut_input: dict | None = None,
+    ) -> dict:
+        """Accept an opaque shortcut_id for intake. Never runs Shortcuts."""
+        return plane.run_shortcut(shortcut_id, confirm=confirm, shortcut_input=shortcut_input)
+
+    return mcp
+
+
+def make_control_plane(
+    *,
+    event_db: Path | None = None,
+    approval_db: Path | None = None,
+    shortcut_registry: dict[str, Any] | None = None,
+    bridge_client: BridgeWorkClientProtocol | None = None,
+) -> ControlPlane:
+    return ControlPlane(
+        event_store=EventStore(event_db),
+        approval_store=ApprovalStore(approval_db),
+        shortcut_registry=shortcut_registry,
+        bridge_client=bridge_client,
+    )
+
+
+def make_control_plane_app(plane: ControlPlane | None = None) -> Starlette:
+    plane = plane or make_control_plane()
+    mcp = build_control_plane_mcp(plane)
+
+    async def health(_request: Request) -> JSONResponse:
+        return JSONResponse(
+            {
+                "status": "ok",
+                "mcp_path": "/mcp",
+                "bind": f"{CONTROL_PLANE_HOST}:{CONTROL_PLANE_PORT}",
+                "spawn_flag": spawn_flag(),
+                "execution_enabled": False,
+                "auth_fail_closed": True,
+                "trust_loopback": trust_loopback(),
+                "tools": list(CONTROL_PLANE_TOOL_NAMES),
+            }
+        )
+
+    # Native FastMCP Streamable HTTP app owns session_manager.run() lifespan.
+    # Do not nest that app under a /mcp prefix — that double-prefixes the path
+    # and drops the session-manager lifespan.
+    mcp.custom_route("/health", methods=["GET"])(health)
+    # Do not serve RFC 9728 here. LifeOps 404s these paths and ChatGPT
+    # Auth=None create succeeds. A 200 PRMD with bearer_methods_supported
+    # makes Create Connector fail even when discover returns 200.
+    app = mcp.streamable_http_app()
+    app.add_middleware(FailClosedAuthMiddleware)
+    return app
+
+
+def main() -> None:
+    import uvicorn
+
+    uvicorn.run(
+        make_control_plane_app(),
+        host=CONTROL_PLANE_HOST,
+        port=CONTROL_PLANE_PORT,
+        log_level="info",
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_approval_route_gate.py
+++ b/tests/test_approval_route_gate.py
@@ -253,6 +253,9 @@ MUTATING_METHOD_EXCEPTION_POLICY = {
     ),
     ("POST", "/llm/warmup"): ApprovalExceptionPolicy("llm_call", True, "LLM warmup call; no provider write"),
     ("POST", "/memory/extract"): ApprovalExceptionPolicy("local_write", True, "optional local memory file save; no provider write"),
+    ("POST", "/events/capture"): ApprovalExceptionPolicy(
+        "local_write", True, "append-only local evidence capture; no provider write"
+    ),
     ("PUT", "/notifications/config"): ApprovalExceptionPolicy(
         "local_write", True, "local notification config file update; no provider write"
     ),

--- a/tests/test_event_capture.py
+++ b/tests/test_event_capture.py
@@ -1,0 +1,250 @@
+"""POST /events/capture adversarial fixtures. No Bridge, no spawn, no MCP server."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from event_store import MAX_PAYLOAD_BYTES, EventStore
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _valid_body(**overrides) -> dict:
+    body = {
+        "source": "manual",
+        "source_object_id": "capture-1",
+        "observed_at": "2026-09-05T18:00:00+00:00",
+        "occurred_at": "2026-09-05T17:59:00+00:00",
+        "event_type": "manual.capture",
+        "payload": {"text": "Nathan said 100 drones may cost $6 each."},
+        "provenance": {"source_ref": "manual:test/capture-1"},
+    }
+    body.update(overrides)
+    return body
+
+
+@pytest.fixture
+def client(tmp_path):
+    import inbox_server
+
+    mock_ambient = MagicMock()
+    mock_ambient.is_running = False
+    mock_dictation = MagicMock()
+    mock_dictation.is_running = False
+    mock_dictation.available = True
+
+    fake_state = inbox_server.ServerState()
+    fake_state.ambient = mock_ambient
+    fake_state.dictation = mock_dictation
+    fake_state.event_store = EventStore(tmp_path / "events.sqlite3")
+
+    runtime = inbox_server.InboxServerRuntime(
+        server_state=fake_state,
+        init_contacts_func=lambda: 0,
+        google_auth_func=inbox_server._empty_google_services,
+        start_scheduler=False,
+        ambient_autostart=False,
+    )
+
+    with (
+        patch.dict(os.environ, {"INBOX_SERVER_TOKEN": "", "INBOX_TEST_MODE": "1"}, clear=False),
+        TestClient(inbox_server.create_app(runtime), raise_server_exceptions=False) as c,
+    ):
+        yield c, fake_state
+
+
+def test_malformed_event_is_error(client):
+    http, _ = client
+    response = http.post(
+        "/events/capture",
+        content=b"{not-json",
+        headers={"content-type": "application/json"},
+    )
+    assert response.status_code == 422
+    assert response.json().get("result", "error") == "error" or "detail" in response.json()
+
+
+def test_missing_provenance_is_error(client):
+    http, _ = client
+    body = _valid_body()
+    del body["provenance"]
+    response = http.post("/events/capture", json=body)
+    assert response.status_code == 422
+    payload = response.json()
+    assert payload.get("result", "error") == "error" or "detail" in payload
+
+
+def test_exact_duplicate_retry_is_already_exists(client):
+    http, state = client
+    body = _valid_body()
+    first = http.post("/events/capture", json=body)
+    second = http.post("/events/capture", json=body)
+    assert first.status_code == 201
+    assert first.json()["result"] == "created"
+    assert second.status_code == 200
+    assert second.json()["result"] == "already_exists"
+    assert first.json()["event"]["event_id"] == second.json()["event"]["event_id"]
+    assert state.event_store.count() == 1
+
+
+def test_conflicting_same_id_payload_is_error(client):
+    http, state = client
+    first = http.post("/events/capture", json=_valid_body())
+    event_id = first.json()["event"]["event_id"]
+    second = http.post(
+        "/events/capture",
+        json=_valid_body(event_id=event_id, payload={"text": "other payload"}),
+    )
+    assert first.status_code == 201
+    assert second.status_code == 409
+    assert second.json()["result"] == "error"
+    assert state.event_store.count() == 1
+
+
+def test_idempotency_key_payload_digest_mismatch_is_error(client):
+    http, state = client
+    response = http.post(
+        "/events/capture",
+        json=_valid_body(event_id="evt_deadbeefdeadbeefdeadbeefdeadbeef"),
+    )
+    assert response.status_code == 422
+    assert response.json()["result"] == "error"
+    assert state.event_store.count() == 0
+
+
+def test_oversized_payload_is_error(client):
+    http, _ = client
+    response = http.post(
+        "/events/capture",
+        json=_valid_body(payload={"text": "x" * (MAX_PAYLOAD_BYTES + 1)}),
+    )
+    assert response.status_code in {413, 422}
+    assert response.json().get("result", "error") == "error" or "detail" in response.json()
+
+
+def test_interrupted_repeated_request_is_idempotent(client):
+    http, state = client
+    body = _valid_body(source_object_id="retry-1")
+    first = http.post("/events/capture", json=body)
+    # Dropped HTTP response: client repeats the same request.
+    repeat = http.post("/events/capture", json=body)
+    assert first.json()["result"] == "created"
+    assert repeat.json()["result"] == "already_exists"
+    assert state.event_store.count() == 1
+
+
+def test_malformed_untrusted_source_locator_is_error(client):
+    http, _ = client
+    response = http.post(
+        "/events/capture",
+        json=_valid_body(provenance={"source_ref": "https://evil.example/steal"}),
+    )
+    assert response.status_code == 422
+    assert response.json().get("result", "error") == "error" or "detail" in response.json()
+
+
+def test_capture_is_not_approval_gated(client):
+    import inbox_server
+
+    http, _ = client
+    assert inbox_server._approval_rule_for_request("POST", "/events/capture") is None
+    response = http.post("/events/capture", json=_valid_body())
+    assert response.status_code == 201
+    assert "X-Inbox-Approval-Lease" not in response.request.headers
+
+
+def test_capture_route_does_not_call_bridge_or_spawn():
+    server = (ROOT / "inbox_server.py").read_text()
+    start = server.index('@app.post("/events/capture"')
+    end = server.index("@app.", start + 10)
+    handler = server[start:end].lower()
+    assert "bridge" not in handler
+    assert "spawn" not in handler
+    assert "subprocess" not in handler
+
+
+def test_capture_does_not_start_mcp_or_set_spawn_flag(client):
+    http, _ = client
+    http.post("/events/capture", json=_valid_body())
+    assert os.getenv("INBOX_CONTROL_PLANE_SPAWN", "0") == "0"
+    assert not (ROOT / "mcp_server.py").read_text().count("events/capture")
+
+
+def test_same_key_same_digest_replays_original_http_receipt(client):
+    http, state = client
+    body = _valid_body()
+    first = http.post("/events/capture", json=body)
+    second = http.post("/events/capture", json=body)
+    assert first.status_code == 201
+    assert second.status_code == 200
+    assert second.status_code != 403
+    assert first.json()["event"] == second.json()["event"]
+    assert first.json()["event"]["payload"] == body["payload"]
+    assert first.json()["event"]["provenance"] == body["provenance"]
+    assert state.event_store.count() == 1
+
+
+def test_same_key_different_digest_is_409_not_403_and_does_not_overwrite(client):
+    http, state = client
+    first = http.post("/events/capture", json=_valid_body())
+    original = first.json()["event"]
+    conflict = http.post(
+        "/events/capture",
+        json=_valid_body(
+            event_id=original["event_id"],
+            payload={"text": "other payload"},
+        ),
+    )
+    assert conflict.status_code == 409
+    assert conflict.status_code != 403
+    assert conflict.json()["result"] == "error"
+    assert conflict.json()["event"] is None
+    stored = state.event_store.get(original["event_id"])
+    assert stored is not None
+    assert stored.payload == original["payload"]
+    assert state.event_store.count() == 1
+
+
+def test_http_correction_creates_history_without_mutating_original(client):
+    http, state = client
+    first = http.post("/events/capture", json=_valid_body())
+    original_id = first.json()["event"]["event_id"]
+    correction = http.post(
+        "/events/capture",
+        json=_valid_body(payload={"text": "later correction"}),
+    )
+    assert first.status_code == 201
+    assert correction.status_code == 201
+    assert correction.json()["event"]["event_id"] != original_id
+    assert state.event_store.count() == 2
+    assert state.event_store.get(original_id).payload == first.json()["event"]["payload"]
+
+
+def test_capture_handler_has_no_approval_lookup_or_provider_call():
+    import ast
+
+    server = (ROOT / "inbox_server.py").read_text()
+    tree = ast.parse(server)
+    capture_fn = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.AsyncFunctionDef) and node.name == "capture_event"
+    )
+    called: set[str] = set()
+    for node in ast.walk(capture_fn):
+        if isinstance(node, ast.Call):
+            func = node.func
+            if isinstance(func, ast.Name):
+                called.add(func.id)
+            elif isinstance(func, ast.Attribute):
+                called.add(func.attr)
+    assert "mint_local_approval_lease" not in called
+    assert "_approval_decision_for_request" not in called
+    assert "gmail_compose_send" not in called
+    assert "sheets_values_update" not in called
+    assert "spawn" not in called

--- a/tests/test_event_store.py
+++ b/tests/test_event_store.py
@@ -1,0 +1,158 @@
+"""EventStore atom: append-only, deterministic identity, idempotent retry."""
+
+from __future__ import annotations
+
+import sqlite3
+
+import pytest
+
+from event_store import (
+    MAX_PAYLOAD_BYTES,
+    CaptureEvent,
+    EventStore,
+    EventStoreConflict,
+    EventStoreValidationError,
+)
+
+
+def _event(**overrides) -> CaptureEvent:
+    body = {
+        "source": "manual",
+        "source_object_id": "capture-1",
+        "observed_at": "2026-09-05T18:00:00+00:00",
+        "occurred_at": "2026-09-05T17:59:00+00:00",
+        "event_type": "manual.capture",
+        "payload": {"text": "Nathan said 100 drones may cost $6 each."},
+        "provenance": {"source_ref": "manual:test/capture-1"},
+    }
+    body.update(overrides)
+    return CaptureEvent.create(**body)
+
+
+def test_append_is_created_then_already_exists_on_exact_retry(tmp_path):
+    store = EventStore(tmp_path / "events.sqlite3")
+    event = _event()
+
+    stored, result = store.append(event)
+    retry, retry_result = store.append(event)
+
+    assert result == "created"
+    assert retry_result == "already_exists"
+    assert stored.event_id == retry.event_id == event.event_id
+    assert store.count() == 1
+    assert not hasattr(store, "update")
+    assert not hasattr(store, "delete")
+
+
+def test_identity_is_deterministic_for_the_same_observation(tmp_path):
+    first = _event()
+    second = _event()
+    assert first.event_id == second.event_id
+    assert first.identity_digest == second.identity_digest
+
+
+def test_missing_provenance_is_rejected():
+    with pytest.raises(EventStoreValidationError, match="provenance"):
+        _event(provenance={})
+
+
+def test_malformed_source_locator_is_rejected():
+    with pytest.raises(EventStoreValidationError, match="source_ref"):
+        _event(provenance={"source_ref": "file:///etc/passwd"})
+    with pytest.raises(EventStoreValidationError, match="source_ref"):
+        _event(provenance={"source_ref": "javascript:alert(1)"})
+    with pytest.raises(EventStoreValidationError, match="source_ref"):
+        _event(provenance={"source_ref": "manual:../escape"})
+
+
+def test_oversized_payload_is_rejected():
+    with pytest.raises(EventStoreValidationError, match="payload"):
+        _event(payload={"text": "x" * (MAX_PAYLOAD_BYTES + 1)})
+
+
+def test_conflicting_same_id_payload_is_rejected(tmp_path):
+    store = EventStore(tmp_path / "events.sqlite3")
+    first, _ = store.append(_event())
+    with pytest.raises(EventStoreConflict):
+        store.append(
+            _event(
+                event_id=first.event_id,
+                payload={"text": "different observation"},
+            )
+        )
+    assert store.count() == 1
+
+
+def test_supplied_event_id_digest_mismatch_is_rejected(tmp_path):
+    store = EventStore(tmp_path / "events.sqlite3")
+    with pytest.raises(EventStoreValidationError, match="event_id"):
+        store.append(_event(event_id="evt_deadbeefdeadbeefdeadbeefdeadbeef"))
+    assert store.count() == 0
+
+
+def test_interrupted_retry_does_not_duplicate(tmp_path):
+    store = EventStore(tmp_path / "events.sqlite3")
+    event = _event()
+    store.append(event)
+    # Simulate client retry after a dropped response.
+    stored, result = store.append(event)
+    assert result == "already_exists"
+    assert store.count() == 1
+    assert store.get(event.event_id).payload == event.payload
+
+
+def test_sqlite_rejects_update_and_delete(tmp_path):
+    store = EventStore(tmp_path / "events.sqlite3")
+    event = _event()
+    store.append(event)
+    with sqlite3.connect(store.db_path) as conn:
+        with pytest.raises(sqlite3.IntegrityError, match="append-only"):
+            conn.execute(
+                "UPDATE events SET source = 'tamper' WHERE event_id = ?", (event.event_id,)
+            )
+        with pytest.raises(sqlite3.IntegrityError, match="append-only"):
+            conn.execute("DELETE FROM events WHERE event_id = ?", (event.event_id,))
+        assert conn.execute("PRAGMA integrity_check").fetchone()[0] == "ok"
+
+
+def test_exact_retry_replays_original_receipt_and_payload(tmp_path):
+    store = EventStore(tmp_path / "events.sqlite3")
+    event = _event(payload={"z": 1, "text": "keep me", "a": True})
+    first, _ = store.append(event)
+    retry, result = store.append(event)
+    stored = store.get(first.event_id)
+    assert result == "already_exists"
+    assert store.count() == 1
+    assert stored is not None
+    assert stored.payload == {"z": 1, "text": "keep me", "a": True}
+    assert stored.provenance == {"source_ref": "manual:test/capture-1"}
+    assert stored.ingested_at == first.ingested_at
+    assert retry.ingested_at == first.ingested_at
+    assert retry.event_id == first.event_id == event.event_id
+
+
+def test_correction_appends_new_event_and_preserves_original(tmp_path):
+    store = EventStore(tmp_path / "events.sqlite3")
+    original, _ = store.append(_event())
+    with pytest.raises(EventStoreConflict):
+        store.append(_event(event_id=original.event_id, payload={"text": "corrected in place"}))
+    correction, result = store.append(_event(payload={"text": "corrected in place"}))
+    assert result == "created"
+    assert correction.event_id != original.event_id
+    assert store.count() == 2
+    assert store.get(original.event_id).payload == original.payload
+    assert store.get(correction.event_id).payload == {"text": "corrected in place"}
+
+
+def test_event_store_has_no_scheduler_or_authority_surface():
+    source = (
+        __import__("pathlib").Path(__file__).resolve().parents[1] / "event_store.py"
+    ).read_text()
+    lowered = source.lower()
+    assert "bridge" not in lowered
+    assert "spawn" not in lowered
+    assert "subprocess" not in lowered
+    assert "lease_expires" not in lowered
+    assert "in_flight" not in lowered
+    assert "fencing" not in lowered
+    assert "approval" not in lowered

--- a/tests/test_mcp_control_plane.py
+++ b/tests/test_mcp_control_plane.py
@@ -1,0 +1,632 @@
+"""PR-2B MCP control plane: Bridge ingest only. No spawn, no epistemic tool."""
+
+from __future__ import annotations
+
+import ast
+import asyncio
+import json
+import shutil
+from pathlib import Path
+
+import httpx
+import pytest
+import uvicorn
+from mcp import ClientSession
+from mcp.client.streamable_http import streamable_http_client
+from starlette.testclient import TestClient
+
+from approval_store import ApprovalStore
+from bridge_work_client import (
+    BRIDGE_BIN_ENV,
+    BRIDGE_REPO_ENV,
+    BridgeIngestError,
+    BridgeIngestReceipt,
+    BridgeWorkClient,
+    build_ingest_argv,
+    build_submit_work_envelope,
+)
+from event_store import CaptureEvent, EventStore, identity_digest_for
+from mcp_control_plane import (
+    CONTROL_PLANE_PORT,
+    CONTROL_PLANE_TOKEN_ENV,
+    CONTROL_PLANE_TOOL_NAMES,
+    SPAWN_ENV,
+    TRUST_LOOPBACK_ENV,
+    ControlPlane,
+    build_control_plane_mcp,
+    make_control_plane_app,
+    spawn_flag,
+    trust_loopback,
+)
+from tools_registry import TOOLS, include_names
+
+pytestmark = pytest.mark.safe
+
+ROOT = Path(__file__).resolve().parents[1]
+BRIDGE_BIN = shutil.which("bridge")
+
+
+class StubBridgeClient:
+    """Test double: records envelopes; never executes workers."""
+
+    def __init__(self, *, fail_with: str | None = None) -> None:
+        self.calls: list[dict] = []
+        self.fail_with = fail_with
+        self.executor_invocations = 0
+
+    def ingest_event(self, envelope: dict) -> BridgeIngestReceipt:
+        self.calls.append(envelope)
+        if self.fail_with:
+            raise BridgeIngestError(self.fail_with)
+        work_id = envelope.get("external_id") or "wrk_stub"
+        return BridgeIngestReceipt(
+            result_id=f"result:workpacket:inbox:control_plane:{work_id}",
+            work_packet_id=f"workpacket:inbox:control_plane:{work_id}",
+            status="accepted_for_intake",
+            summary="event accepted for intake; execution authority was not granted",
+            intake_path=f"/tmp/.bridge/intake/{work_id}.json",
+        )
+
+
+def _evidence_refs(**overrides) -> list[dict]:
+    ref = {
+        "ref": "inbox:evt_test",
+        "authority_type": "inbox_event",
+        "authority_id": "evt_test",
+        "digest": "abc",
+    }
+    ref.update(overrides)
+    return [ref]
+
+
+def _capture_body(**overrides) -> dict:
+    body = {
+        "source": "manual",
+        "source_object_id": "capture-1",
+        "observed_at": "2026-09-05T18:00:00+00:00",
+        "occurred_at": "2026-09-05T17:59:00+00:00",
+        "event_type": "manual.capture",
+        "payload": {"text": "Nathan said 100 drones may cost $6 each."},
+        "provenance": {"source_ref": "manual:test/capture-1"},
+    }
+    body.update(overrides)
+    return body
+
+
+@pytest.fixture
+def bridge_stub() -> StubBridgeClient:
+    return StubBridgeClient()
+
+
+@pytest.fixture
+def plane(tmp_path, bridge_stub) -> ControlPlane:
+    return ControlPlane(
+        event_store=EventStore(tmp_path / "events.sqlite3"),
+        approval_store=ApprovalStore(tmp_path / "approvals.sqlite3"),
+        bridge_client=bridge_stub,
+    )
+
+
+def test_frozen_tools_are_not_rest_registry_names():
+    with pytest.raises(ValueError, match="unknown tool names"):
+        include_names(CONTROL_PLANE_TOOL_NAMES)
+    rest_names = {tool.name for tool in TOOLS}
+    assert rest_names.isdisjoint(CONTROL_PLANE_TOOL_NAMES)
+
+
+def test_seven_tools_enumerate(plane):
+    mcp = build_control_plane_mcp(plane)
+    names = tuple(tool.name for tool in asyncio.run(mcp.list_tools()))
+    assert names == CONTROL_PLANE_TOOL_NAMES
+    assert len(names) == 7
+
+
+def test_no_epistemic_mcp_tool(plane):
+    mcp = build_control_plane_mcp(plane)
+    names = {tool.name for tool in asyncio.run(mcp.list_tools())}
+    assert "epistemic" not in names
+    assert not any("epistemic" in name for name in names)
+
+
+def test_auth_fails_closed_when_token_unset(plane, monkeypatch):
+    monkeypatch.delenv(CONTROL_PLANE_TOKEN_ENV, raising=False)
+    monkeypatch.setenv("INBOX_MCP_TOKEN", "gateway-secret")
+    app = make_control_plane_app(plane)
+    with TestClient(app) as client:
+        health = client.get("/health")
+        mcp = client.get("/mcp")
+    assert health.status_code == 200
+    assert health.json()["bind"] == f"127.0.0.1:{CONTROL_PLANE_PORT}"
+    assert health.json()["auth_fail_closed"] is True
+    assert mcp.status_code == 401
+
+
+def test_auth_rejects_missing_and_invalid_token(plane, monkeypatch):
+    monkeypatch.setenv(CONTROL_PLANE_TOKEN_ENV, "control-secret")
+    app = make_control_plane_app(plane)
+    with TestClient(app) as client:
+        missing = client.get("/mcp")
+        invalid = client.get("/mcp", headers={"Authorization": "Bearer nope"})
+        valid = client.get("/mcp", headers={"Authorization": "Bearer control-secret"})
+        health = client.get("/health")
+    assert missing.status_code == 401
+    assert invalid.status_code == 401
+    assert valid.status_code != 401
+    assert health.status_code == 200
+
+
+def test_trust_loopback_defaults_off(monkeypatch):
+    monkeypatch.delenv(TRUST_LOOPBACK_ENV, raising=False)
+    assert trust_loopback() is False
+    monkeypatch.setenv(TRUST_LOOPBACK_ENV, "1")
+    assert trust_loopback() is True
+
+
+def test_oauth_protected_resource_is_absent_like_lifeops(plane, monkeypatch):
+    """ChatGPT Auth=None create matches LifeOps: no RFC 9728 card."""
+    monkeypatch.setenv(CONTROL_PLANE_TOKEN_ENV, "control-secret")
+    app = make_control_plane_app(plane)
+    with TestClient(app) as client:
+        root = client.get("/.well-known/oauth-protected-resource")
+        nested = client.get("/.well-known/oauth-protected-resource/mcp")
+    assert root.status_code == 404
+    assert nested.status_code == 404
+
+
+def test_server_discover_does_not_require_token(plane, monkeypatch):
+    """ChatGPT Secure MCP Tunnel refresh probes server/discover without our bearer."""
+    monkeypatch.setenv(CONTROL_PLANE_TOKEN_ENV, "control-secret")
+    app = make_control_plane_app(plane)
+    with TestClient(app) as client:
+        response = client.post(
+            "/mcp",
+            headers={
+                "Accept": "application/json, text/event-stream",
+                "Content-Type": "application/json",
+            },
+            json={
+                "jsonrpc": "2.0",
+                "id": "openai-mcp-discover",
+                "method": "server/discover",
+                "params": {},
+            },
+        )
+        initialize = client.post(
+            "/mcp",
+            headers={
+                "Accept": "application/json, text/event-stream",
+                "Content-Type": "application/json",
+            },
+            json={"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}},
+        )
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["id"] == "openai-mcp-discover"
+    assert payload["result"]["resultType"] == "complete"
+    assert payload["result"]["supportedVersions"] == ["2025-06-18"]
+    assert (
+        payload["result"]["_meta"]["io.modelcontextprotocol/serverInfo"]["name"]
+        == "Inbox Control Plane"
+    )
+    assert initialize.status_code == 401
+
+
+def test_capture_reuses_pr0_event_store_identity(plane):
+    body = _capture_body()
+    mcp_result = plane.capture(**body)
+    digest = identity_digest_for(
+        source=body["source"],
+        source_object_id=body["source_object_id"],
+        occurred_at=body["occurred_at"],
+        event_type=body["event_type"],
+        payload=body["payload"],
+        source_ref=body["provenance"]["source_ref"],
+    )
+    expected_id = f"evt_{digest[:32]}"
+    stored = plane.event_store.get(expected_id)
+    assert mcp_result["result"] == "created"
+    assert mcp_result["executed"] is False
+    assert mcp_result["event"]["event_id"] == expected_id
+    assert stored is not None
+    assert stored.event_id == expected_id
+    retry = plane.capture(**body)
+    assert retry["result"] == "already_exists"
+    assert retry["event"]["event_id"] == expected_id
+    assert plane.event_store.count() == 1
+
+
+def test_capture_matches_direct_eventstore_append(tmp_path):
+    store = EventStore(tmp_path / "events.sqlite3")
+    plane = ControlPlane(
+        event_store=store,
+        approval_store=ApprovalStore(tmp_path / "approvals.sqlite3"),
+    )
+    body = _capture_body(source_object_id="capture-compare")
+    event = CaptureEvent.create(**body)
+    stored, result = store.append(event)
+    mcp = plane.capture(**body)
+    assert result == "created"
+    assert mcp["result"] == "already_exists"
+    assert mcp["event"]["event_id"] == stored.event_id
+
+
+def test_submit_work_confirm_true_is_intake_not_execution(plane, bridge_stub, monkeypatch):
+    monkeypatch.setenv(SPAWN_ENV, "0")
+    result = plane.submit_work(_evidence_refs(), confirm=True, summary="do the thing")
+    assert result["result"] == "accepted_for_intake"
+    assert result["executed"] is False
+    assert result["confirm_is_authority"] is False
+    assert result["spawn_flag"] == 0
+    assert result["bridge_intake_path"]
+    assert result["bridge_result_id"]
+    assert result["bridge_work_packet_id"]
+    assert plane.execution_log == []
+    assert bridge_stub.executor_invocations == 0
+    assert len(bridge_stub.calls) == 1
+    listed = plane.get_work()
+    assert listed["result"] == "ok"
+    assert listed["work"][0]["work_id"] == result["work_id"]
+    assert listed["work"][0]["executed"] is False
+    assert listed["work"][0]["bridge"]["intake_path"] == result["bridge_intake_path"]
+
+
+def test_submit_work_cannot_supply_lease_or_capability(plane, bridge_stub):
+    for kwargs in (
+        {"lease": "lease_fake"},
+        {"lease_token": "tok"},
+        {"capability_token": "cap"},
+        {"approval_digest": "deadbeef"},
+        {"spawn": 1},
+        {"evidence_refs": _evidence_refs(lease_token="nested")},
+    ):
+        evidence = kwargs.pop("evidence_refs", _evidence_refs())
+        result = plane.submit_work(evidence, confirm=True, **kwargs)
+        assert result["result"] == "DENIED"
+        assert result["reason"] == "model_supplied_authority"
+        assert result["executed"] is False
+    assert plane.execution_log == []
+    assert plane.work == {}
+    assert bridge_stub.calls == []
+
+
+def test_submit_work_spawn_flag_one_still_does_not_execute(plane, monkeypatch):
+    monkeypatch.setenv(SPAWN_ENV, "1")
+    assert spawn_flag() == 1
+    result = plane.submit_work(_evidence_refs(), confirm=True)
+    assert result["result"] == "accepted_for_intake"
+    assert result["executed"] is False
+    assert result["spawn_flag"] == 1
+    assert plane.execution_log == []
+
+
+def test_submit_work_requires_evidence_refs(plane, bridge_stub):
+    assert plane.submit_work([])["result"] == "DENIED"
+    assert plane.submit_work(None)["result"] == "DENIED"
+    assert bridge_stub.calls == []
+
+
+def test_submit_work_bridge_reject_does_not_invoke_executor(tmp_path):
+    stub = StubBridgeClient(fail_with="bridge_rejected")
+    plane = ControlPlane(
+        event_store=EventStore(tmp_path / "events.sqlite3"),
+        approval_store=ApprovalStore(tmp_path / "approvals.sqlite3"),
+        bridge_client=stub,
+    )
+    result = plane.submit_work(_evidence_refs(), confirm=True, summary="should fail closed")
+    assert result["result"] == "DENIED"
+    assert result["reason"] == "bridge_rejected"
+    assert result["executed"] is False
+    assert plane.work == {}
+    assert plane.execution_log == []
+    assert stub.executor_invocations == 0
+    assert len(stub.calls) == 1
+
+
+def test_submit_work_missing_bridge_authority_fails_closed(tmp_path, monkeypatch):
+    monkeypatch.delenv(BRIDGE_BIN_ENV, raising=False)
+    monkeypatch.delenv(BRIDGE_REPO_ENV, raising=False)
+    monkeypatch.setenv("PATH", "/usr/bin:/bin")
+    plane = ControlPlane(
+        event_store=EventStore(tmp_path / "events.sqlite3"),
+        approval_store=ApprovalStore(tmp_path / "approvals.sqlite3"),
+        bridge_client=BridgeWorkClient.from_env(),
+    )
+    result = plane.submit_work(_evidence_refs(), confirm=True)
+    assert result["result"] == "DENIED"
+    assert result["executed"] is False
+    assert result["reason"] in {
+        "bridge_binary_missing",
+        "bridge_repo_missing",
+        "bridge_binary_not_allowlisted",
+    }
+    assert plane.work == {}
+    assert plane.execution_log == []
+
+
+def test_bridge_work_client_argv_is_allowlisted_ingest_only(tmp_path):
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    bridge = bin_dir / "bridge"
+    bridge.write_text("#!/bin/sh\nexit 1\n", encoding="utf-8")
+    bridge.chmod(0o755)
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    argv = build_ingest_argv(bridge_bin=bridge.resolve(), repo=repo.resolve())
+    assert argv == [str(bridge.resolve()), "ingest", "-", "--repo", str(repo.resolve())]
+    assert "spawn" not in argv
+    assert "shell" not in "".join(argv).lower()
+
+
+def test_bridge_work_client_rejects_non_bridge_binary_name(tmp_path):
+    impostor = tmp_path / "not-bridge"
+    impostor.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    impostor.chmod(0o755)
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    with pytest.raises(BridgeIngestError, match="bridge_binary_not_allowlisted"):
+        build_ingest_argv(bridge_bin=impostor.resolve(), repo=repo.resolve())
+
+
+@pytest.mark.skipif(not BRIDGE_BIN, reason="local bridge binary not installed")
+def test_submit_work_integration_against_local_bridge(tmp_path, monkeypatch):
+    """Real `bridge ingest` handshake; stores intake path/id only."""
+    bridge_bin = Path(BRIDGE_BIN).resolve()
+    assert bridge_bin.name == "bridge"
+    repo = tmp_path / "bridge-repo"
+    repo.mkdir()
+    client = BridgeWorkClient(bridge_bin=bridge_bin, repo=repo)
+    plane = ControlPlane(
+        event_store=EventStore(tmp_path / "events.sqlite3"),
+        approval_store=ApprovalStore(tmp_path / "approvals.sqlite3"),
+        bridge_client=client,
+    )
+    monkeypatch.setenv(SPAWN_ENV, "0")
+    result = plane.submit_work(
+        _evidence_refs(),
+        confirm=True,
+        summary="LA-03 integration against local Bridge ingest",
+    )
+    assert result["result"] == "accepted_for_intake"
+    assert result["executed"] is False
+    assert result["spawn_flag"] == 0
+    assert result["confirm_is_authority"] is False
+    intake_path = Path(result["bridge_intake_path"])
+    assert intake_path.is_file()
+    assert str(repo.resolve()) in str(intake_path.resolve())
+    assert result["bridge_work_packet_id"].startswith("workpacket:")
+    assert result["bridge_result_id"].startswith("result:")
+    stored = json.loads(intake_path.read_text(encoding="utf-8"))
+    assert "event" in stored and "work_packet" in stored
+    assert plane.execution_log == []
+    # Adversarial: reject path does not write executor state
+    bad = StubBridgeClient(fail_with="bridge_rejected")
+    denied_plane = ControlPlane(
+        event_store=EventStore(tmp_path / "events2.sqlite3"),
+        approval_store=ApprovalStore(tmp_path / "approvals2.sqlite3"),
+        bridge_client=bad,
+    )
+    denied = denied_plane.submit_work(_evidence_refs(), confirm=True)
+    assert denied["result"] == "DENIED"
+    assert denied_plane.execution_log == []
+
+
+def test_server_side_approval_lookup_is_not_execution(plane):
+    minted = plane.approval_store.create_request(
+        method="POST",
+        path="/messages/compose",
+        body={},
+        provider="gmail",
+        operation="submit_work",
+        approval_class="consequential",
+        executor="inbox",
+        account_ref="",
+        resource_ref="",
+        item_count=1,
+        payload_hash="",
+        query_hash="",
+    )
+    plane.approval_store.decide_request(
+        minted["request_id"], approved=True, lease_id="lease_server_only"
+    )
+    result = plane.submit_work(_evidence_refs(), confirm=True)
+    assert result["result"] == "accepted_for_intake"
+    assert result["executed"] is False
+    assert result["server_authority_present"] is True
+    fetched = plane.get_work(result["work_id"])
+    assert fetched["work"]["server_authority"]["lease_id"] == "lease_server_only"
+
+
+def test_resolve_is_per_world_and_does_not_fill_from_memory(plane):
+    ok = plane.resolve(["control_plane", "capture"])
+    assert ok["result"] == "ok"
+    assert ok["missing_filled_from_memory"] is False
+    assert [row["world"] for row in ok["worlds"]] == ["control_plane", "capture"]
+    bridge = plane.resolve(["bridge"])
+    assert bridge["result"] == "DENIED"
+    assert bridge["worlds"][0]["status"] == "unavailable"
+    assert bridge["worlds"][0]["source"] == "not_probed"
+    unknown = plane.resolve(["invented_world"])
+    assert unknown["result"] == "DENIED"
+    assert unknown["worlds"][0]["source"] == "unknown_world"
+    mixed = plane.resolve(["capture", "bridge"])
+    assert mixed["worlds"][0]["status"] == "ok"
+    assert mixed["worlds"][1]["status"] == "unavailable"
+
+
+def test_run_shortcut_unknown_id_denied_known_id_does_not_execute(plane):
+    unknown = plane.run_shortcut("SC-999", confirm=True)
+    assert unknown["result"] == "DENIED"
+    assert unknown["executed"] is False
+    known = plane.run_shortcut("SC-014", confirm=True)
+    assert known["result"] == "accepted_for_intake"
+    assert known["executed"] is False
+    assert known["argv_executed"] is False
+    assert known["stored_name_returned"] is False
+    named = plane.run_shortcut("SC-014", stored_name="Open Inbox")
+    assert named["result"] == "DENIED"
+    assert named["reason"] == "model_supplied_authority"
+
+
+def test_cancel_and_verify_do_not_execute(plane):
+    submitted = plane.submit_work(_evidence_refs(), confirm=True)
+    work_id = submitted["work_id"]
+    cancelled = plane.cancel_work(work_id, confirm=True)
+    verified = plane.verify_work(work_id, confirm=True)
+    assert cancelled["result"] == "accepted_for_intake"
+    assert verified["result"] == "accepted_for_intake"
+    assert cancelled["executed"] is False
+    assert verified["executed"] is False
+    assert verified["verifier_executed"] is False
+    assert plane.cancel_work("wrk_missing")["result"] == "DENIED"
+    assert plane.verify_work("wrk_missing")["result"] == "DENIED"
+
+
+def test_control_plane_source_cannot_import_spawn_or_subprocess():
+    source = (ROOT / "mcp_control_plane.py").read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    imported = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imported.update(alias.name.split(".")[0] for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            imported.add(node.module.split(".")[0])
+    # PR-2B: thin bridge_work_client is allowed; subprocess/spawn stay out.
+    assert "bridge_work_client" in imported
+    assert "subprocess" not in imported
+    assert "bridge" not in imported  # no Go package / spawn module
+    assert "inbox_bridge_adapter" not in imported
+    assert "run_shell" not in source
+    assert "epistemic" not in source.lower()
+    assert "PublicAuthMiddleware" not in source
+    assert "_is_publicly_authorized" not in source
+    assert 'Mount("/mcp"' not in source
+    assert "streamable_http_app()" in source
+    assert "bridge spawn" not in source.lower()
+    assert "promote-approval" not in source.lower()
+    # Client itself must not allowlist spawn.
+    client_src = (ROOT / "bridge_work_client.py").read_text(encoding="utf-8")
+    assert 'ALLOWED_VERBS = frozenset({"ingest"})' in client_src
+    assert "shell=False" in client_src
+    assert '"spawn"' not in client_src
+    assert '"promote-approval"' not in client_src
+
+
+def test_build_submit_work_envelope_is_bridge_contracts_v1():
+    envelope = build_submit_work_envelope(
+        work_id="wrk_abc",
+        summary="hello",
+        evidence_refs=_evidence_refs(),
+        occurred_at="2026-09-06T06:00:00Z",
+    )
+    assert envelope["version"] == "bridge.contracts.v1"
+    assert envelope["id"] == "inbox:control_plane:wrk_abc"
+    assert envelope["kind"] == "inbox.control_plane.submit_work"
+    assert envelope["source"] == "inbox"
+    assert envelope["payload"]["text"] == "hello"
+    assert "role" not in envelope
+    assert "lease" not in envelope
+    assert "capability" not in envelope
+
+
+def _tool_payload(result) -> dict:
+    if getattr(result, "structuredContent", None) is not None:
+        payload = result.structuredContent
+        if (
+            isinstance(payload, dict)
+            and set(payload) == {"result"}
+            and isinstance(payload["result"], dict)
+        ):
+            payload = payload["result"]
+        if isinstance(payload, dict):
+            return payload
+    texts = []
+    for block in getattr(result, "content", []) or []:
+        text = getattr(block, "text", None)
+        if text:
+            texts.append(text)
+    if len(texts) == 1:
+        try:
+            parsed = json.loads(texts[0])
+        except json.JSONDecodeError:
+            return {"text": texts[0]}
+        if isinstance(parsed, dict):
+            return parsed
+    return {"isError": getattr(result, "isError", None), "content": texts}
+
+
+async def _serve_control_plane(app):
+    config = uvicorn.Config(app, host="127.0.0.1", port=0, log_level="warning")
+    server = uvicorn.Server(config)
+    task = asyncio.create_task(server.serve())
+    try:
+        for _ in range(200):
+            if server.started:
+                break
+            await asyncio.sleep(0.025)
+        else:
+            raise RuntimeError("control plane uvicorn did not start")
+        port = server.servers[0].sockets[0].getsockname()[1]
+        yield f"http://127.0.0.1:{port}"
+    finally:
+        server.should_exit = True
+        await task
+
+
+def test_real_mcp_client_initialize_lists_tools_and_resolve(plane, monkeypatch):
+    """Official Streamable HTTP client against the production ASGI topology."""
+    monkeypatch.setenv(CONTROL_PLANE_TOKEN_ENV, "control-secret")
+    monkeypatch.setenv(SPAWN_ENV, "0")
+    app = make_control_plane_app(plane)
+    token = "control-secret"
+
+    async def scenario():
+        agen = _serve_control_plane(app)
+        base = await anext(agen)
+        try:
+            url = f"{base}/mcp"
+            headers = {"Authorization": f"Bearer {token}"}
+            async with (
+                httpx.AsyncClient(
+                    headers=headers,
+                    timeout=httpx.Timeout(30.0, read=60.0),
+                    follow_redirects=False,
+                ) as http,
+                streamable_http_client(url, http_client=http) as streams,
+            ):
+                read, write = streams[0], streams[1]
+                async with ClientSession(read, write) as session:
+                    init = await session.initialize()
+                    listed = await session.list_tools()
+                    resolved = await session.call_tool("resolve", {"worlds": ["control_plane"]})
+                    return init, listed, resolved
+        finally:
+            await agen.aclose()
+
+    init, listed, resolved = asyncio.run(scenario())
+    names = tuple(tool.name for tool in listed.tools)
+    payload = _tool_payload(resolved)
+    assert init.serverInfo is not None
+    assert init.serverInfo.name == "Inbox Control Plane"
+    assert names == CONTROL_PLANE_TOOL_NAMES
+    assert resolved.isError is False
+    assert payload["result"] == "ok"
+    assert payload["executed"] is False
+    assert payload["spawn_flag"] == 0
+    assert payload["missing_filled_from_memory"] is False
+
+
+def test_mcp_post_does_not_307_and_does_not_500_without_session_manager(plane, monkeypatch):
+    monkeypatch.setenv(CONTROL_PLANE_TOKEN_ENV, "control-secret")
+    app = make_control_plane_app(plane)
+    with TestClient(app, raise_server_exceptions=False) as client:
+        response = client.post(
+            "/mcp",
+            headers={
+                "Authorization": "Bearer control-secret",
+                "Accept": "application/json, text/event-stream",
+                "Content-Type": "application/json",
+            },
+            json={"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}},
+        )
+    assert response.status_code not in {307, 404, 500}
+    assert response.status_code != 401

--- a/tools_registry.py
+++ b/tools_registry.py
@@ -14,7 +14,7 @@ the full and readonly MCP servers, so they cannot drift.
 from __future__ import annotations
 
 import inspect
-from collections.abc import Callable
+from collections.abc import Callable, Iterable
 from dataclasses import dataclass, field
 from typing import Any, Literal
 from urllib.parse import quote
@@ -107,10 +107,28 @@ def _build_handler(tool: Tool, backend: Any) -> Callable[..., Any]:
     return handler
 
 
-def register_all(mcp: Any, backend: Any, *, readonly_only: bool) -> list[str]:
+def include_names(names: Iterable[str], tools: Iterable[Tool] | None = None) -> list[Tool]:
+    """Select registry tools by name, preserving caller order. Unknown names fail closed."""
+    catalog = list(tools) if tools is not None else TOOLS
+    index = {tool.name: tool for tool in catalog}
+    wanted = list(names)
+    missing = [name for name in wanted if name not in index]
+    if missing:
+        raise ValueError(f"unknown tool names: {missing}")
+    return [index[name] for name in wanted]
+
+
+def register_all(
+    mcp: Any,
+    backend: Any,
+    *,
+    readonly_only: bool,
+    names: Iterable[str] | None = None,
+) -> list[str]:
     """Register every applicable tool from TOOLS onto `mcp`. Returns names registered."""
+    selected = include_names(names) if names is not None else list(TOOLS)
     registered: list[str] = []
-    for tool in TOOLS:
+    for tool in selected:
         if readonly_only and not tool.readonly:
             continue
         handler = _build_handler(tool, backend)


### PR DESCRIPTION
## Summary

TASK-026 SOURCE CONVERGENCE only: replay proven local-actuator intake/EventStore/MCP→Bridge semantics onto current Inbox main while preserving Phase-C provider semantics from #79/#80.

- **Current base SHA:** `61c824f0847d87e2444f14dd5b6413425efb2f24`
- **Provenance lineage (not canonical until landed):**
  - PR0 capture `c2844f5d32f760a45520672706010d14d64eb680`
  - PR1 MCP `fe2ceb7d4c937a192a85b579baed142033b1fc97`
  - PR2 transport `b5acc06254ca7b419d84e1ebd18212a5da58dfa0`
- **Replayed files/semantics:** `event_store.py`, `mcp_control_plane.py`, `bridge_work_client.py`, `config/shortcut_registry.example.json`, focused tests, surgical `inbox_server.py` `POST /events/capture`, approval-route exception, additive `tools_registry.include_names`, docs/manifest. Contracts: append-only EventStore; ingest-only MCP (`spawn=0`, confirm≠authority); thin `submit_work`→Bridge ingest.
- **Intentionally excluded branch drift:** wholesale actuator `inbox_server.py`/`services.py`; PR2 deletion of Phase-C provider-identity tests; runtime DBs/logs/credentials; LifeOps prototype stores; ASSET-087 reconstruction; OCI/GAS/LaunchAgent/runtime switches.
- **EventStore authority boundary:** capture/evidence intake history only — not SYS-002, Tasks, HomeBase, Bridge receipts, commitments, or provider idempotency sidecars.
- **MCP ingest-only boundary:** frozen tools; no arbitrary exec; model lease/capability denied.
- **Bridge/HomeBase boundary:** Inbox does not execute workers or mint execution authority.
- **#79/#80 regression preservation:** provider `list_id`/`task_id`, `lifeops_idempotency:<key>`, no bindings SQLite/module; approvals remain mandatory; leases transport-only.
- **Not** an ASSET-087 import. Does **not** reopen Inbox #78. No `lifeops-core`.

## Validation

- EventStore/capture + MCP/Bridge-handoff + Phase-C provider identity + approval-route: **143 passed**
- `tests/test_approval_store.py`: **11 passed**
- `pytest -m safe`: **454 passed**, 1568 deselected
- Ruff: base **49** / head **48** / NEW **0** (changed/new files clean)
- Bandit (`-c pyproject.toml`): base **9** / head **9** / NEW **0** (semantic; inbox_server B105 line shifts only)
- Runtime switch: **NO**
- Provider mutation: **NO**
- OCI/GAS deployment: **NO**

## Test plan

- [x] Focused EventStore/capture/MCP suites
- [x] Phase-C `test_task_create_provider_identity.py`
- [x] Approval route/store suites
- [x] `pytest -m safe`
- [x] Ruff/Bandit broken-baseline ratchet NEW=0
- [ ] CI differential gate / merge
- [ ] Fresh-main verification after merge


Made with [Cursor](https://cursor.com)